### PR TITLE
Support case-insensitive on non-Windows OSs.

### DIFF
--- a/src/Microsoft.ComponentDetection.Common/EnvironmentVariableService.cs
+++ b/src/Microsoft.ComponentDetection.Common/EnvironmentVariableService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Composition;
 using Microsoft.ComponentDetection.Contracts;
 
@@ -9,8 +10,12 @@ namespace Microsoft.ComponentDetection.Common
     {
         public bool DoesEnvironmentVariableExist(string name)
         {
-            var enabledVar = Environment.GetEnvironmentVariable(name);
-            return !string.IsNullOrEmpty(enabledVar);
+            // Environment variables are case-insensitive on Windows, and case-sensitive on
+            // Linux and MacOS.
+            // https://docs.microsoft.com/en-us/dotnet/api/system.environment.getenvironmentvariable
+            return Environment.GetEnvironmentVariables().Keys
+                .OfType<string>()
+                .FirstOrDefault(x => string.Compare(x, name, true) == 0) != null;
         }
     }
 }

--- a/src/Microsoft.ComponentDetection.Detectors/go/GoComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/go/GoComponentDetector.cs
@@ -33,7 +33,7 @@ namespace Microsoft.ComponentDetection.Detectors.Go
 
         public override IEnumerable<ComponentType> SupportedComponentTypes { get; } = new[] { ComponentType.Go };
 
-        public override int Version => 2;
+        public override int Version => 3;
 
         private HashSet<string> projectRoots = new HashSet<string>();
 

--- a/test/Microsoft.ComponentDetection.Common.Tests/EnvironmentVariableServiceTests.cs
+++ b/test/Microsoft.ComponentDetection.Common.Tests/EnvironmentVariableServiceTests.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.ComponentDetection.Common;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using System;
+
+namespace Microsoft.ComponentDetection.Common.Tests
+{
+    [TestClass]
+    public class EnvironmentVariableServiceTests
+    {
+        public const string MyEnvVar = nameof(MyEnvVar);
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            Environment.SetEnvironmentVariable(EnvironmentVariableServiceTests.MyEnvVar, "true");
+        }
+
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            Environment.SetEnvironmentVariable(EnvironmentVariableServiceTests.MyEnvVar, null);
+        }
+
+        [TestMethod]
+        public void EnvironmentVariableService_ChecksAreCaseInsensitive()
+        {
+            var testSubject = new EnvironmentVariableService();
+
+            Assert.IsFalse(testSubject.DoesEnvironmentVariableExist("THIS_ENVIRONMENT_VARIABLE_DOES_NOT_EXIST"));
+
+            Assert.IsTrue(testSubject.DoesEnvironmentVariableExist(MyEnvVar));
+            Assert.IsTrue(testSubject.DoesEnvironmentVariableExist(MyEnvVar.ToLower()));
+            Assert.IsTrue(testSubject.DoesEnvironmentVariableExist(MyEnvVar.ToUpper()));
+        }
+    }
+}


### PR DESCRIPTION
The environment variable EnableGoCliScan existence gates usage of the Go
CLI tools for determing what modules are in-use.  The current check does
a get of the environment variable, and if it exists behavior is enabled.
On Windows this is case-insensitive, but on Linux (or MacOS) this is
case-sensitive so the user must exactly use the casing of
'EnableGoCliScan'.

Our CI system automatically capitalizes all environment variables when
they are defined, so EnableGoCliScan becomes ENABLEGOCLISCAN.  I am not
aware of a way to control this behavior, so there is no way to enable Go
CLI tooling.  My fix is to treat all environment variable exitence
checks as case-insensitive.