### PR TITLE
Support renamed dependencies in Cargo.toml

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/rust/RustCrateDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/rust/RustCrateDetector.cs
@@ -21,7 +21,7 @@ namespace Microsoft.ComponentDetection.Detectors.Rust
 
         public override IEnumerable<ComponentType> SupportedComponentTypes => new[] { ComponentType.Cargo };
 
-        public override int Version { get; } = 5;
+        public override int Version { get; } = 6;
 
         public override IEnumerable<string> Categories => new List<string> { "Rust" };
 

--- a/src/Microsoft.ComponentDetection.Detectors/rust/RustCrateUtilities.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/rust/RustCrateUtilities.cs
@@ -321,7 +321,20 @@ namespace Microsoft.ComponentDetection.Detectors.Rust
                             return null;
                         }
 
-                        dependencySpecifications.Add(dependency, versionSpecifier);
+                        // If the dependency is renamed, use the actual name of the package:
+                        // https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#renaming-dependencies-in-cargotoml
+                        string dependencyName;
+                        if (dependencies[dependency].TomlType == TomlObjectType.Table &&
+                        dependencies.Get<TomlTable>(dependency).ContainsKey("package"))
+                        {
+                            dependencyName = dependencies.Get<TomlTable>(dependency).Get<string>("package");
+                        }
+                        else
+                        {
+                            dependencyName = dependency;
+                        }
+
+                        dependencySpecifications.Add(dependencyName, versionSpecifier);
                     }
                 }
             }

--- a/src/Microsoft.ComponentDetection.Detectors/rust/RustCrateV2Detector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/rust/RustCrateV2Detector.cs
@@ -21,7 +21,7 @@ namespace Microsoft.ComponentDetection.Detectors.Rust
 
         public override IEnumerable<ComponentType> SupportedComponentTypes => new[] { ComponentType.Cargo };
 
-        public override int Version { get; } = 4;
+        public override int Version { get; } = 5;
 
         public override IEnumerable<string> Categories => new List<string> { "Rust" };
 

--- a/test/Microsoft.ComponentDetection.VerificationTests/resources/rust/standard/Cargo.toml
+++ b/test/Microsoft.ComponentDetection.VerificationTests/resources/rust/standard/Cargo.toml
@@ -10,7 +10,7 @@ path = "main.rs"
 name = "component-detection"
 
 [dependencies]
-serde = "1.0.136"
+renamed_dependency = { package = "serde", version = "1.0.136"}
 
 [dev-dependencies]
 rand = "0.8.4"


### PR DESCRIPTION
Cargo supports renamed dependencies in Cargo.toml: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#renaming-dependencies-in-cargotoml

component-detection currently misses such dependencies, as it uses the renamed dependency name when determining what the root dependencies on. This PR updates component detection to use the real dependency name in such cases.