### PR TITLE
Move from PackageUrl package to packageurl-dotnet

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,7 +26,7 @@
         <PackageVersion Include="Newtonsoft.Json" Version="13.0.1"/>
         <PackageVersion Include="NuGet.ProjectModel" Version="5.6.0"/>
         <PackageVersion Include="NuGet.Versioning" Version="5.6.0"/>
-        <PackageVersion Include="PackageUrl" Version="1.0.0"/>
+        <PackageVersion Include="packageurl-dotnet" Version="1.0.0"/>
         <PackageVersion Include="Polly" Version="7.2.2"/>
         <PackageVersion Include="Semver" Version="2.0.6"/>
         <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118"/>

--- a/src/Microsoft.ComponentDetection.Contracts/Microsoft.ComponentDetection.Contracts.csproj
+++ b/src/Microsoft.ComponentDetection.Contracts/Microsoft.ComponentDetection.Contracts.csproj
@@ -6,7 +6,7 @@
 
     <ItemGroup>
         <PackageReference Include="Newtonsoft.Json"/>
-        <PackageReference Include="PackageUrl"/>
+        <PackageReference Include="packageurl-dotnet"/>
         <PackageReference Include="System.Composition.AttributedModel"/>
         <PackageReference Include="System.Memory"/>
         <PackageReference Include="System.Reactive"/>

--- a/test/Microsoft.ComponentDetection.Contracts.Tests/Microsoft.ComponentDetection.Contracts.Tests.csproj
+++ b/test/Microsoft.ComponentDetection.Contracts.Tests/Microsoft.ComponentDetection.Contracts.Tests.csproj
@@ -14,7 +14,7 @@
 
     <ItemGroup>
         <PackageReference Include="System.Reactive"/>
-        <PackageReference Include="PackageUrl"/>
+        <PackageReference Include="packageurl-dotnet"/>
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This package was renamed as part of reviving the underlying repo.

See: https://github.com/package-url/packageurl-dotnet/pull/10 and https://github.com/package-url/packageurl-dotnet/pull/13