### PR TITLE
Adding NuGet package target frameworks to component detection data.

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,6 +26,7 @@
         <PackageVersion Include="Newtonsoft.Json" Version="13.0.1"/>
         <PackageVersion Include="NuGet.ProjectModel" Version="5.6.0"/>
         <PackageVersion Include="NuGet.Versioning" Version="5.6.0"/>
+        <PackageVersion Include="NuGet.Packaging" Version="5.6.0"/>
         <PackageVersion Include="packageurl-dotnet" Version="1.0.0"/>
         <PackageVersion Include="Polly" Version="7.2.2"/>
         <PackageVersion Include="Semver" Version="2.0.6"/>

--- a/src/Microsoft.ComponentDetection.Contracts/TypedComponent/NugetComponent.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/TypedComponent/NugetComponent.cs
@@ -9,11 +9,12 @@ namespace Microsoft.ComponentDetection.Contracts.TypedComponent
             /* Reserved for deserialization */
         }
 
-        public NuGetComponent(string name, string version, string[] authors = null)
+        public NuGetComponent(string name, string version, string[] authors = null, string[] targetFrameworks = null)
         {
             Name = ValidateRequiredInput(name, nameof(Name), nameof(ComponentType.NuGet));
             Version = ValidateRequiredInput(version, nameof(Version), nameof(ComponentType.NuGet));
             Authors = authors;
+            TargetFrameworks = targetFrameworks;
         }
 
         public string Name { get; set; }
@@ -21,6 +22,8 @@ namespace Microsoft.ComponentDetection.Contracts.TypedComponent
         public string Version { get; set; }
 
         public string[] Authors { get; set; }
+
+        public string[] TargetFrameworks { get; set; }
 
         public override ComponentType Type => ComponentType.NuGet;
 

--- a/src/Microsoft.ComponentDetection.Detectors/nuget/NuGetNuspecUtilities.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/nuget/NuGetNuspecUtilities.cs
@@ -1,8 +1,14 @@
-﻿using System;
+﻿using Microsoft.ComponentDetection.Contracts;
+using NuGet.Frameworks;
+using NuGet.Packaging;
+using System;
+using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Runtime.Versioning;
 using System.Threading.Tasks;
+using System.Xml;
 
 namespace Microsoft.ComponentDetection.Detectors.NuGet
 {
@@ -12,31 +18,76 @@ namespace Microsoft.ComponentDetection.Detectors.NuGet
         // source: https://en.wikipedia.org/wiki/Zip_(file_format)#Limits
         public const int MinimumLengthForZipArchive = 22;
 
-        public static async Task<byte[]> GetNuspecBytesAsync(Stream nupkgStream)
+        public static (string name, string version, string[] authors, HashSet<string> targetFrameworks) GetNuGetPackageDataFromNupkg(IComponentStream nupkgComponentStream)
         {
             try
             {
-                if (nupkgStream.Length < MinimumLengthForZipArchive)
+                if (nupkgComponentStream.Stream.Length < MinimumLengthForZipArchive)
                 {
                     throw new ArgumentException("nupkg is too small");
                 }
 
-                using var archive = new ZipArchive(nupkgStream, ZipArchiveMode.Read, true);
+                string packageName = null;
+                string packageVersion = null;
+                string[] authors = null;
+                HashSet<string> targetFrameworks = null;
 
-                // get the first entry ending in .nuspec at the root of the package
-                ZipArchiveEntry nuspecEntry =
-                    archive.Entries.FirstOrDefault(x =>
-                        x.Name.EndsWith(".nuspec", StringComparison.OrdinalIgnoreCase)
-                        && x.FullName.IndexOf('/') == -1);
+                using var archive = new ZipArchive(nupkgComponentStream.Stream, ZipArchiveMode.Read, true);
+                bool nuspecFound = false;
+                foreach (var entry in archive.Entries)
+                {
+                    if (entry.Name.EndsWith(".nuspec", StringComparison.CurrentCulture) && entry.FullName.IndexOf('/') == -1)
+                    {
+                        //if we've already found an entry that matches this condition, ignore it.
+                        //this matches the semantics of previous use of .FirstOrDefault()
+                        if (nuspecFound)
+                        {
+                            continue;
+                        }
 
-                if (nuspecEntry == null)
+                        //note that we've found the nuspec
+                        nuspecFound = true;
+
+                        //this is the nuspec file, process it to get the data we need
+                        var nuSpecStream = entry.Open();
+                        (packageName, packageVersion, authors, var nuspecFrameworks) = GetNuspecDataFromNuspecStream(nuSpecStream);
+
+                        //add any frameworks found in the nuspec
+                        if (targetFrameworks is null)
+                        {
+                            //It should be common to come across the .nuspec before processing other entries,
+                            //so opportunistically use the hashset we just got
+                            targetFrameworks = nuspecFrameworks;
+                        }
+                        else
+                        {
+                            //add the frameworks to what we already had
+                            targetFrameworks.AddRange(nuspecFrameworks);
+                        }
+                    }
+                    else
+                    {
+                        //process any other entries to get framework names according to the rules of NuGet
+                        FrameworkName frameworkName = FrameworkNameUtility.ParseFrameworkNameFromFilePath(entry.FullName, out _);
+                        if (frameworkName is not null)
+                        {
+                            if (targetFrameworks is null)
+                            {
+                                targetFrameworks = new HashSet<string>();
+                            }
+
+                            targetFrameworks.Add(frameworkName.FullName);
+                        }
+                    }
+                }
+
+                if (!nuspecFound)
                 {
                     throw new FileNotFoundException("No nuspec file was found");
                 }
 
-                using var nuspecStream = nuspecEntry.Open();
-
-                return await GetNuspecBytesFromNuspecStream(nuspecStream, nuspecEntry.Length);
+                //TODO: what if we couldn't find the data in nuspec, or some other error. Need to match previous behavior
+                return (packageName, packageVersion, authors, targetFrameworks);
             }
             catch (InvalidDataException ex)
             {
@@ -45,20 +96,68 @@ namespace Microsoft.ComponentDetection.Detectors.NuGet
             finally
             {
                 // make sure that no matter what we put the stream back to the beginning
-                nupkgStream.Seek(0, SeekOrigin.Begin);
+                nupkgComponentStream.Stream.Seek(0, SeekOrigin.Begin);
             }
         }
 
-        public static async Task<byte[]> GetNuspecBytesFromNuspecStream(Stream nuspecStream, long nuspecLength)
+        public static (string name, string version, string[] authors, HashSet<string> targetFrameworks) GetNuspecDataFromNuspecStream(Stream sourceStream)
         {
-            byte[] nuspecBytes = new byte[nuspecLength];
-            int bytesReadSoFar = 0;
-            while (bytesReadSoFar < nuspecBytes.Length)
+            //The stream we get here may not support the operations we need
+            //copy it to a more flexible MemoryStream
+            //TODO: detect whether this is necessary
+            using MemoryStream nuspecStream = new MemoryStream();
+            sourceStream.CopyTo(nuspecStream);
+            nuspecStream.Position = 0;
+
+            if (nuspecStream.Length == 0)
             {
-                bytesReadSoFar += await nuspecStream.ReadAsync(nuspecBytes, bytesReadSoFar, nuspecBytes.Length - bytesReadSoFar);
+                throw new ArgumentException("The provided stream was empty.", nameof(sourceStream));
             }
 
-            return nuspecBytes;
+            NuspecReader reader = new NuspecReader(nuspecStream);
+
+            string[] authors = reader.GetAuthors().Split(",").Select(author => author.Trim()).ToArray();
+
+            HashSet<string> targetFrameworks = new HashSet<string>();
+
+            foreach (var dependencyGroup in reader.GetDependencyGroups())
+            {
+                if (dependencyGroup.TargetFramework is not null)
+                {
+                    targetFrameworks.Add(dependencyGroup.TargetFramework.DotNetFrameworkName);
+                }
+            }
+
+            return (reader.GetId(), reader.GetVersion().OriginalVersion, authors, targetFrameworks);
+        }
+
+        public static (string name, string version, string[] authors, HashSet<string> targetFrameworks) GetNuGetPackageDataFromNuspec(IComponentStream nuspecComponentStream)
+        {
+            var (name, version, authors, targetFrameworks) = GetNuspecDataFromNuspecStream(nuspecComponentStream.Stream);
+
+            //since we found a loose .nuspec file, attempt to interpret the surrounding directory as an unzipped NuGet package
+            var unzippedPackageLocation = Path.GetFullPath(Path.GetDirectoryName(nuspecComponentStream.Location)) + "\\";
+            foreach (var path in Directory.EnumerateFiles(unzippedPackageLocation, "*", new EnumerationOptions { RecurseSubdirectories = true }))
+            {
+                //Ignore any paths that somehow don't start with the unzipped location.
+                //This will make the operation below safe
+                if (!path.StartsWith(unzippedPackageLocation, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                //get relative path
+                string relativePath = path.Substring(unzippedPackageLocation.Length);
+
+                //process this according to the rules of packages
+                FrameworkName frameworkName = FrameworkNameUtility.ParseFrameworkNameFromFilePath(relativePath, out _);
+                if (frameworkName is not null)
+                {
+                    targetFrameworks.Add(frameworkName.FullName);
+                }
+            }
+
+            return (name, version, authors, targetFrameworks);
         }
     }
 }

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/NuGetComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/NuGetComponentDetectorTests.cs
@@ -45,7 +45,9 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
             var testComponentName = "TestComponentName";
             var testVersion = "1.2.3";
             var testAuthors = new string[] { "author 1", "author 2" };
-            var nuspec = NugetTestUtilities.GetValidNuspec(testComponentName, testVersion, testAuthors);
+            var testTargetFrameworks = new string[] { "net48", "net472", "netstandard2.1" };
+            var testTargetFrameworksConverted = new string[] { ".NETFramework,Version=v4.8", ".NETFramework,Version=v4.7.2", ".NETStandard,Version=v2.1" };
+            var nuspec = NugetTestUtilities.GetValidNuspec(testComponentName, testVersion, testAuthors, testTargetFrameworks);
 
             var (scanResult, componentRecorder) = await detectorTestUtility
                                                     .WithFile("*.nuspec", nuspec)
@@ -59,6 +61,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
             Assert.AreEqual(testComponentName, nuGetComponent.Name, "Component name does not match.");
             Assert.AreEqual(testVersion, nuGetComponent.Version, "Component version does not match.");
             CollectionAssert.AreEqual(testAuthors, nuGetComponent.Authors, "Authors does not match.");
+            CollectionAssert.AreEqual(testTargetFrameworksConverted, nuGetComponent.TargetFrameworks, "TargetFrameworks does not match.");
         }
 
         [TestMethod]


### PR DESCRIPTION
Per a conversation about adding target framework information to the component detection data, this is a PR that shows what that could look like.

Things get slightly tricky here since packages declare target frameworks through the dependency declarations in the nuspec, as well as the folder structure of the package. This hasn't been through much testing beyond the unit tests, but they've been augmented to test some potential patterns.

I mainly want to get some feedback on this before I spend much more time on testing. I can potentially test this against all NuGet.org packages pretty easily, which also gives us a test oracle since they calculate target frameworks as well.

Things that might need consideration:
* Addition of NuGet.Packaging as a dependency
* how the data is plumbed through the NuGetComponent (I followed the Authors example as an array of additional strings)
* Removal of async from ProcessFile (nothing in there was async when I finished)
* Shifting more responsibility to NuGetNuspecUtilities even through it's not strictly nuspec-related anymore.
* Using the nuspec reader rather than bespoke XML parsing

I'm open to any and all feedback here.