### PR TITLE
refactor: use collection’s count property

### DIFF
--- a/src/Microsoft.ComponentDetection.Common/TabularStringFormat.cs
+++ b/src/Microsoft.ComponentDetection.Common/TabularStringFormat.cs
@@ -48,7 +48,7 @@ namespace Microsoft.ComponentDetection.Common
             foreach (var row in rows)
             {
                 sb.Append(verticalLineChar);
-                if (row.Count() != columns.Count)
+                if (row.Count != columns.Count)
                 {
                     throw new InvalidOperationException("All rows must have length equal to the number of columns present.");
                 }
@@ -71,7 +71,7 @@ namespace Microsoft.ComponentDetection.Common
             WriteFlatLine(sb, false);
             var tableWidth = columns.Sum(column => column.Width);
             sb.Append(verticalLineChar);
-            sb.Append(tableTitle.PadRight(tableWidth + columns.Count() - 1));
+            sb.Append(tableTitle.PadRight(tableWidth + columns.Count - 1));
             sb.Append(verticalLineChar);
 
             sb.AppendLine();

--- a/src/Microsoft.ComponentDetection.Detectors/linux/LinuxContainerDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/linux/LinuxContainerDetector.cs
@@ -243,7 +243,7 @@ namespace Microsoft.ComponentDetection.Detectors.Linux
         private bool ValidateBaseImageLayers(ContainerDetails scannedImageDetails, ContainerDetails baseImageDetails)
         {
             var scannedImageLayers = scannedImageDetails.Layers.ToArray();
-            return !(baseImageDetails.Layers.Count() > scannedImageLayers.Count() || baseImageDetails.Layers.Where((layer, index) => scannedImageLayers[index].DiffId != layer.DiffId).Any());
+            return !(baseImageDetails.Layers.Count() > scannedImageLayers.Length || baseImageDetails.Layers.Where((layer, index) => scannedImageLayers[index].DiffId != layer.DiffId).Any());
         }
     }
 }

--- a/src/Microsoft.ComponentDetection.Orchestrator/ArgumentHelper.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/ArgumentHelper.cs
@@ -43,7 +43,7 @@ namespace Microsoft.ComponentDetection.Orchestrator
             {
                 var keyValue = arg.Split('=');
 
-                if (keyValue.Count() != 2)
+                if (keyValue.Length != 2)
                 {
                     continue;
                 }

--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/DetectorProcessingService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/DetectorProcessingService.cs
@@ -233,7 +233,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Services
             {
                 var keyValue = arg.Split('=');
 
-                if (keyValue.Count() != 2)
+                if (keyValue.Length != 2)
                 {
                     continue;
                 }

--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/DetectorRegistryService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/DetectorRegistryService.cs
@@ -51,7 +51,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Services
             var loadedDetectors = LoadComponentDetectorsFromAssemblies(new List<Assembly> { assemblyToSearch }, extraDetectorAssemblies);
 
             var pluralPhrase = loadedDetectors.Count == 1 ? "detector was" : "detectors were";
-            Logger.LogInfo($"{loadedDetectors.Count()} {pluralPhrase} found in {assemblyToSearch.FullName}\n");
+            Logger.LogInfo($"{loadedDetectors.Count} {pluralPhrase} found in {assemblyToSearch.FullName}\n");
 
             return loadedDetectors;
         }
@@ -69,7 +69,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Services
                 var loadedDetectors = LoadComponentDetectorsFromAssemblies(new[] { assembly }, extraDetectorAssemblies);
 
                 var pluralPhrase = loadedDetectors.Count == 1 ? "detector was" : "detectors were";
-                Logger.LogInfo($"{loadedDetectors.Count()} {pluralPhrase} found in {assembly.GetName().Name}\n");
+                Logger.LogInfo($"{loadedDetectors.Count} {pluralPhrase} found in {assembly.GetName().Name}\n");
 
                 detectors.AddRange(loadedDetectors);
 
@@ -93,7 +93,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Services
                 var loadedDetectors = LoadComponentDetectorsFromAssemblies(assemblies, extraDetectorAssemblies);
 
                 var pluralPhrase = loadedDetectors.Count == 1 ? "detector was" : "detectors were";
-                Logger.LogInfo($"{loadedDetectors.Count()} {pluralPhrase} found in {searchPath}\n");
+                Logger.LogInfo($"{loadedDetectors.Count} {pluralPhrase} found in {searchPath}\n");
 
                 detectors.AddRange(loadedDetectors);
 

--- a/test/Microsoft.ComponentDetection.Common.Tests/ComponentStreamEnumerableTests.cs
+++ b/test/Microsoft.ComponentDetection.Common.Tests/ComponentStreamEnumerableTests.cs
@@ -76,7 +76,7 @@ namespace Microsoft.ComponentDetection.Common.Tests
                 },
             }, loggerMock.Object).ToList();
 
-            enumerable.Count()
+            enumerable.Count
                 .Should().Be(1);
 
             loggerMock.VerifyAll();

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/NuGetProjectModelProjectCentricComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/NuGetProjectModelProjectCentricComponentDetectorTests.cs
@@ -107,7 +107,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
             var ommittedComponentInformationJson = scanResult.AdditionalTelemetryDetails[NuGetProjectModelProjectCentricComponentDetector.OmittedFrameworkComponentsTelemetryKey];
             var omittedComponentsWithCount = JsonConvert.DeserializeObject<Dictionary<string, int>>(ommittedComponentInformationJson);
 
-            Assert.IsTrue(omittedComponentsWithCount.Keys.Count() > 5, "Ommitted framework assemblies are missing. There should be more than ten, but this is a gut check to make sure we have data.");
+            Assert.IsTrue(omittedComponentsWithCount.Keys.Count > 5, "Ommitted framework assemblies are missing. There should be more than ten, but this is a gut check to make sure we have data.");
             Assert.AreEqual(omittedComponentsWithCount["Microsoft.NETCore.App"], 4, "There should be four cases of the NETCore.App library being omitted in the test data.");
         }
 
@@ -134,7 +134,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
                 Assert.IsTrue(dependencies.Contains(expectedId));
             }
 
-            Assert.AreEqual(dependencies.Count(), expectedDependencyIdsForCompositionTypedParts.Count());
+            Assert.AreEqual(dependencies.Count(), expectedDependencyIdsForCompositionTypedParts.Length);
 
             Assert.AreEqual(graph.GetComponents().Count(), detectedComponents.Count());
 
@@ -225,7 +225,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
             var omittedComponentsWithCount = JsonConvert.DeserializeObject<Dictionary<string, int>>(ommittedComponentInformationJson);
 
             // With 3.X, we don't expect there to be a lot of these, but there are still netstandard libraries present which can bring things into the graph
-            Assert.AreEqual(omittedComponentsWithCount.Keys.Count(), 4, "Ommitted framework assemblies are missing. There should be more than ten, but this is a gut check to make sure we have data.");
+            Assert.AreEqual(omittedComponentsWithCount.Keys.Count, 4, "Ommitted framework assemblies are missing. There should be more than ten, but this is a gut check to make sure we have data.");
             Assert.AreEqual(omittedComponentsWithCount["System.Reflection"], 1, "There should be one case of the System.Reflection library being omitted in the test data.");
         }
 
@@ -294,7 +294,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
             
             var dependencyGraphs = componentRecorder.GetDependencyGraphsByLocation();
 
-            dependencyGraphs.Count().Should().Be(0);
+            dependencyGraphs.Count.Should().Be(0);
         }
 
         private string Convert22SampleToOSAgnostic(string project_assets)

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/PythonCommandServiceTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/PythonCommandServiceTests.cs
@@ -162,7 +162,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
                 var result = await service.ParseFile(testPath);
                 (string, GitComponent) expected = ("knack==0.4.1", null);
 
-                Assert.AreEqual(1, result.Count());
+                Assert.AreEqual(1, result.Count);
                 Assert.AreEqual(expected, result.First());
             }
             finally

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/YarnLockDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/YarnLockDetectorTests.cs
@@ -834,9 +834,9 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
             builder.Append(@"""dependencies"": {");
 
             var prodComponents = components.Where(c => !c.IsDevDependency).ToList();
-            for (var i = 0; i < prodComponents.Count(); i++)
+            for (var i = 0; i < prodComponents.Count; i++)
             {
-                if (i == prodComponents.Count() - 1)
+                if (i == prodComponents.Count - 1)
                 {
                     builder.Append($@"  ""{prodComponents[i].Name}"": ""{prodComponents[i].RequestedVersion}""");
                 }
@@ -855,9 +855,9 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
 
                 var dependencyComponents = components.Where(c => c.IsDevDependency).ToList();
 
-                for (var i = 0; i < dependencyComponents.Count(); i++)
+                for (var i = 0; i < dependencyComponents.Count; i++)
                 {
-                    if (i == dependencyComponents.Count() - 1)
+                    if (i == dependencyComponents.Count - 1)
                     {
                         builder.Append($@"  ""{dependencyComponents[i].Name}"": ""{dependencyComponents[i].RequestedVersion}""");
                     }

--- a/test/Microsoft.ComponentDetection.Orchestrator.Tests/GraphTranslationUtilityTests.cs
+++ b/test/Microsoft.ComponentDetection.Orchestrator.Tests/GraphTranslationUtilityTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Tests
 
             var convertedGraphContract = GraphTranslationUtility.AccumulateAndConvertToContract(dependencyGraphs);
 
-            convertedGraphContract.Count().Should().Be(2);
+            convertedGraphContract.Count.Should().Be(2);
             convertedGraphContract.Keys.Should().BeEquivalentTo(new List<string>() { "file1.json", "file2.json" });
 
             var graph1 = convertedGraphContract["file1.json"];

--- a/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/BcdeScanExecutionServiceTests.cs
+++ b/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/BcdeScanExecutionServiceTests.cs
@@ -246,7 +246,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Tests.Services
             var result = DetectComponentsHappyPath(args, restrictions => { }, new List<ComponentRecorder> { componentRecorder });
 
             result.Result.Should().Be(ProcessingResultCode.Success);
-            result.DependencyGraphs.Count().Should().Be(1);
+            result.DependencyGraphs.Count.Should().Be(1);
             var matchingGraph = result.DependencyGraphs.First();
             matchingGraph.Key.Should().Be(mockGraphLocation);
             var explicitlyReferencedComponents = matchingGraph.Value.ExplicitlyReferencedComponentIds;
@@ -255,7 +255,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Tests.Services
 
             var actualGraph = matchingGraph.Value.Graph;
             actualGraph.Keys.Count.Should().Be(2);
-            actualGraph[detectedComponents[0].Component.Id].Count().Should().Be(1);
+            actualGraph[detectedComponents[0].Component.Id].Count.Should().Be(1);
             actualGraph[detectedComponents[0].Component.Id].Should().Contain(detectedComponents[1].Component.Id);
             actualGraph[detectedComponents[1].Component.Id].Should().BeNull();
 
@@ -302,7 +302,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Tests.Services
             var result = DetectComponentsHappyPath(args, restrictions => { }, new List<ComponentRecorder> { componentRecorder });
 
             result.Result.Should().Be(ProcessingResultCode.Success);
-            result.DependencyGraphs.Count().Should().Be(1);
+            result.DependencyGraphs.Count.Should().Be(1);
             var matchingGraph = result.DependencyGraphs.First();
             matchingGraph.Key.Should().Be(mockGraphLocation);
             var explicitlyReferencedComponents = matchingGraph.Value.ExplicitlyReferencedComponentIds;
@@ -312,9 +312,9 @@ namespace Microsoft.ComponentDetection.Orchestrator.Tests.Services
 
             var actualGraph = matchingGraph.Value.Graph;
             actualGraph.Keys.Count.Should().Be(2);
-            actualGraph[detectedComponents[0].Component.Id].Count().Should().Be(1);
+            actualGraph[detectedComponents[0].Component.Id].Count.Should().Be(1);
             actualGraph[detectedComponents[0].Component.Id].Should().Contain(detectedComponents[1].Component.Id);
-            actualGraph[detectedComponents[1].Component.Id].Count().Should().Be(1);
+            actualGraph[detectedComponents[1].Component.Id].Count.Should().Be(1);
             actualGraph[detectedComponents[1].Component.Id].Should().Contain(detectedComponents[0].Component.Id);
         }
 
@@ -589,7 +589,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Tests.Services
             detectorRestrictionServiceMock.Setup(
                 x => x.ApplyRestrictions(
                     It.IsAny<DetectorRestrictions>(),
-                    It.Is<IEnumerable<IComponentDetector>>(inputDetectors => registeredDetectors.Intersect(inputDetectors).Count() == registeredDetectors.Count())))
+                    It.Is<IEnumerable<IComponentDetector>>(inputDetectors => registeredDetectors.Intersect(inputDetectors).Count() == registeredDetectors.Length)))
                 .Returns(restrictedDetectors)
                 .Callback<DetectorRestrictions, IEnumerable<IComponentDetector>>(
                     (restrictions, detectors) => restrictionAsserter?.Invoke(restrictions));
@@ -611,7 +611,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Tests.Services
             detectorProcessingServiceMock.Setup(x =>
                 x.ProcessDetectorsAsync(
                    args,
-                   It.Is<IEnumerable<IComponentDetector>>(inputDetectors => restrictedDetectors.Intersect(inputDetectors).Count() == restrictedDetectors.Count()),
+                   It.Is<IEnumerable<IComponentDetector>>(inputDetectors => restrictedDetectors.Intersect(inputDetectors).Count() == restrictedDetectors.Length),
                    Match.Create<DetectorRestrictions>(restriction => true)))
                 .ReturnsAsync(processingResult);
 
@@ -634,7 +634,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Tests.Services
             detectorRestrictionServiceMock.Setup(
                 x => x.ApplyRestrictions(
                     It.IsAny<DetectorRestrictions>(),
-                    It.Is<IEnumerable<IComponentDetector>>(inputDetectors => registeredDetectors.Intersect(inputDetectors).Count() == registeredDetectors.Count())))
+                    It.Is<IEnumerable<IComponentDetector>>(inputDetectors => registeredDetectors.Intersect(inputDetectors).Count() == registeredDetectors.Length)))
                 .Returns(restrictedDetectors);
 
             // We initialize detected component's DetectedBy here because of a Moq constraint -- certain operations (Adding interfaces) have to happen before .Object
@@ -654,7 +654,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Tests.Services
             detectorProcessingServiceMock.Setup(x =>
                 x.ProcessDetectorsAsync(
                    args,
-                   It.Is<IEnumerable<IComponentDetector>>(inputDetectors => restrictedDetectors.Intersect(inputDetectors).Count() == restrictedDetectors.Count()),
+                   It.Is<IEnumerable<IComponentDetector>>(inputDetectors => restrictedDetectors.Intersect(inputDetectors).Count() == restrictedDetectors.Length),
                    Match.Create<DetectorRestrictions>(restriction => true)))
                 .ReturnsAsync(processingResult);
 


### PR DESCRIPTION
`Count()` is a LINQ extension method, whereas `Count` is a property of the collection.

See: https://stackoverflow.com/questions/4098186/lists-count-vs-count