### PR TITLE
Target netstandard2.0 for contracts

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -34,6 +34,7 @@
         <PackageVersion Include="System.Composition.Hosting" Version="1.4.1"/>
         <PackageVersion Include="System.Composition.Runtime" Version="1.4.1"/>
         <PackageVersion Include="System.Composition.TypedParts" Version="1.4.1"/>
+        <PackageVersion Include="System.Memory" Version="4.5.4"/>
         <PackageVersion Include="System.Reactive" Version="5.0.0"/>
         <PackageVersion Include="System.Runtime.Loader" Version="4.3.0"/>
         <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="4.9.0"/>

--- a/src/Microsoft.ComponentDetection.Contracts/Microsoft.ComponentDetection.Contracts.csproj
+++ b/src/Microsoft.ComponentDetection.Contracts/Microsoft.ComponentDetection.Contracts.csproj
@@ -1,10 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+    <PropertyGroup Label="Build">
+        <TargetFramework>netstandard2.0</TargetFramework>
+    </PropertyGroup>
+
     <ItemGroup>
-        <PackageReference Include="System.Composition.AttributedModel"/>
         <PackageReference Include="Newtonsoft.Json"/>
-        <PackageReference Include="System.Reactive"/>
         <PackageReference Include="PackageUrl"/>
+        <PackageReference Include="System.Composition.AttributedModel"/>
+        <PackageReference Include="System.Memory"/>
+        <PackageReference Include="System.Reactive"/>
+        <PackageReference Include="System.Threading.Tasks.Dataflow"/>
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Targeting netstandard2.0 for our contracts allows them to be more portable across multiple versions of .NET. There is zero impact to performance as this project contains no logic.