### PR TITLE
Fix Pypi Dev version parsing

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/pip/IPyPiClient.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/IPyPiClient.cs
@@ -210,7 +210,7 @@ namespace Microsoft.ComponentDetection.Detectors.Pip
                 }
                 catch (ArgumentException ae)
                 {
-                    Logger.LogError($"Component {release.Key} : {JsonConvert.SerializeObject(release.Value)} could not be added to the sorted list of pip components. Error details follow:");
+                    Logger.LogError($"Component {release.Key} : {JsonConvert.SerializeObject(release.Value)} could not be added to the sorted list of pip components for spec={spec.Name}. Usually this happens with unexpected PyPi version formats (e.g. prerelease/dev versions). Error details follow:");
                     Logger.LogException(ae, true);
                     continue;
                 }

--- a/src/Microsoft.ComponentDetection.Detectors/pip/PipComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/PipComponentDetector.cs
@@ -21,7 +21,7 @@ namespace Microsoft.ComponentDetection.Detectors.Pip
 
         public override IEnumerable<ComponentType> SupportedComponentTypes { get; } = new[] { ComponentType.Pip };
 
-        public override int Version { get; } = 4;
+        public override int Version { get; } = 5;
 
         [Import]
         public IPythonCommandService PythonCommandService { get; set; }
@@ -68,7 +68,7 @@ namespace Microsoft.ComponentDetection.Detectors.Pip
                                 .Select(tuple => new DetectedComponent(tuple.Item2))
                                 .ToList()
                                 .ForEach(gitComponent => singleFileComponentRecorder.RegisterUsage(gitComponent, isExplicitReferencedDependency: true));
-}
+            }
             catch (Exception e)
             {
                 Logger.LogFailedReadingFile(file.Location, e);

--- a/src/Microsoft.ComponentDetection.Detectors/pip/PythonVersion.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/PythonVersion.cs
@@ -28,6 +28,8 @@ namespace Microsoft.ComponentDetection.Detectors.Pip
 
         public int? PostNumber { get; set; }
 
+        public string DevLabel { get; set; }
+
         public int? DevNumber { get; set; }
 
         public bool Floating { get; set; } = false;
@@ -79,6 +81,12 @@ namespace Microsoft.ComponentDetection.Detectors.Pip
             if (groups["post_n2"].Success && int.TryParse(groups["post_n2"].Value, out int postRelease2))
             {
                 PostNumber = postRelease2;
+            }
+
+            if (groups["dev_l"].Success)
+            {
+                DevLabel = groups["dev_l"].Value;
+                DevNumber = 0;
             }
 
             if (groups["dev_n"].Success && int.TryParse(groups["dev_n"].Value, out int devNumber))

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/PythonVersionTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/PythonVersionTests.cs
@@ -55,9 +55,6 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
 
             for (int i = 1; i < versions.Count; i++)
             {
-                var verA = versions[i - 1];
-                var verB = versions[i];
-                var temp = verA < verB;
                 Assert.IsTrue(versions[i - 1] < versions[i]);
             }
         }

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/PythonVersionTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/PythonVersionTests.cs
@@ -32,6 +32,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
             // This is a list of versions supplied by PEP440 for testing (minus local versions)
             var versions = new List<string>
             {
+                "1.0.dev",
                 "1.0.dev456",
                 "1.0a1",
                 "1.0a2.dev456",
@@ -41,16 +42,22 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
                 "1.0b2",
                 "1.0b2.post345.dev456",
                 "1.0b2.post345",
+                "1.0rc1.dev",
                 "1.0rc1.dev456",
                 "1.0rc1",
                 "1.0",
                 "1.0.post456.dev34",
                 "1.0.post456",
+                "1.1.dev",
                 "1.1.dev1",
+                "1.1",
             }.Select(x => new PythonVersion(x)).ToList();
 
             for (int i = 1; i < versions.Count; i++)
             {
+                var verA = versions[i - 1];
+                var verB = versions[i];
+                var temp = verA < verB;
                 Assert.IsTrue(versions[i - 1] < versions[i]);
             }
         }


### PR DESCRIPTION
## Problem
Our PipComponentDetector is having issues resolving for dev dependency versions that do not have any number as suffix, e.g. `0.5.7.dev`. This causes `IPyPiClient` to parse that version as if it were a release candidate `0.5.7` and consequently throws errors when adding it to dictionary, see line below: https://github.com/microsoft/component-detection/blob/6176381b4dfefe649cc51be95a5ead764e3e5721/src/Microsoft.ComponentDetection.Detectors/pip/IPyPiClient.cs#L213

## Steps to reproduce
1. Create a `requirements.txt` file
2. Add a dependency on `nltk==3.6.2`
3. Run de detector look at the failure caused by [ntlk -> joblib](https://github.com/nltk/nltk/blob/6797ee3958fe3fa0192d347b26ea0fc433b8bfc5/pip-req.txt#L14) version parsing.

## Solution
Add a new property that stores the `dev` label, and set the `devNumber` version to 0 to ensure we don't flag this package version as a "released".