### PR TITLE
Fix Pod detection for missing podspecs

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/cocoapods/PodComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/cocoapods/PodComponentDetector.cs
@@ -25,7 +25,7 @@ namespace Microsoft.ComponentDetection.Detectors.CocoaPods
 
         public override IEnumerable<ComponentType> SupportedComponentTypes { get; } = new[] { ComponentType.Pod, ComponentType.Git };
 
-        public override int Version { get; } = 1;
+        public override int Version { get; } = 2;
 
         private class Pod : IYamlConvertible
         {
@@ -300,10 +300,17 @@ namespace Microsoft.ComponentDetection.Detectors.CocoaPods
 
                 foreach (var dependency in pod.Value)
                 {
-                    var dependencyKey = podSpecs[dependency.Podspec];
-                    if (dependencyKey != pod.Key)
+                    if (podSpecs.TryGetValue(dependency.Podspec, out string dependencyKey))
                     {
-                        dependenciesMap[pod.Key].Add(podSpecs[dependency.Podspec]);
+                        if (dependencyKey != pod.Key)
+                        {
+                            var temp = podSpecs[dependency.Podspec];
+                            dependenciesMap[pod.Key].Add(podSpecs[dependency.Podspec]);
+                        }
+                    }
+                    else
+                    {
+                        Logger.LogWarning($"Missing podspec declaration. podspec={dependency.Podspec}, version={dependency.PodVersion}");
                     }
                 }
             }

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/PodDetectorTest.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/PodDetectorTest.cs
@@ -53,6 +53,8 @@ COCOAPODS: 1.4.0.beta.1";
     - AzureData (= 0.5.0)
   - KeychainAccess (3.2.1)
   - Willow (5.2.1)
+  - Auth (1.44.1):
+    - MissingDep (= 5.0.0)
 
 DEPENDENCIES:
   - AzureMobile (~> 0.5.0)
@@ -73,13 +75,14 @@ COCOAPODS: 0.39.0";
             Assert.AreEqual(ProcessingResultCode.Success, scanResult.ResultCode);
 
             var detectedComponents = componentRecorder.GetDetectedComponents();
-            Assert.AreEqual(5, detectedComponents.Count());
+            Assert.AreEqual(6, detectedComponents.Count());
 
             AssertPodComponentNameAndVersion(detectedComponents, "AzureCore", "0.5.0");
             AssertPodComponentNameAndVersion(detectedComponents, "AzureData", "0.5.0");
             AssertPodComponentNameAndVersion(detectedComponents, "AzureMobile", "0.5.0");
             AssertPodComponentNameAndVersion(detectedComponents, "KeychainAccess", "3.2.1");
             AssertPodComponentNameAndVersion(detectedComponents, "Willow", "5.2.1");
+            AssertPodComponentNameAndVersion(detectedComponents, "Auth", "1.44.1");
         }
 
         [TestMethod]


### PR DESCRIPTION
## Problem
Pod detection is throwing the following exception when a podspec is missing, even though we were able to capture the entire snapshot of dependencies.

`LogFailedReadingFile logged KeyNotFoundException: The given key 'X' was not present in the dictionary.`

## Solution
Log a warning and proceed capturing components.