### PR TITLE
Added author detection for Npm and Nuget Component

### DIFF
--- a/src/Microsoft.ComponentDetection.Contracts/Internal/NpmAuthor.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/Internal/NpmAuthor.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace Microsoft.ComponentDetection.Contracts.Internal
+{
+    public class NpmAuthor
+    {
+        public NpmAuthor(string name, string email = null)
+        {
+            Name = name ?? throw new ArgumentNullException(nameof(name));
+            Email = email;
+        }
+
+        public string Name { get; set; }
+        
+        public string Email { get; set; }
+    }
+}

--- a/src/Microsoft.ComponentDetection.Contracts/Internal/NpmAuthor.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/Internal/NpmAuthor.cs
@@ -7,7 +7,7 @@ namespace Microsoft.ComponentDetection.Contracts.Internal
         public NpmAuthor(string name, string email = null)
         {
             Name = name ?? throw new ArgumentNullException(nameof(name));
-            Email = email;
+            Email = string.IsNullOrEmpty(email) ? null : email;
         }
 
         public string Name { get; set; }

--- a/src/Microsoft.ComponentDetection.Contracts/TypedComponent/NpmComponent.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/TypedComponent/NpmComponent.cs
@@ -1,4 +1,5 @@
-﻿using PackageUrl;
+﻿using Microsoft.ComponentDetection.Contracts.Internal;
+using PackageUrl;
 
 namespace Microsoft.ComponentDetection.Contracts.TypedComponent
 {
@@ -21,6 +22,8 @@ namespace Microsoft.ComponentDetection.Contracts.TypedComponent
         public string Version { get; set; }
 
         public string Hash { get; set; }
+
+        public NpmAuthor Author { get; set; }
 
         public override ComponentType Type => ComponentType.Npm;
 

--- a/src/Microsoft.ComponentDetection.Contracts/TypedComponent/NpmComponent.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/TypedComponent/NpmComponent.cs
@@ -10,11 +10,12 @@ namespace Microsoft.ComponentDetection.Contracts.TypedComponent
             /* Reserved for deserialization */
         }
 
-        public NpmComponent(string name, string version, string hash = null)
+        public NpmComponent(string name, string version, string hash = null, NpmAuthor author = null)
         {
             Name = ValidateRequiredInput(name, nameof(Name), nameof(ComponentType.Npm));
             Version = ValidateRequiredInput(version, nameof(Version), nameof(ComponentType.Npm));
             Hash = hash; // Not required; only found in package-lock.json, not package.json
+            Author = author;
         }
 
         public string Name { get; set; }

--- a/src/Microsoft.ComponentDetection.Contracts/TypedComponent/NugetComponent.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/TypedComponent/NugetComponent.cs
@@ -9,15 +9,18 @@ namespace Microsoft.ComponentDetection.Contracts.TypedComponent
             /* Reserved for deserialization */
         }
 
-        public NuGetComponent(string name, string version)
+        public NuGetComponent(string name, string version, string[] authors = null)
         {
             Name = ValidateRequiredInput(name, nameof(Name), nameof(ComponentType.NuGet));
             Version = ValidateRequiredInput(version, nameof(Version), nameof(ComponentType.NuGet));
+            Authors = authors;
         }
 
         public string Name { get; set; }
 
         public string Version { get; set; }
+
+        public string[] Authors { get; set; }
 
         public override ComponentType Type => ComponentType.NuGet;
 

--- a/src/Microsoft.ComponentDetection.Detectors/nuget/NuGetComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/nuget/NuGetComponentDetector.cs
@@ -106,7 +106,8 @@ namespace Microsoft.ComponentDetection.Detectors.NuGet
 
                 string name = metadataNode["id"].InnerText;
                 string version = metadataNode["version"].InnerText;
-                string[] authors = metadataNode["authors"]?.InnerText.Split(",").Select(email => email.Trim()).ToArray();                
+
+                string[] authors = metadataNode["authors"]?.InnerText.Split(",").Select(author => author.Trim()).ToArray();                
 
                 if (!NuGetVersion.TryParse(version, out NuGetVersion parsedVer))
                 {

--- a/src/Microsoft.ComponentDetection.Detectors/nuget/NuGetComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/nuget/NuGetComponentDetector.cs
@@ -10,6 +10,7 @@ using System.Xml.Linq;
 using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Contracts.Internal;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
+using MoreLinq;
 using NuGet.Versioning;
 
 namespace Microsoft.ComponentDetection.Detectors.NuGet
@@ -105,6 +106,7 @@ namespace Microsoft.ComponentDetection.Detectors.NuGet
 
                 string name = metadataNode["id"].InnerText;
                 string version = metadataNode["version"].InnerText;
+                string[] authors = metadataNode["authors"]?.InnerText.Split(",").Select(email => email.Trim()).ToArray();                
 
                 if (!NuGetVersion.TryParse(version, out NuGetVersion parsedVer))
                 {
@@ -113,7 +115,7 @@ namespace Microsoft.ComponentDetection.Detectors.NuGet
                     return;
                 }
 
-                TypedComponent component = new NuGetComponent(name, version);
+                NuGetComponent component = new NuGetComponent(name, version, authors);
                 singleFileComponentRecorder.RegisterUsage(new DetectedComponent(component));
             }
             catch (Exception e)

--- a/test/Microsoft.ComponentDetection.Contracts.Tests/TypedComponentSerializationTests.cs
+++ b/test/Microsoft.ComponentDetection.Contracts.Tests/TypedComponentSerializationTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using FluentAssertions;
+using Microsoft.ComponentDetection.Contracts.Internal;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
@@ -28,25 +29,32 @@ namespace Microsoft.ComponentDetection.Contracts.Tests
         [TestMethod]
         public void TypedComponent_Serialization_NuGet()
         {
-            TypedComponent.TypedComponent tc = new NuGetComponent("SomeNuGetComponent", "1.2.3");
+            string testComponentName = "SomeNuGetComponent";
+            string testVersion = "1.2.3";
+            string[] testAuthors = { "John Doe", "Jane Doe" };
+            TypedComponent.TypedComponent tc = new NuGetComponent(testComponentName, testVersion, testAuthors);
             var result = JsonConvert.SerializeObject(tc);
             var deserializedTC = JsonConvert.DeserializeObject<TypedComponent.TypedComponent>(result);
             deserializedTC.Should().BeOfType(typeof(NuGetComponent));
             var nugetComponent = (NuGetComponent)deserializedTC;
-            nugetComponent.Name.Should().Be("SomeNuGetComponent");
-            nugetComponent.Version.Should().Be("1.2.3");
+            nugetComponent.Name.Should().Be(testComponentName);
+            nugetComponent.Version.Should().Be(testVersion);
+            nugetComponent.Authors.Should().BeEquivalentTo(testAuthors);
         }
 
         [TestMethod]
         public void TypedComponent_Serialization_Npm()
         {
-            TypedComponent.TypedComponent tc = new NpmComponent("SomeNpmComponent", "1.2.3");
-            var result = JsonConvert.SerializeObject(tc);
+            NpmAuthor npmAuthor = new Internal.NpmAuthor("someAuthorName", "someAuthorEmail");
+            NpmComponent npmCompObj = new NpmComponent("SomeNpmComponent", "1.2.3");
+            npmCompObj.Author = npmAuthor;
+            var result = JsonConvert.SerializeObject(npmCompObj);
             var deserializedTC = JsonConvert.DeserializeObject<TypedComponent.TypedComponent>(result);
             deserializedTC.Should().BeOfType(typeof(NpmComponent));
             var npmComponent = (NpmComponent)deserializedTC;
             npmComponent.Name.Should().Be("SomeNpmComponent");
             npmComponent.Version.Should().Be("1.2.3");
+            npmComponent.Author.Should().BeEquivalentTo(npmAuthor);
         }
 
         [TestMethod]

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/NpmDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/NpmDetectorTests.cs
@@ -140,6 +140,27 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         }
 
         [TestMethod]
+        public async Task TestNpmDetector_AuthorNull_WhenAuthorMalformed_AuthorAsSingleString()
+        {
+            string authorName = GetRandomString();
+            string authroUrl = GetRandomString();
+            string authorEmail = GetRandomString();
+            var (packageJsonName, packageJsonContents, packageJsonPath) =
+                NpmTestUtilities.GetPackageJsonNoDependenciesMalformedAuthorAsSingleString(authorName, authorEmail, authroUrl);
+            var detector = new NpmComponentDetector();
+
+            var (scanResult, componentRecorder) = await detectorTestUtility
+                .WithDetector(detector)
+                .WithFile(packageJsonName, packageJsonContents, packageJsonSearchPattern, fileLocation: packageJsonPath)
+                .ExecuteDetector();
+            Assert.AreEqual(ProcessingResultCode.Success, scanResult.ResultCode);
+            var detectedComponents = componentRecorder.GetDetectedComponents();
+            AssertDetectedComponentCount(detectedComponents, 1);
+            AssertNpmComponent(detectedComponents);
+            Assert.IsNull(((NpmComponent)detectedComponents.First().Component).Author);
+        }
+
+        [TestMethod]
         public async Task TestNpmDetector_AuthorNameDetected_WhenEmailNotPresentAndUrlNotPresent_AuthorAsSingleString()
         {
             string authorName = GetRandomString();

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/NpmDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/NpmDetectorTests.cs
@@ -1,0 +1,237 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.ComponentDetection.Common.DependencyGraph;
+using Microsoft.ComponentDetection.Contracts;
+using Microsoft.ComponentDetection.Contracts.TypedComponent;
+using Microsoft.ComponentDetection.Detectors.Npm;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Microsoft.ComponentDetection.TestsUtilities;
+
+using static Microsoft.ComponentDetection.Detectors.Tests.Utilities.TestUtilityExtensions;
+
+namespace Microsoft.ComponentDetection.Detectors.Tests
+{
+    [TestClass]
+    [TestCategory("Governance/All")]
+    [TestCategory("Governance/ComponentDetection")]
+    public class NpmDetectorTests
+    {
+        private Mock<ILogger> loggerMock;
+        private Mock<IPathUtilityService> pathUtilityService;
+        private ComponentRecorder componentRecorder;
+        private DetectorTestUtility<NpmComponentDetector> detectorTestUtility = DetectorTestUtilityCreator.Create<NpmComponentDetector>();
+        private List<string> packageJsonSearchPattern = new List<string> { "package.json" };
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            loggerMock = new Mock<ILogger>();
+            pathUtilityService = new Mock<IPathUtilityService>();
+            pathUtilityService.Setup(x => x.GetParentDirectory(It.IsAny<string>())).Returns((string path) => Path.GetDirectoryName(path));
+            componentRecorder = new ComponentRecorder();
+        }
+
+        [TestMethod]
+        public async Task TestNpmDetector_NameAndVersionDetected()
+        {
+            string componentName = GetRandomString();
+            string version = NewRandomVersion();
+            var (packageJsonName, packageJsonContents, packageJsonPath) = 
+                NpmTestUtilities.GetPackageJsonNoDependenciesForNameAndVersion(componentName, version);
+            var detector = new NpmComponentDetector();
+            
+            var (scanResult, componentRecorder) = await detectorTestUtility
+                .WithDetector(detector)
+                .WithFile(packageJsonName, packageJsonContents, packageJsonSearchPattern, fileLocation: packageJsonPath)
+                .ExecuteDetector();
+            Assert.AreEqual(ProcessingResultCode.Success, scanResult.ResultCode);
+            var detectedComponents = componentRecorder.GetDetectedComponents();
+            Assert.AreEqual(1, detectedComponents.Count());
+            Assert.AreEqual(detectedComponents.First().Component.Type, ComponentType.Npm);
+            Assert.AreEqual(((NpmComponent)detectedComponents.First().Component).Name, componentName);
+            Assert.AreEqual(((NpmComponent)detectedComponents.First().Component).Version, version);
+        }
+
+        [TestMethod]
+        public async Task TestNpmDetector_AuthorNameAndEmailDetected_AuthorInJsonFormat()
+        {
+            string authorName = GetRandomString();
+            string authorEmail = GetRandomString();
+            var (packageJsonName, packageJsonContents, packageJsonPath) = NpmTestUtilities.GetPackageJsonNoDependenciesForAuthorAndEmailInJsonFormat(authorName, authorEmail);
+            var detector = new NpmComponentDetector();
+
+            var (scanResult, componentRecorder) = await detectorTestUtility
+                .WithDetector(detector)
+                .WithFile(packageJsonName, packageJsonContents, packageJsonSearchPattern, fileLocation: packageJsonPath)
+                .ExecuteDetector();
+            Assert.AreEqual(ProcessingResultCode.Success, scanResult.ResultCode);
+            var detectedComponents = componentRecorder.GetDetectedComponents();
+            AssertDetectedComponentCount(detectedComponents, 1);
+            AssertNpmComponent(detectedComponents);
+            Assert.AreEqual(authorName, ((NpmComponent)detectedComponents.First().Component).Author.Name);
+            Assert.AreEqual(authorEmail, ((NpmComponent)detectedComponents.First().Component).Author.Email);
+        }
+
+        [TestMethod]
+        public async Task TestNpmDetector_AuthorNameDetectedWhenEmailIsNotPresent_AuthorInJsonFormat()
+        {
+            string authorName = GetRandomString();
+            var (packageJsonName, packageJsonContents, packageJsonPath) = 
+                NpmTestUtilities.GetPackageJsonNoDependenciesForAuthorAndEmailInJsonFormat(authorName, null);
+            var detector = new NpmComponentDetector();
+
+            var (scanResult, componentRecorder) = await detectorTestUtility
+                .WithDetector(detector)
+                .WithFile(packageJsonName, packageJsonContents, packageJsonSearchPattern, fileLocation: packageJsonPath)
+                .ExecuteDetector();
+            Assert.AreEqual(ProcessingResultCode.Success, scanResult.ResultCode);
+            var detectedComponents = componentRecorder.GetDetectedComponents();
+            AssertDetectedComponentCount(detectedComponents, 1);
+            AssertNpmComponent(detectedComponents);
+            Assert.AreEqual(authorName, ((NpmComponent)detectedComponents.First().Component).Author.Name);
+            Assert.IsNull(((NpmComponent)detectedComponents.First().Component).Author.Email);  
+        }
+
+        [TestMethod]
+        public async Task TestNpmDetector_AuthorNameAndAuthorEmailDetected_WhenAuthorNameAndEmailAndUrlIsPresent_AuthorAsSingleString()
+        {
+            string authorName = GetRandomString();
+            string authorEmail = GetRandomString();
+            string authroUrl = GetRandomString();
+            var (packageJsonName, packageJsonContents, packageJsonPath) = 
+                NpmTestUtilities.GetPackageJsonNoDependenciesForAuthorAndEmailAsSingleString(authorName, authorEmail, authroUrl);
+            var detector = new NpmComponentDetector();
+
+            var (scanResult, componentRecorder) = await detectorTestUtility
+                .WithDetector(detector)
+                .WithFile(packageJsonName, packageJsonContents, packageJsonSearchPattern, fileLocation: packageJsonPath)
+                .ExecuteDetector();
+            Assert.AreEqual(ProcessingResultCode.Success, scanResult.ResultCode);
+            var detectedComponents = componentRecorder.GetDetectedComponents();
+            AssertDetectedComponentCount(detectedComponents, 1);
+            AssertNpmComponent(detectedComponents);
+            Assert.AreEqual(authorName, ((NpmComponent)detectedComponents.First().Component).Author.Name);
+            Assert.AreEqual(authorEmail, ((NpmComponent)detectedComponents.First().Component).Author.Email);
+        }
+
+        [TestMethod]
+        public async Task TestNpmDetector_AuthorNameDetected_WhenEmailNotPresentAndUrlIsPresent_AuthorAsSingleString()
+        {
+            string authorName = GetRandomString();
+            string authroUrl = GetRandomString();
+            var (packageJsonName, packageJsonContents, packageJsonPath) = 
+                NpmTestUtilities.GetPackageJsonNoDependenciesForAuthorAndEmailAsSingleString(authorName, null, authroUrl);
+            var detector = new NpmComponentDetector();
+
+            var (scanResult, componentRecorder) = await detectorTestUtility
+                .WithDetector(detector)
+                .WithFile(packageJsonName, packageJsonContents, packageJsonSearchPattern, fileLocation: packageJsonPath)
+                .ExecuteDetector();
+            Assert.AreEqual(ProcessingResultCode.Success, scanResult.ResultCode);
+            var detectedComponents = componentRecorder.GetDetectedComponents();
+            AssertDetectedComponentCount(detectedComponents, 1);
+            AssertNpmComponent(detectedComponents);
+            Assert.AreEqual(authorName, ((NpmComponent)detectedComponents.First().Component).Author.Name);
+            Assert.IsNull(((NpmComponent)detectedComponents.First().Component).Author.Email);
+        }
+
+        [TestMethod]
+        public async Task TestNpmDetector_AuthorNameDetected_WhenEmailNotPresentAndUrlNotPresent_AuthorAsSingleString()
+        {
+            string authorName = GetRandomString();
+            string authroUrl = GetRandomString();
+            var (packageJsonName, packageJsonContents, packageJsonPath) =
+                NpmTestUtilities.GetPackageJsonNoDependenciesForAuthorAndEmailAsSingleString(authorName);
+            var detector = new NpmComponentDetector();
+
+            var (scanResult, componentRecorder) = await detectorTestUtility
+                .WithDetector(detector)
+                .WithFile(packageJsonName, packageJsonContents, packageJsonSearchPattern, fileLocation: packageJsonPath)
+                .ExecuteDetector();
+            Assert.AreEqual(ProcessingResultCode.Success, scanResult.ResultCode);
+            var detectedComponents = componentRecorder.GetDetectedComponents();
+            AssertDetectedComponentCount(detectedComponents, 1);
+            AssertNpmComponent(detectedComponents);
+            Assert.AreEqual(authorName, ((NpmComponent)detectedComponents.First().Component).Author.Name);
+            Assert.IsNull(((NpmComponent)detectedComponents.First().Component).Author.Email);
+        }
+
+        [TestMethod]
+        public async Task TestNpmDetector_AuthorNameAndAuthorEmailDetected_WhenUrlNotPresent_AuthorAsSingleString()
+        {
+            string authorName = GetRandomString();
+            string authorEmail = GetRandomString();
+            var (packageJsonName, packageJsonContents, packageJsonPath) =
+                NpmTestUtilities.GetPackageJsonNoDependenciesForAuthorAndEmailAsSingleString(authorName, authorEmail);
+            var detector = new NpmComponentDetector();
+
+            var (scanResult, componentRecorder) = await detectorTestUtility
+                .WithDetector(detector)
+                .WithFile(packageJsonName, packageJsonContents, packageJsonSearchPattern, fileLocation: packageJsonPath)
+                .ExecuteDetector();
+
+            Assert.AreEqual(ProcessingResultCode.Success, scanResult.ResultCode);
+            var detectedComponents = componentRecorder.GetDetectedComponents();
+            AssertDetectedComponentCount(detectedComponents, 1);
+            AssertNpmComponent(detectedComponents);
+            Assert.AreEqual(authorName, ((NpmComponent)detectedComponents.First().Component).Author.Name);
+            Assert.AreEqual(authorEmail, ((NpmComponent)detectedComponents.First().Component).Author.Email);
+        }
+
+        [TestMethod]
+        public async Task TestNpmDetector_NullAuthor_WhenAuthorNameIsNullOrEmpty_AuthorAsJson()
+        {
+            string authorName = string.Empty;
+            string authorEmail = GetRandomString();
+            var (packageJsonName, packageJsonContents, packageJsonPath) =
+                NpmTestUtilities.GetPackageJsonNoDependenciesForAuthorAndEmailInJsonFormat(authorName, authorEmail);
+            var detector = new NpmComponentDetector();
+
+            var (scanResult, componentRecorder) = await detectorTestUtility
+                .WithDetector(detector)
+                .WithFile(packageJsonName, packageJsonContents, packageJsonSearchPattern, fileLocation: packageJsonPath)
+                .ExecuteDetector();
+
+            Assert.AreEqual(ProcessingResultCode.Success, scanResult.ResultCode);
+            var detectedComponents = componentRecorder.GetDetectedComponents();
+            AssertDetectedComponentCount(detectedComponents, 1);
+            AssertNpmComponent(detectedComponents);
+            Assert.IsNull(((NpmComponent)detectedComponents.First().Component).Author);
+        }
+
+        [TestMethod]
+        public async Task TestNpmDetector_NullAuthor_WhenAuthorNameIsNullOrEmpty_AuthorAsSingleString()
+        {
+            string authorName = string.Empty;
+            string authorEmail = GetRandomString();
+            var (packageJsonName, packageJsonContents, packageJsonPath) =
+                NpmTestUtilities.GetPackageJsonNoDependenciesForAuthorAndEmailAsSingleString(authorName, authorEmail);
+            var detector = new NpmComponentDetector();
+
+            var (scanResult, componentRecorder) = await detectorTestUtility
+                .WithDetector(detector)
+                .WithFile(packageJsonName, packageJsonContents, packageJsonSearchPattern, fileLocation: packageJsonPath)
+                .ExecuteDetector();
+
+            Assert.AreEqual(ProcessingResultCode.Success, scanResult.ResultCode);
+            var detectedComponents = componentRecorder.GetDetectedComponents();
+            AssertDetectedComponentCount(detectedComponents, 1);
+            AssertNpmComponent(detectedComponents);
+            Assert.IsNull(((NpmComponent)detectedComponents.First().Component).Author);
+        }
+
+        private static void AssertDetectedComponentCount(IEnumerable<DetectedComponent> detectedComponents, int expectedCount)
+        {
+            Assert.AreEqual(expectedCount, detectedComponents.Count());
+        }
+
+        private static void AssertNpmComponent(IEnumerable<DetectedComponent> detectedComponents)
+        {
+            Assert.AreEqual(detectedComponents.First().Component.Type, ComponentType.Npm);
+        }
+    }
+}

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/NpmTestUtilities.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/NpmTestUtilities.cs
@@ -92,6 +92,73 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
             return ("package.json", packageJsonTemplate, Path.Combine(Path.GetTempPath(), "package.json"));
         }
 
+        public static (string, string, string) GetPackageJsonNoDependenciesForNameAndVersion(string packageName, string packageVersion)
+        {
+            string packagejson = @"{{
+                ""name"": ""{0}"",
+                ""version"": ""{1}""
+            }}";
+            var packageJsonTemplate = string.Format(packagejson, packageName, packageVersion);
+            return ("package.json", packageJsonTemplate, Path.Combine(Path.GetTempPath(), "package.json"));
+        }
+
+        public static (string, string, string) GetPackageJsonNoDependenciesForAuthorAndEmailInJsonFormat(
+            string authorName, string authorEmail = null)
+        {
+            string packagejson;
+            if (authorEmail != null)
+            {
+                packagejson = @"{{
+                    ""name"": ""test"",
+                    ""version"": ""0.0.0"",
+                    ""author"": {{
+                        ""name"": ""{0}"",
+                        ""email"": ""{1}""
+                    }}
+                }}";
+            } else
+            {
+                packagejson = @"{{
+                    ""name"": ""test"",
+                    ""version"": ""0.0.0"",
+                    ""author"": {{
+                        ""name"": ""{0}"",
+                    }}
+                }}";
+            }
+            
+            var packageJsonTemplate = string.Format(packagejson, authorName, authorEmail);
+            return ("package.json", packageJsonTemplate, Path.Combine(Path.GetTempPath(), "package.json"));
+        }
+
+        public static (string, string, string) GetPackageJsonNoDependenciesForAuthorAndEmailAsSingleString(
+            string authorName, string authorEmail = null, string authorUrl = null)
+        {
+            string packagejson = @"{{{{
+                    ""name"": ""test"",
+                    ""version"": ""0.0.0"",
+                    ""author"": {0}
+                }}}}";
+            string author;
+
+            if (authorEmail != null && authorUrl != null)
+            {
+                author = @"""{0} <{1}> ({2})""";
+            } else if (authorEmail == null && authorUrl != null)
+            {
+                author = @"""{0} ({2})""";
+            } else if (authorEmail != null && authorUrl == null)
+            {
+                author = @"""{0} <{1}>""";
+            } else
+            {
+                author = @"""{0}""";
+            }
+
+            var packageJsonTemplate = string.Format(string.Format(packagejson, author), authorName, authorEmail, authorUrl);
+            return ("package.json", packageJsonTemplate, Path.Combine(Path.GetTempPath(), "package.json"));
+        }
+
         public static (string, string, string) GetWellFormedPackageLock2(string lockFileName, string rootName0 = null, string rootVersion0 = null, string rootName2 = null, string rootVersion2 = null, string packageName0 = "test", string packageName1 = null, string packageName3 = null)
         {
             string packageLockJson = @"{{

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/NpmTestUtilities.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/NpmTestUtilities.cs
@@ -159,6 +159,37 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
             return ("package.json", packageJsonTemplate, Path.Combine(Path.GetTempPath(), "package.json"));
         }
 
+        public static (string, string, string) GetPackageJsonNoDependenciesMalformedAuthorAsSingleString(
+            string authorName, string authorEmail = null, string authorUrl = null)
+        {
+            string packagejson = @"{{{{
+                    ""name"": ""test"",
+                    ""version"": ""0.0.0"",
+                    ""author"": {0}
+                }}}}";
+            string author;
+
+            if (authorEmail != null && authorUrl != null)
+            {
+                author = @"""{0} <{1} ({2})""";
+            }
+            else if (authorEmail == null && authorUrl != null)
+            {
+                author = @"""{0} ({2}""";
+            }
+            else if (authorEmail != null && authorUrl == null)
+            {
+                author = @"""{0} <{1}""";
+            }
+            else
+            {
+                author = @"""{0}""";
+            }
+
+            var packageJsonTemplate = string.Format(string.Format(packagejson, author), authorName, authorEmail, authorUrl);
+            return ("package.json", packageJsonTemplate, Path.Combine(Path.GetTempPath(), "package.json"));
+        }
+
         public static (string, string, string) GetWellFormedPackageLock2(string lockFileName, string rootName0 = null, string rootVersion0 = null, string rootName2 = null, string rootVersion2 = null, string packageName0 = "test", string packageName1 = null, string packageName3 = null)
         {
             string packageLockJson = @"{{

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/NugetTestUtilities.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/NugetTestUtilities.cs
@@ -17,20 +17,20 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
     {
         public static string GetRandomValidNuSpecComponent()
         {
-            string componentName = Guid.NewGuid().ToString("N");
+            string componentName = GetRandomString();
             string componentSpecFileName = $"{componentName}.nuspec";
             string componentSpecPath = Path.Combine(Path.GetTempPath(), componentSpecFileName);
-            var template = GetTemplatedNuspec(componentName, NewRandomVersion());
+            var template = GetTemplatedNuspec(componentName, NewRandomVersion(), new string[] { GetRandomString(), GetRandomString() });
 
             return template;
         }
 
         public static IComponentStream GetRandomValidNuSpecComponentStream()
         {
-            string componentName = Guid.NewGuid().ToString("N");
+            string componentName = GetRandomString();
             string componentSpecFileName = $"{componentName}.nuspec";
             string componentSpecPath = Path.Combine(Path.GetTempPath(), componentSpecFileName);
-            var template = GetTemplatedNuspec(componentName, NewRandomVersion());
+            var template = GetTemplatedNuspec(componentName, NewRandomVersion(), new string[] { GetRandomString(), GetRandomString() });
 
             var mock = new Mock<IComponentStream>();
             mock.SetupGet(x => x.Stream).Returns(template.ToStream());
@@ -52,11 +52,16 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
             return mock.Object;
         }
 
-        public static string GetRandomValidNuPkgComponent()
+        public static string GetRandomValidNuspec()
         {
-            string componentName = Guid.NewGuid().ToString("N");
-            var template = GetTemplatedNuspec(componentName, NewRandomVersion());
+            string componentName = GetRandomString();
+            var template = GetTemplatedNuspec(componentName, NewRandomVersion(), new string[] { GetRandomString(), GetRandomString() });
             return template;
+        }
+
+        public static string GetValidNuspec(string componentName, string version, string[] authors)
+        {
+            return GetTemplatedNuspec(componentName, version, authors);
         }
 
         public static async Task<Stream> ZipNupkgComponent(string filename, string content)
@@ -79,13 +84,13 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
 
         public static string GetRandomMalformedNuPkgComponent()
         {
-            string componentName = Guid.NewGuid().ToString("N");
-            var template = GetTemplatedNuspec(componentName, NewRandomVersion());
+            string componentName = GetRandomString();
+            var template = GetTemplatedNuspec(componentName, NewRandomVersion(), new string[] { GetRandomString(), GetRandomString() });
             template = template.Replace("<id>", "<?malformed>");
             return template;
         }
 
-        private static string GetTemplatedNuspec(string id, string version)
+        private static string GetTemplatedNuspec(string id, string version, string[] authors)
         {
             string nuspec = @"<?xml version=""1.0"" encoding=""utf-8""?>
                             <package xmlns=""http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"">
@@ -94,7 +99,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
                                     <id>{0}</id>
                                     <version>{1}</version>
                                     <description></description>
-                                    <authors></authors>
+                                    <authors>{2}</authors>
 
                                     <!-- Optional elements -->
                                     <!-- ... -->
@@ -102,7 +107,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
                                 <!-- Optional 'files' node -->
                             </package>";
 
-            return string.Format(nuspec, id, version);
+            return string.Format(nuspec, id, version, string.Join(",", authors));
         }
 
         private static string GetTemplatedNuGetConfig(string repositoryPath)

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/Utilities/TestUtilityExtensions.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/Utilities/TestUtilityExtensions.cs
@@ -13,5 +13,10 @@ namespace Microsoft.ComponentDetection.Detectors.Tests.Utilities
                 RandomNumberGenerator.GetInt32(0, 1000))
                 .ToString();
         }
+
+        public static string GetRandomString()
+        {
+            return Guid.NewGuid().ToString("N");
+        }
     }
 }


### PR DESCRIPTION
Added author Detection for NpmComponents and NugetComponent

[Executive Order](https://www.whitehouse.gov/briefing-room/presidential-actions/2021/05/12/executive-order-on-improving-the-nations-cybersecurity/) requirements 4. e.x. and 4.e.vi. require provenance (origination) information of both open-source software and software code and components. 

This change enables component detection to extract author information for NPM packages from `package.json` files and for Nuget Component from `.nuspec` file.