### PR TITLE
fix: log a warning when duplicate components are found in a yarn.lock

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/yarn/YarnLockComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/yarn/YarnLockComponentDetector.cs
@@ -69,7 +69,12 @@ namespace Microsoft.ComponentDetection.Detectors.Yarn
             {
                 foreach (var satisfiedVersion in entry.Satisfied)
                 {
-                    yarnPackages.Add($"{entry.Name}@{satisfiedVersion}", entry);
+                    var key = $"{entry.Name}@{satisfiedVersion}";
+                    var addSuccessful = yarnPackages.TryAdd(key, entry);
+                    if (!addSuccessful)
+                    {
+                        Logger.LogWarning($"Found duplicate entry {key} in {location}");
+                    }
                 }
             }
 

--- a/src/Microsoft.ComponentDetection.Detectors/yarn/YarnLockComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/yarn/YarnLockComponentDetector.cs
@@ -22,7 +22,7 @@ namespace Microsoft.ComponentDetection.Detectors.Yarn
 
         public override IEnumerable<ComponentType> SupportedComponentTypes { get; } = new[] { ComponentType.Npm };
 
-        public override int Version { get; } = 5;
+        public override int Version => 6;
 
         public override IEnumerable<string> Categories => new[] { Enum.GetName(typeof(DetectorClass), DetectorClass.Npm) };
 

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/YarnLockDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/YarnLockDetectorTests.cs
@@ -825,6 +825,38 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
             dependencyGraph.GetDependenciesForComponent(componentCId).Should().HaveCount(0);
         }
 
+        [TestMethod]
+        public async Task MalformedYarnLockV1_Duplicate()
+        {
+            const string componentNameA = "lodash-shim";
+            const string requestedVersionA = "file:lodash-shim";
+            const string componentNameB = "lodash";
+            const string requestedVersionB = "file:lodash-shim";
+            const string actualVersion = "2.4.2";
+            
+            var builder = new StringBuilder();
+
+            builder.AppendLine(CreateYarnLockV2FileContent(new List<YarnTestComponentDefinition>()));
+            builder.AppendLine($"\"{componentNameA}@{requestedVersionA}\", \"{componentNameB}@{requestedVersionB}\":");
+            builder.AppendLine($"  version: {actualVersion}");
+            builder.AppendLine();
+
+            var yarnLockFileContent = builder.ToString();
+            var packageJsonFileContent = CreatePackageJsonFileContent(new List<YarnTestComponentDefinition>());
+            
+            var (scanResult, componentRecorder) = await detectorTestUtility
+                .WithFile("yarn.lock", yarnLockFileContent)
+                .WithFile("package.json", packageJsonFileContent, new List<string> { "package.json" })
+                .ExecuteDetector();
+            
+            scanResult.ResultCode.Should().Be(ProcessingResultCode.Success);
+            
+            var detectedComponents = componentRecorder.GetDetectedComponents();
+
+            detectedComponents.Should().HaveCount(1);
+            var detectedComponent = detectedComponents.First();
+        }
+
         private string CreatePackageJsonFileContent(IList<YarnTestComponentDefinition> components)
         {
             var builder = new StringBuilder();


### PR DESCRIPTION
It's possible, but rare, for yarn dependencies in the same block to have different names. This is a partial fix for #68, but more investigation may be required.