### PR TITLE
Initial implementation of VcpkgDetector and VcpkgComponent

### DIFF
--- a/src/Microsoft.ComponentDetection.Contracts/DetectorClass.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/DetectorClass.cs
@@ -35,5 +35,8 @@
 
         /// <summary>Indicates a detector applies to Conda packages.</summary>
         Conda,
+
+        /// <summary>Indicates a detector applies to Vcpkg packages.</summary>
+        Vcpkg,
     }
 }

--- a/src/Microsoft.ComponentDetection.Contracts/TypedComponent/ComponentType.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/TypedComponent/ComponentType.cs
@@ -44,5 +44,8 @@ namespace Microsoft.ComponentDetection.Contracts.TypedComponent
 
         [EnumMember]
         Conda = 13,
+
+        [EnumMember]
+        Vcpkg = 14,
     }
 }

--- a/src/Microsoft.ComponentDetection.Contracts/TypedComponent/VcpkgComponent.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/TypedComponent/VcpkgComponent.cs
@@ -1,0 +1,63 @@
+﻿using PackageUrl;
+
+namespace Microsoft.ComponentDetection.Contracts.TypedComponent
+{
+    public class VcpkgComponent : TypedComponent
+    {
+        private VcpkgComponent()
+        {
+            /* Reserved for deserialization */
+        }
+
+        public VcpkgComponent(string spdxid, string name, string version, string triplet = null, string portVersion = null, string description = null, string downloadLocation = null)
+        {
+            SPDXID = ValidateRequiredInput(spdxid, nameof(SPDXID), nameof(ComponentType.Vcpkg));
+            Name = ValidateRequiredInput(name, nameof(Name), nameof(ComponentType.Vcpkg));
+            Version = version;
+            PortVersion = portVersion;
+            Triplet = triplet;
+            Description = description;
+            DownloadLocation = downloadLocation;
+        }
+
+        public string SPDXID { get; set; }
+
+        public string Name { get; set; }
+
+        public string DownloadLocation { get; set; }
+
+        public string Triplet { get; set; }
+
+        public string Version { get; set; }
+
+        public string Description { get; set; }
+
+        public string PortVersion { get; set; }
+
+        public override ComponentType Type => ComponentType.Vcpkg;
+
+        public override string Id
+        {
+            get
+            {
+                if (PortVersion != null)
+                    return $"{Name} {Version}#{PortVersion} - {Type}";
+                else
+                    return $"{Name} {Version} - {Type}";
+            }
+        }
+
+        public override PackageURL PackageUrl
+        {
+            get
+            {
+                if (PortVersion != null)
+                    return new PackageURL($"pkg:vcpkg/{Name}@{Version}?port_version={PortVersion}");
+                else if (Version != null)
+                    return new PackageURL($"pkg:vcpkg/{Name}@{Version}");
+                else
+                    return new PackageURL($"pkg:vcpkg/{Name}");
+            }
+        }
+    }
+}

--- a/src/Microsoft.ComponentDetection.Detectors/vcpkg/Contracts/Package.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/vcpkg/Contracts/Package.cs
@@ -1,0 +1,19 @@
+namespace Microsoft.ComponentDetection.Detectors.Vcpkg.Contracts
+{
+    public class Package
+    {
+        public string SPDXID { get; set; }
+
+        public string VersionInfo { get; set; }
+
+        public string DownloadLocation { get; set; }
+
+        public string Filename { get; set; }
+
+        public string Homepage { get; set; }
+
+        public string Description { get; set; }
+
+        public string Name { get; set; }
+    }
+}

--- a/src/Microsoft.ComponentDetection.Detectors/vcpkg/Contracts/VcpkgSBOM.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/vcpkg/Contracts/VcpkgSBOM.cs
@@ -1,0 +1,14 @@
+namespace Microsoft.ComponentDetection.Detectors.Vcpkg.Contracts
+{
+    /// <summary>
+    /// Take from https://github.com/anchore/syft/tree/main/schema/json.
+    /// Match version to tag used i.e. https://github.com/anchore/syft/blob/v0.16.1/internal/constants.go#L9
+    /// Can convert JSON Schema to C# using quicktype.io.
+    /// </summary>
+    public class VcpkgSBOM
+    {
+        public Package[] Packages { get; set; }
+
+        public string Name { get; set; }
+    }
+}

--- a/src/Microsoft.ComponentDetection.Detectors/vcpkg/VcpkgComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/vcpkg/VcpkgComponentDetector.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Composition;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Microsoft.ComponentDetection.Common;
+using Microsoft.ComponentDetection.Common.Telemetry.Records;
+using Microsoft.ComponentDetection.Contracts;
+using Microsoft.ComponentDetection.Contracts.Internal;
+using Microsoft.ComponentDetection.Contracts.TypedComponent;
+using Microsoft.ComponentDetection.Detectors.Vcpkg.Contracts;
+using Newtonsoft.Json;
+
+namespace Microsoft.ComponentDetection.Detectors.Vcpkg
+{
+    [Export(typeof(IComponentDetector))]
+    public class VcpkgComponentDetector : FileComponentDetector, IDefaultOffComponentDetector
+    {
+        [Import]
+        public ICommandLineInvocationService CommandLineInvocationService { get; set; }
+
+        [Import]
+        public IEnvironmentVariableService EnvVarService { get; set; }
+
+        public override string Id { get; } = "Vcpkg";
+
+        public override IEnumerable<string> Categories => new[] { Enum.GetName(typeof(DetectorClass), DetectorClass.Vcpkg) };
+
+        public override IList<string> SearchPatterns { get; } = new List<string> { "vcpkg.spdx.json" };
+
+        public override IEnumerable<ComponentType> SupportedComponentTypes { get; } = new[] { ComponentType.Go };
+
+        public override int Version => 1;
+
+        private HashSet<string> projectRoots = new HashSet<string>();
+
+        protected override async Task OnFileFound(ProcessRequest processRequest, IDictionary<string, string> detectorArgs)
+        {
+            var singleFileComponentRecorder = processRequest.SingleFileComponentRecorder;
+            var file = processRequest.ComponentStream;
+
+            Logger.LogWarning($"vcpkg detector found {file}");
+
+            var projectRootDirectory = Directory.GetParent(file.Location);
+            if (projectRoots.Any(path => projectRootDirectory.FullName.StartsWith(path)))
+            {
+                return;
+            }
+
+            ParseSpdxFile(singleFileComponentRecorder, file);
+        }
+
+        private void ParseSpdxFile(
+            ISingleFileComponentRecorder singleFileComponentRecorder,
+            IComponentStream file)
+        {
+            using var reader = new StreamReader(file.Stream);
+            var sbom = JsonConvert.DeserializeObject<VcpkgSBOM>(reader.ReadToEnd());
+
+            foreach (var item in sbom.Packages)
+            {
+                if (item.Name == null || item.Name.Length == 0) { continue; }
+                try
+                {
+                    Logger.LogWarning($"parsed package {item.Name}");
+                    if (item.SPDXID == "SPDXRef-port")
+                    {
+                        var split = item.VersionInfo.Split('#');
+                        var component = new VcpkgComponent(item.SPDXID, item.Name, split[0], portVersion: split.Length >= 2 ? split[1] : "0", downloadLocation: item.DownloadLocation);
+                        singleFileComponentRecorder.RegisterUsage(new DetectedComponent(component));
+                    }
+                    else if (item.SPDXID == "SPDXRef-binary")
+                    {
+                        var split = item.Name.Split(':');
+                        var component = new VcpkgComponent(item.SPDXID, item.Name, item.VersionInfo, triplet: split[1], downloadLocation: item.DownloadLocation);
+                        singleFileComponentRecorder.RegisterUsage(new DetectedComponent(component));
+                    }
+                    else if (item.SPDXID.StartsWith("SPDXRef-resource-"))
+                    {
+                        var dl = item.DownloadLocation;
+                        var split = dl.Split("#");
+                        var subpath = split.Length > 1 ? split[1] : null;
+                        dl = split.Length > 1 ? split[0] : dl;
+                        split = dl.Split("@");
+                        var version = split.Length > 1 ? split[1] : null;
+                        dl = split.Length > 1 ? split[0] : dl;
+
+                        var component = new VcpkgComponent(item.SPDXID, item.Name, version, downloadLocation: dl);
+                        singleFileComponentRecorder.RegisterUsage(new DetectedComponent(component));
+                    }
+                }
+                catch (Exception)
+                {
+                    Logger.LogWarning($"failed while handling {item.Name}");
+                }
+            }
+        }
+    }
+}

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/Resources/vcpkg/nlohmann-json/vcpkg.spdx.json
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/Resources/vcpkg/nlohmann-json/vcpkg.spdx.json
@@ -1,0 +1,115 @@
+{
+    "$schema": "https://raw.githubusercontent.com/spdx/spdx-spec/v2.2.1/schemas/spdx-schema.json",
+    "spdxVersion": "SPDX-2.2",
+    "dataLicense": "CC0-1.0",
+    "SPDXID": "SPDXRef-DOCUMENT",
+    "documentNamespace": "https://spdx.org/spdxdocs/nlohmann-json-x64-linux-3.10.4-78c7f190-b402-44d1-a364-b9ac86392b84",
+    "name": "nlohmann-json:x64-linux@3.10.4 69dcfc6886529ad2d210f71f132d743672a7e65d2c39f53456f17fc5fc08b278",
+    "creationInfo": {
+        "creators": [
+            "Tool: vcpkg-unknownhash"
+        ],
+        "created": "2022-01-18T21:12:48Z"
+    },
+    "relationships": [
+        {
+            "spdxElementId": "SPDXRef-port",
+            "relationshipType": "GENERATES",
+            "relatedSpdxElement": "SPDXRef-binary"
+        },
+        {
+            "spdxElementId": "SPDXRef-port",
+            "relationshipType": "CONTAINS",
+            "relatedSpdxElement": "SPDXRef-file-0"
+        },
+        {
+            "spdxElementId": "SPDXRef-port",
+            "relationshipType": "CONTAINS",
+            "relatedSpdxElement": "SPDXRef-file-1"
+        },
+        {
+            "spdxElementId": "SPDXRef-binary",
+            "relationshipType": "GENERATED_FROM",
+            "relatedSpdxElement": "SPDXRef-port"
+        },
+        {
+            "spdxElementId": "SPDXRef-file-0",
+            "relationshipType": "CONTAINED_BY",
+            "relatedSpdxElement": "SPDXRef-port"
+        },
+        {
+            "spdxElementId": "SPDXRef-file-1",
+            "relationshipType": "CONTAINED_BY",
+            "relatedSpdxElement": "SPDXRef-port"
+        },
+        {
+            "spdxElementId": "SPDXRef-file-1",
+            "relationshipType": "DEPENDENCY_MANIFEST_OF",
+            "relatedSpdxElement": "SPDXRef-port"
+        }
+    ],
+    "packages": [
+        {
+            "name": "nlohmann-json",
+            "SPDXID": "SPDXRef-port",
+            "versionInfo": "3.10.4",
+            "downloadLocation": "git+https://github.com/Microsoft/vcpkg#ports/nlohmann-json",
+            "homepage": "https://github.com/nlohmann/json",
+            "licenseConcluded": "NOASSERTION",
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "description": "JSON for Modern C++",
+            "comment": "This is the port (recipe) consumed by vcpkg."
+        },
+        {
+            "name": "nlohmann-json:x64-linux",
+            "SPDXID": "SPDXRef-binary",
+            "versionInfo": "69dcfc6886529ad2d210f71f132d743672a7e65d2c39f53456f17fc5fc08b278",
+            "downloadLocation": "NONE",
+            "licenseConcluded": "NOASSERTION",
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "comment": "This is a binary package built by vcpkg."
+        },
+        {
+            "SPDXID": "SPDXRef-resource-1",
+            "name": "nlohmann/json",
+            "downloadLocation": "git+https://github.com/nlohmann/json@v3.10.4",
+            "licenseConcluded": "NOASSERTION",
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "checksums": [
+                {
+                    "algorithm": "SHA512",
+                    "checksumValue": "f78592db6218165cbc74c10bcba40366f1bfea84405b7ee25fe97a056d5b7a15aeeb956d93296673928dcbd6e26ffcfb152f885b4a44d5d55751396ccf090835"
+                }
+            ]
+        }
+    ],
+    "files": [
+        {
+            "fileName": "./portfile.cmake",
+            "SPDXID": "SPDXRef-file-0",
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "49b4f9e11cdd0ef697a2750187fa5fa42e7e833dbf411d299ca4d1e9f147773a"
+                }
+            ],
+            "licenseConcluded": "NOASSERTION",
+            "copyrightText": "NOASSERTION"
+        },
+        {
+            "fileName": "./vcpkg.json",
+            "SPDXID": "SPDXRef-file-1",
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "b97c75815135eb812a88ee92d50170928d4c69517bfb332e181070cbce2c081b"
+                }
+            ],
+            "licenseConcluded": "NOASSERTION",
+            "copyrightText": "NOASSERTION"
+        }
+    ]
+}

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/Resources/vcpkg/tinyxml2/vcpkg.spdx.json
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/Resources/vcpkg/tinyxml2/vcpkg.spdx.json
@@ -1,0 +1,115 @@
+{
+  "$schema": "https://raw.githubusercontent.com/spdx/spdx-spec/v2.2.1/schemas/spdx-schema.json",
+  "spdxVersion": "SPDX-2.2",
+  "dataLicense": "CC0-1.0",
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "documentNamespace": "https://spdx.org/spdxdocs/tinyxml2-x64-linux-9.0.0-c99e4f03-5275-458b-8a69-b5f8dfa45f18",
+  "name": "tinyxml2:x64-linux@9.0.0 5c7679507def92c5c71df44aec08a90a5c749f7f805b3f0e8e70f5e8a5b1b8d0",
+  "creationInfo": {
+    "creators": [
+      "Tool: vcpkg-unknownhash"
+    ],
+    "created": "2022-01-14T00:28:41Z"
+  },
+  "relationships": [
+    {
+      "spdxElementId": "SPDXRef-port",
+      "relationshipType": "GENERATES",
+      "relatedSpdxElement": "SPDXRef-binary"
+    },
+    {
+      "spdxElementId": "SPDXRef-port",
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-file-0"
+    },
+    {
+      "spdxElementId": "SPDXRef-port",
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-file-1"
+    },
+    {
+      "spdxElementId": "SPDXRef-binary",
+      "relationshipType": "GENERATED_FROM",
+      "relatedSpdxElement": "SPDXRef-port"
+    },
+    {
+      "spdxElementId": "SPDXRef-file-0",
+      "relationshipType": "CONTAINED_BY",
+      "relatedSpdxElement": "SPDXRef-port"
+    },
+    {
+      "spdxElementId": "SPDXRef-file-1",
+      "relationshipType": "CONTAINED_BY",
+      "relatedSpdxElement": "SPDXRef-port"
+    },
+    {
+      "spdxElementId": "SPDXRef-file-1",
+      "relationshipType": "DEPENDENCY_MANIFEST_OF",
+      "relatedSpdxElement": "SPDXRef-port"
+    }
+  ],
+  "packages": [
+    {
+      "name": "tinyxml2",
+      "SPDXID": "SPDXRef-port",
+      "versionInfo": "9.0.0",
+      "downloadLocation": "git+https://github.com/Microsoft/vcpkg#ports/tinyxml2",
+      "homepage": "https://github.com/leethomason/tinyxml2",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "copyrightText": "NOASSERTION",
+      "description": "A simple, small, efficient, C++ XML parser",
+      "comment": "This is the port (recipe) consumed by vcpkg."
+    },
+    {
+      "name": "tinyxml2:x64-linux",
+      "SPDXID": "SPDXRef-binary",
+      "versionInfo": "5c7679507def92c5c71df44aec08a90a5c749f7f805b3f0e8e70f5e8a5b1b8d0",
+      "downloadLocation": "NONE",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "copyrightText": "NOASSERTION",
+      "comment": "This is a binary package built by vcpkg."
+    },
+    {
+      "SPDXID": "SPDXRef-resource-1",
+      "name": "leethomason/tinyxml2",
+      "downloadLocation": "git+https://github.com/leethomason/tinyxml2@9.0.0",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "copyrightText": "NOASSERTION",
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "9c5ce8131984690df302ca3e32314573b137180ed522c92fd631692979c942372a28f697fdb3d5e56bcf2d3dc596262b724d088153f3e1d721c9536f2a883367"
+        }
+      ]
+    }
+  ],
+  "files": [
+    {
+      "fileName": "./portfile.cmake",
+      "SPDXID": "SPDXRef-file-0",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "dad309c46aea9ccd9a3779723970963b2792d6a7fade26f95437be8ed18ccd60"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "copyrightText": "NOASSERTION"
+    },
+    {
+      "fileName": "./vcpkg.json",
+      "SPDXID": "SPDXRef-file-1",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "4f8ddfeb9d3faa3ecf03f22a07678a060e353cde5e2b46be1cbe519993aab841"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "copyrightText": "NOASSERTION"
+    }
+  ]
+}


### PR DESCRIPTION
This PR contains an initial implementation of detecting SPDX files produced by vcpkg. This depends upon experimental features that are not yet released in the vcpkg tool.

<!-- Please complete this new detector checklist -->
#### New Detector Checklist

- [x] I have gone through the docs for creating a new detector [here](https://github.com/microsoft/component-detection/blob/main/docs/creating-a-new-detector.md)
- [x] My new detector implements `IDefaultOffComponentDetector`
- [ ] I have created a PR to the [verification repo](https://github.com/microsoft/componentdetection-verification) with components that my new detector can find
- [ ] (If necessary) I have updated the [Feature Overview](https://github.com/microsoft/component-detection/blob/main/README.md#feature-overview) table in the README
