### PR TITLE
Handle duplicate DiffId docker image layers

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/linux/LinuxContainerDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/linux/LinuxContainerDetector.cs
@@ -111,6 +111,7 @@ namespace Microsoft.ComponentDetection.Detectors.Linux
                     }
                     catch (Exception e)
                     {
+                        Logger.LogWarning($"Processing of image {image} failed with exception: {e.Message}");
                         using var record = new LinuxContainerDetectorImageDetectionFailed
                         {
                             ExceptionType = e.GetType().ToString(),
@@ -153,6 +154,7 @@ namespace Microsoft.ComponentDetection.Detectors.Linux
                 }
                 catch (Exception e)
                 {
+                    Logger.LogWarning($"Scanning of image {kvp.Key} failed with exception: {e.Message}");
                     using var record = new LinuxContainerDetectorImageDetectionFailed
                     {
                         ExceptionType = e.GetType().ToString(),

--- a/src/Microsoft.ComponentDetection.Detectors/linux/LinuxScanner.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/linux/LinuxScanner.cs
@@ -90,10 +90,12 @@ namespace Microsoft.ComponentDetection.Detectors.Linux
                     $"Scan failed with exit info: {stdout}{Environment.NewLine}{stderr}");
             }
 
-            var layerDictionary = dockerLayers.ToDictionary(
-                layer => layer.DiffId,
-                layer => new List<LinuxComponent>());
-           
+            var layerDictionary = dockerLayers
+                .DistinctBy(layer => layer.DiffId)
+                .ToDictionary(
+                    layer => layer.DiffId,
+                    _ => new List<LinuxComponent>());
+
             try
             {
                 var syftOutput = JsonConvert.DeserializeObject<SyftOutput>(stdout);


### PR DESCRIPTION
When Docker layers are empty there is a possibility that the digest ID is constant between layer indexes. Previously that would cause an exception in the `.ToDictionary` call in LinuxScanner.cs where it expects unique keys.