### PR TITLE
Bump to net6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,10 +22,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup .NET
+      - name: Setup .NET 6
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.x
+          dotnet-version: 6.0.x
 
       - name: Restore packages
         run: dotnet restore

--- a/.github/workflows/gen-docs.yml
+++ b/.github/workflows/gen-docs.yml
@@ -15,10 +15,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup .NET Core
+      - name: Setup .NET 6
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.x
+          dotnet-version: 6.0.x
 
       - name: Generate docs
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,10 +27,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup .NET
+      - name: Setup .NET 6
         uses: actions/setup-dotnet@v1.9.0
         with:
-          dotnet-version: 3.1.x
+          dotnet-version: 6.0.x
 
       - name: Restore packages
         run: dotnet restore

--- a/.github/workflows/snapshot-publish.yml
+++ b/.github/workflows/snapshot-publish.yml
@@ -16,10 +16,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2.4.0
 
-      - name: Setup .NET Core
+      - name: Setup .NET 6
         uses: actions/setup-dotnet@v1.9.0
         with:
-          dotnet-version: 3.1.x
+          dotnet-version: 6.0.x
 
       - run: dotnet restore
 

--- a/.github/workflows/snapshot-verify.yml
+++ b/.github/workflows/snapshot-verify.yml
@@ -46,10 +46,10 @@ jobs:
           unzip output.zip
           rm output.zip
 
-      - name: Setup .NET Core
+      - name: Setup .NET 6
         uses: actions/setup-dotnet@v1.9.0
         with:
-          dotnet-version: 3.1.x
+          dotnet-version: 6.0.x
 
       - run: dotnet restore
 

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -15,10 +15,10 @@ jobs:
       with:
           fetch-depth: 0
 
-    - name: Setup .NET Core
+    - name: Setup .NET 6
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.x
+        dotnet-version: 6.0.x
 
     - name: dotnet restore
       run: dotnet restore

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
     <PropertyGroup Label="Build">
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6</TargetFramework>
         <LangVersion>latest</LangVersion>
         <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
         <TreatWarningsAsErrors Condition="'$(OFFICIAL_BUILD)' == 'True'">true</TreatWarningsAsErrors>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,7 +19,6 @@
         <PackageVersion Include="DotNet.Glob" Version="2.1.1"/>
         <PackageVersion Include="MinVer" Version="2.5.0"/>
         <PackageVersion Include="Moq" Version="4.16.1"/>
-        <PackageVersion Include="morelinq" Version="3.3.2"/>
         <PackageVersion Include="MSTest.TestAdapter" Version="2.2.3"/>
         <PackageVersion Include="MSTest.TestFramework" Version="2.2.3"/>
         <PackageVersion Include="Nett" Version="0.15.0"/>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
 	"sdk": {
-		"version": "3.1.300",
+		"version": "6.0.200",
 		"rollForward": "latestMinor"
 	}
 }

--- a/src/Microsoft.ComponentDetection.Detectors/Microsoft.ComponentDetection.Detectors.csproj
+++ b/src/Microsoft.ComponentDetection.Detectors/Microsoft.ComponentDetection.Detectors.csproj
@@ -2,7 +2,6 @@
 
     <ItemGroup>
         <PackageReference Include="DotNet.Glob" />
-        <PackageReference Include="morelinq" />
         <PackageReference Include="Nett" />
         <PackageReference Include="NuGet.ProjectModel" />
         <PackageReference Include="NuGet.Versioning" />

--- a/src/Microsoft.ComponentDetection.Detectors/linux/LinuxScanner.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/linux/LinuxScanner.cs
@@ -9,7 +9,6 @@ using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Contracts.BcdeModels;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.ComponentDetection.Detectors.Linux.Contracts;
-using MoreLinq.Extensions;
 using Newtonsoft.Json;
 
 namespace Microsoft.ComponentDetection.Detectors.Linux


### PR DESCRIPTION
Bump to .NET 6 and remove morelinq dependency, as `DistinctBy` is now natively supported by `Sytem.Linq`.