### PR TITLE
Target .NET Core 3.1

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -26,8 +26,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.x
-        include-prerelease: true
+        dotnet-version: 3.1.x
 
     - name: dotnet restore
       run: dotnet restore

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,8 +20,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.x
-        include-prerelease: true
+        dotnet-version: 3.1.x
 
     - name: dotnet restore
       run: dotnet restore

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -62,8 +62,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.x
-        include-prerelease: true
+        dotnet-version: 3.1.x
 
     - name: dotnet restore
       run: dotnet restore

--- a/.github/workflows/gen-docs.yml
+++ b/.github/workflows/gen-docs.yml
@@ -18,8 +18,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 6.0.x
-          include-prerelease: true
+          dotnet-version: 3.1.x
 
       - name: Generate docs
         run: |

--- a/.github/workflows/publish-release-snapshot.yml
+++ b/.github/workflows/publish-release-snapshot.yml
@@ -22,8 +22,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.x
-        include-prerelease: true
+        dotnet-version: 3.1.x
 
     - name: dotnet restore
       run: dotnet restore

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -18,8 +18,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.x
-        include-prerelease: true
+        dotnet-version: 3.1.x
 
     - name: dotnet restore
       run: dotnet restore

--- a/.github/workflows/verify-snapshot.yml
+++ b/.github/workflows/verify-snapshot.yml
@@ -22,8 +22,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.x
-        include-prerelease: true
+        dotnet-version: 3.1.x
 
     - name: dotnet restore
       run: dotnet restore

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
     <PropertyGroup Label="Build">
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
         <LangVersion>latest</LangVersion>
         <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
         <TreatWarningsAsErrors Condition="'$(OFFICIAL_BUILD)' == 'True'">true</TreatWarningsAsErrors>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,6 +19,7 @@
         <PackageVersion Include="DotNet.Glob" Version="2.1.1"/>
         <PackageVersion Include="MinVer" Version="2.5.0"/>
         <PackageVersion Include="Moq" Version="4.16.1"/>
+        <PackageVersion Include="morelinq" Version="3.3.2"/>
         <PackageVersion Include="MSTest.TestAdapter" Version="2.2.3"/>
         <PackageVersion Include="MSTest.TestFramework" Version="2.2.3"/>
         <PackageVersion Include="Nett" Version="0.15.0"/>

--- a/README.md
+++ b/README.md
@@ -42,8 +42,7 @@ Component Detection is built with extensibility in mind! Please see our [CONTRIB
 
 
 # Building and running Component Detection
-DotNet Core SDK 6.0.0-rc2 is currently in use, you can install it from https://dotnet.microsoft.com/download/dotnet/6.0
-We also use node and npm, you can install them from https://nodejs.org/en/download/
+.NET Core 3.1 is currently in use, you can install it from https://dotnet.microsoft.com/download/dotnet/3.1
 
 The below commands mirror what we do to setup our CI environments:
 

--- a/global.json
+++ b/global.json
@@ -1,7 +1,6 @@
 {
 	"sdk": {
-		"version": "6.0.100-rc.2.21505.57",
-		"allowPrerelease": true,
+		"version": "3.1.300",
 		"rollForward": "latestMinor"
 	}
 }

--- a/src/Microsoft.ComponentDetection.Contracts/TypedComponent/PodComponent.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/TypedComponent/PodComponent.cs
@@ -37,7 +37,7 @@ namespace Microsoft.ComponentDetection.Contracts.TypedComponent
                     qualifiers.Add("repository_url", SpecRepo);
                 }
 
-                return new ("cocoapods", null, Name, Version, qualifiers, null);
+                return new PackageURL("cocoapods", null, Name, Version, qualifiers, null);
             }
         }
     }

--- a/src/Microsoft.ComponentDetection.Detectors/Microsoft.ComponentDetection.Detectors.csproj
+++ b/src/Microsoft.ComponentDetection.Detectors/Microsoft.ComponentDetection.Detectors.csproj
@@ -2,6 +2,7 @@
 
     <ItemGroup>
         <PackageReference Include="DotNet.Glob" />
+        <PackageReference Include="morelinq" />
         <PackageReference Include="Nett" />
         <PackageReference Include="NuGet.ProjectModel" />
         <PackageReference Include="NuGet.Versioning" />

--- a/src/Microsoft.ComponentDetection.Detectors/linux/LinuxScanner.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/linux/LinuxScanner.cs
@@ -9,6 +9,7 @@ using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Contracts.BcdeModels;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.ComponentDetection.Detectors.Linux.Contracts;
+using MoreLinq.Extensions;
 using Newtonsoft.Json;
 
 namespace Microsoft.ComponentDetection.Detectors.Linux


### PR DESCRIPTION
Changes include:

- Update `global.json` to require at least .NET Core 3.1.300 (this version specifically is required for centrally managing NuGet packages
- Update GitHub Actions to install .NET Core 3.1
- Update `README.md` to reflect the new requirements
- Fully qualify a constructor in `PodComponent`
- Add `morelinq` dependency to get `DistinctBy`

Closes #18