### PR TITLE
Migrate IPyPiClient cache to LRU MemoryCache

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,6 +14,7 @@
         <PackageVersion Include="FluentAssertions" Version="6.1.0"/>
         <PackageVersion Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7"/>
         <PackageVersion Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0"/>
+        <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.9.4"/>
         <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0"/>
         <PackageVersion Include="DotNet.Glob" Version="2.1.1"/>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,7 @@
         <PackageVersion Include="FluentAssertions" Version="6.1.0"/>
         <PackageVersion Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7"/>
         <PackageVersion Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0"/>
-        <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
+        <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="3.1.23" />
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.9.4"/>
         <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0"/>
         <PackageVersion Include="DotNet.Glob" Version="2.1.1"/>

--- a/src/Microsoft.ComponentDetection.Common/EnvironmentVariableService.cs
+++ b/src/Microsoft.ComponentDetection.Common/EnvironmentVariableService.cs
@@ -10,12 +10,7 @@ namespace Microsoft.ComponentDetection.Common
     {
         public bool DoesEnvironmentVariableExist(string name)
         {
-            // Environment variables are case-insensitive on Windows, and case-sensitive on
-            // Linux and MacOS.
-            // https://docs.microsoft.com/en-us/dotnet/api/system.environment.getenvironmentvariable
-            return Environment.GetEnvironmentVariables().Keys
-                .OfType<string>()
-                .FirstOrDefault(x => string.Compare(x, name, true) == 0) != null;
+            return GetEnvironmentVariable(name) != null;
         }
 
         public string GetEnvironmentVariable(string name)

--- a/src/Microsoft.ComponentDetection.Common/EnvironmentVariableService.cs
+++ b/src/Microsoft.ComponentDetection.Common/EnvironmentVariableService.cs
@@ -17,5 +17,17 @@ namespace Microsoft.ComponentDetection.Common
                 .OfType<string>()
                 .FirstOrDefault(x => string.Compare(x, name, true) == 0) != null;
         }
+
+        public string GetEnvironmentVariable(string name)
+        {
+            // Environment variables are case-insensitive on Windows, and case-sensitive on
+            // Linux and MacOS.
+            // https://docs.microsoft.com/en-us/dotnet/api/system.environment.getenvironmentvariable
+            var caseInsensitiveName = Environment.GetEnvironmentVariables().Keys
+                .OfType<string>()
+                .FirstOrDefault(x => string.Compare(x, name, true) == 0);
+
+            return caseInsensitiveName != null ? Environment.GetEnvironmentVariable(caseInsensitiveName) : null;
+        }
     }
 }

--- a/src/Microsoft.ComponentDetection.Common/Telemetry/Records/PyPiCacheTelemetryRecord.cs
+++ b/src/Microsoft.ComponentDetection.Common/Telemetry/Records/PyPiCacheTelemetryRecord.cs
@@ -1,0 +1,19 @@
+﻿using System.Net;
+
+namespace Microsoft.ComponentDetection.Common.Telemetry.Records
+{
+    public class PypiCacheTelemetryRecord : BaseDetectionTelemetryRecord
+    {
+        public override string RecordName => "PyPiCache";
+
+        /// <summary>
+        /// Total number of PyPi requests that hit the cache instead of PyPi APIs
+        /// </summary>
+        public int NumCacheHits { get; set; }
+
+        /// <summary>
+        /// Size of the PyPi cache at class destruction
+        /// </summary>
+        public int FinalCacheSize { get; set; }
+    }
+}

--- a/src/Microsoft.ComponentDetection.Common/Telemetry/Records/PyPiCacheTelemetryRecord.cs
+++ b/src/Microsoft.ComponentDetection.Common/Telemetry/Records/PyPiCacheTelemetryRecord.cs
@@ -7,12 +7,12 @@ namespace Microsoft.ComponentDetection.Common.Telemetry.Records
         public override string RecordName => "PyPiCache";
 
         /// <summary>
-        /// Total number of PyPi requests that hit the cache instead of PyPi APIs
+        /// Gets or sets total number of PyPi requests that hit the cache instead of PyPi APIs.
         /// </summary>
         public int NumCacheHits { get; set; }
 
         /// <summary>
-        /// Size of the PyPi cache at class destruction
+        /// Gets or sets the size of the PyPi cache at class destruction.
         /// </summary>
         public int FinalCacheSize { get; set; }
     }

--- a/src/Microsoft.ComponentDetection.Contracts/IEnvironmentVariableService.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/IEnvironmentVariableService.cs
@@ -3,5 +3,7 @@ namespace Microsoft.ComponentDetection.Contracts
     public interface IEnvironmentVariableService
     {
         bool DoesEnvironmentVariableExist(string name);
+
+        string GetEnvironmentVariable(string name);
     }
 }

--- a/src/Microsoft.ComponentDetection.Detectors/Microsoft.ComponentDetection.Detectors.csproj
+++ b/src/Microsoft.ComponentDetection.Detectors/Microsoft.ComponentDetection.Detectors.csproj
@@ -9,6 +9,7 @@
         <PackageReference Include="Polly" />
         <PackageReference Include="Semver" />
         <PackageReference Include="yamldotnet" />
+        <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
         <PackageReference Include="Newtonsoft.Json" />
         <PackageReference Include="System.Composition.AttributedModel" />
         <PackageReference Include="System.Composition.Convention" />

--- a/src/Microsoft.ComponentDetection.Detectors/pip/IPyPiClient.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/IPyPiClient.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Composition;
 using System.IO;
@@ -11,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.ComponentDetection.Common.Telemetry.Records;
 using Microsoft.ComponentDetection.Contracts;
+using Microsoft.Extensions.Caching.Memory;
 using Newtonsoft.Json;
 using Polly;
 
@@ -31,9 +31,17 @@ namespace Microsoft.ComponentDetection.Detectors.Pip
         [Import]
         public ILogger Logger { get; set; }
 
+        [Import]
+        public IEnvironmentVariableService EnvironmentVariableService { get; set; }
+
         private static HttpClientHandler httpClientHandler = new HttpClientHandler() { CheckCertificateRevocationList = true };
 
         internal static HttpClient HttpClient = new HttpClient(httpClientHandler);
+
+        // Values used for cache creation
+        private const long CACHEINTERVALSECONDS = 60;
+        private const long DEFAULTCACHEENTRIES = 128;
+        private bool checkedMaxEntriesVariable = false;
 
         // time to wait before retrying a failed call to pypi.org
         private static readonly TimeSpan RETRYDELAY = TimeSpan.FromSeconds(1);
@@ -45,21 +53,23 @@ namespace Microsoft.ComponentDetection.Detectors.Pip
         private long retries = 0;
 
         /// <summary>
-        /// This cache is used mostly for consistency, to create a unified view of Pypi response.
+        /// A thread safe cache implementation which contains a mapping of URI -> HttpResponseMessage
+        /// and has a limited number of entries which will expire after the cache fills or a specified interval.
         /// </summary>
-        private readonly ConcurrentDictionary<string, Task<HttpResponseMessage>> cachedResponses = new ConcurrentDictionary<string, Task<HttpResponseMessage>>();
+        private MemoryCache cachedResponses = new MemoryCache(new MemoryCacheOptions { SizeLimit = DEFAULTCACHEENTRIES });
 
         /// <summary>
-        /// Returns a cached response if it exists, otherwise returns the response from Pypi REST call.
-        /// The response from Pypi is not automatically added to the cache, to allow caller to make that decision.
+        /// Returns a cached response if it exists, otherwise returns the response from PyPi REST call.
+        /// The response from PyPi is not automatically added to the cache, to allow caller to make that decision.
         /// </summary>
         /// <param name="uri">The REST Uri to call.</param>
-        /// <returns>The cached response or a new result from Pypi.</returns>
-        private async Task<HttpResponseMessage> GetPypiResponse(string uri)
+        /// <returns>The cached response or a new result from PyPi.</returns>
+        private async Task<HttpResponseMessage> GetPyPiResponse(string uri)
         {
-            if (cachedResponses.TryGetValue(uri, out var value))
+            if (cachedResponses.TryGetValue(uri, out HttpResponseMessage result))
             {
-                return await value;
+                Logger.LogVerbose("Retrieved cached Python data from " + uri);
+                return result;
             }
 
             Logger.LogInfo("Getting Python data from " + uri);
@@ -67,20 +77,34 @@ namespace Microsoft.ComponentDetection.Detectors.Pip
         }
 
         /// <summary>
-        /// Used to update the consistency cache, decision has to be made by the caller to allow for retries!.
+        /// Used to update the in-memory LRU cache, decision has to be made by the caller to allow for retries.
         /// </summary>
         /// <param name="uri">The REST Uri to call.</param>
         /// <param name="message">The proposed response by the caller to store for this Uri.</param>
         /// <returns>The `first-wins` response accepted into the cache.
-        /// This might be different from the input if another caller wins the race!.</returns>
-        private async Task<HttpResponseMessage> CachePypiResponse(string uri, HttpResponseMessage message)
+        /// This might be different from the input if another caller wins the race.</returns>
+        private async Task<HttpResponseMessage> CachePyPiResponseMemory(string uri, HttpResponseMessage message)
         {
-            if (!cachedResponses.TryAdd(uri, Task.FromResult(message)))
+            // On the initial caching attempt, see if the user specified an override
+            // for PyPiMaxCacheEntries and recreate the cache if needed
+            if (!checkedMaxEntriesVariable)
             {
-                return await cachedResponses[uri];
+                var maxEntriesVariable = EnvironmentVariableService.GetEnvironmentVariable("PyPiMaxCacheEntries");
+                if (!string.IsNullOrEmpty(maxEntriesVariable) && long.TryParse(maxEntriesVariable, out var maxEntries))
+                {
+                    Logger.LogInfo($"Setting IPyPiClient max cache entries to {maxEntries}");
+                    cachedResponses = new MemoryCache(new MemoryCacheOptions { SizeLimit = maxEntries });
+                }
+
+                checkedMaxEntriesVariable = true;
             }
 
-            return message;
+            return await cachedResponses.GetOrCreateAsync(uri, cacheEntry =>
+            {
+                cacheEntry.SlidingExpiration = TimeSpan.FromSeconds(CACHEINTERVALSECONDS); // This entry will expire after CACHEINTERVALSECONDS seconds from last use
+                cacheEntry.Size = 1; // Specify a size of 1 so a set number of entries can always be in the cache
+                return Task.FromResult(message);
+            });
         }
 
         public async Task<IList<PipDependencySpecification>> FetchPackageDependencies(string name, string version, PythonProjectRelease release)
@@ -88,9 +112,9 @@ namespace Microsoft.ComponentDetection.Detectors.Pip
             var dependencies = new List<PipDependencySpecification>();
 
             var uri = release.Url.ToString();
-            var response = await GetPypiResponse(uri);
+            var response = await GetPyPiResponse(uri);
 
-            response = await CachePypiResponse(uri, response);
+            response = await CachePyPiResponseMemory(uri, response);
 
             if (!response.IsSuccessStatusCode)
             {
@@ -169,10 +193,10 @@ namespace Microsoft.ComponentDetection.Detectors.Pip
                         return Task.FromResult<HttpResponseMessage>(null);
                     }
 
-                    return GetPypiResponse(requestUri);
+                    return GetPyPiResponse(requestUri);
                 });
 
-            request = await CachePypiResponse(requestUri, request);
+            request = await CachePyPiResponseMemory(requestUri, request);
 
             if (request == null)
             {

--- a/test/Microsoft.ComponentDetection.Common.Tests/BaseDetectionTelemetryRecordTests.cs
+++ b/test/Microsoft.ComponentDetection.Common.Tests/BaseDetectionTelemetryRecordTests.cs
@@ -59,6 +59,7 @@ namespace Microsoft.ComponentDetection.Common.Tests
                 typeof(string),
                 typeof(string[]),
                 typeof(bool),
+                typeof(int),
                 typeof(int?),
                 typeof(TimeSpan?),
                 typeof(HttpStatusCode),

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/PyPiClientTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/PyPiClientTests.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Microsoft.ComponentDetection.Common;
 using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Detectors.Pip;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -24,6 +26,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         {
             pypiClient = new PyPiClient()
             {
+                EnvironmentVariableService = new EnvironmentVariableService(),
                 Logger = new Mock<ILogger>().Object,
             };
         }
@@ -41,14 +44,152 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
                 },
             };
 
-            PyPiClient.HttpClient = new HttpClient(MockHttpMessageHandler(JsonConvert.SerializeObject(pythonProject)));
+            var mockHandler = MockHttpMessageHandler(JsonConvert.SerializeObject(pythonProject));
+            PyPiClient.HttpClient = new HttpClient(mockHandler.Object);
 
             Func<Task> action = async () => await pypiClient.GetReleases(pythonSpecs);
 
             await action.Should().NotThrowAsync();
         }
 
-        private HttpMessageHandler MockHttpMessageHandler(string content)
+        [TestMethod]
+        public async Task GetReleases_DuplicateEntries_CallsGetAsync_Once()
+        {
+            var pythonSpecs = new PipDependencySpecification { DependencySpecifiers = new List<string> { "==1.0.0" } };
+            var pythonProject = new PythonProject
+            {
+                Releases = new Dictionary<string, IList<PythonProjectRelease>>
+                {
+                    { "1.0.0", new List<PythonProjectRelease> { new PythonProjectRelease() } },
+                },
+            };
+
+            var mockHandler = MockHttpMessageHandler(JsonConvert.SerializeObject(pythonProject));
+            PyPiClient.HttpClient = new HttpClient(mockHandler.Object);
+
+            Func<Task> action = async () => await pypiClient.GetReleases(pythonSpecs);
+
+            await action.Should().NotThrowAsync();
+            await action.Should().NotThrowAsync();
+
+            // Verify the API call was performed only once
+            mockHandler.Protected().Verify(
+               "SendAsync",
+               Times.Once(),
+               ItExpr.IsAny<HttpRequestMessage>(),
+               ItExpr.IsAny<CancellationToken>()
+            );
+        }
+
+        [TestMethod]
+        public async Task GetReleases_DifferentEntries_CallsGetAsync_Once()
+        {
+            var pythonSpecs = new PipDependencySpecification { DependencySpecifiers = new List<string> { "==1.0.0" } };
+            var pythonProject = new PythonProject
+            {
+                Releases = new Dictionary<string, IList<PythonProjectRelease>>
+                {
+                    { "1.0.0", new List<PythonProjectRelease> { new PythonProjectRelease() } },
+                },
+            };
+
+            var mockHandler = MockHttpMessageHandler(JsonConvert.SerializeObject(pythonProject));
+            PyPiClient.HttpClient = new HttpClient(mockHandler.Object);
+
+            Func<Task> action = async () =>
+            {
+                pythonSpecs.Name = Guid.NewGuid().ToString();
+                await pypiClient.GetReleases(pythonSpecs);
+            };
+
+            await action.Should().NotThrowAsync();
+            await action.Should().NotThrowAsync();
+
+            // Verify the API call was performed only once
+            mockHandler.Protected().Verify(
+               "SendAsync",
+               Times.Exactly(2),
+               ItExpr.IsAny<HttpRequestMessage>(),
+               ItExpr.IsAny<CancellationToken>()
+            );
+        }
+
+        [TestMethod]
+        public async Task FetchPackageDependencies_DuplicateEntries_CallsGetAsync_Once()
+        {
+            var mockHandler = MockHttpMessageHandler("invalid ZIP");
+            PyPiClient.HttpClient = new HttpClient(mockHandler.Object);
+
+            Func<Task> action = async () => await pypiClient.FetchPackageDependencies("a", "1.0.0", new PythonProjectRelease { PackageType = "bdist_wheel", PythonVersion = "3.5.2", Size = 1000, Url = new Uri($"https://testurl") });
+
+            await action.Should().ThrowAsync<InvalidDataException>();
+            await action.Should().ThrowAsync<InvalidDataException>();
+
+            // Verify the API call was performed only once
+            mockHandler.Protected().Verify(
+               "SendAsync",
+               Times.Once(),
+               ItExpr.IsAny<HttpRequestMessage>(),
+               ItExpr.IsAny<CancellationToken>()
+            );
+        }
+
+        [TestMethod]
+        public async Task FetchPackageDependencies_DifferentEntries_CallsGetAsync_Once()
+        {
+            var mockHandler = MockHttpMessageHandler("invalid ZIP");
+            PyPiClient.HttpClient = new HttpClient(mockHandler.Object);
+
+            Func<Task> action = async () => await pypiClient.FetchPackageDependencies("a", "1.0.0", new PythonProjectRelease { PackageType = "bdist_wheel", PythonVersion = "3.5.2", Size = 1000, Url = new Uri($"https://{Guid.NewGuid()}") });
+
+            await action.Should().ThrowAsync<InvalidDataException>();
+            await action.Should().ThrowAsync<InvalidDataException>();
+
+            // Verify the API call was performed only once
+            mockHandler.Protected().Verify(
+               "SendAsync",
+               Times.Exactly(2),
+               ItExpr.IsAny<HttpRequestMessage>(),
+               ItExpr.IsAny<CancellationToken>()
+            );
+        }
+
+        [TestMethod]
+        public async Task GetReleases_MaxEntriesVariable_CreatesNewCache()
+        {
+            var pythonSpecs = new PipDependencySpecification { DependencySpecifiers = new List<string> { "==1.0.0" } };
+            var pythonProject = new PythonProject
+            {
+                Releases = new Dictionary<string, IList<PythonProjectRelease>>
+                {
+                    { "1.0.0", new List<PythonProjectRelease> { new PythonProjectRelease() } },
+                },
+            };
+
+            var mockHandler = MockHttpMessageHandler(JsonConvert.SerializeObject(pythonProject));
+            PyPiClient.HttpClient = new HttpClient(mockHandler.Object);
+
+            var mockLogger = new Mock<ILogger>();
+            var mockEvs = new Mock<IEnvironmentVariableService>();
+            mockEvs.Setup(x => x.GetEnvironmentVariable(It.Is<string>(s => s.Equals("PyPiMaxCacheEntries")))).Returns("32");
+
+            var mockedPyPi = new PyPiClient()
+            {
+                EnvironmentVariableService = mockEvs.Object,
+                Logger = mockLogger.Object,
+            };
+
+            Func<Task> action = async () => await mockedPyPi.GetReleases(pythonSpecs);
+
+            await action.Should().NotThrowAsync();
+            await action.Should().NotThrowAsync();
+
+            // Verify the cache setup call was performed only once
+            mockEvs.Verify(x => x.GetEnvironmentVariable(It.IsAny<string>()), Times.Once());
+            mockLogger.Verify(x => x.LogInfo(It.Is<string>(s => s.Equals("Setting IPyPiClient max cache entries to 32"))), Times.Once());
+        }
+
+        private Mock<HttpMessageHandler> MockHttpMessageHandler(string content)
         {
             var handlerMock = new Mock<HttpMessageHandler>();
             handlerMock.Protected()
@@ -62,7 +203,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
                    Content = new StringContent(content),
                });
 
-            return handlerMock.Object;
+            return handlerMock;
         }
     }
 }

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/PyPiClientTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/PyPiClientTests.cs
@@ -77,8 +77,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
                "SendAsync",
                Times.Once(),
                ItExpr.IsAny<HttpRequestMessage>(),
-               ItExpr.IsAny<CancellationToken>()
-            );
+               ItExpr.IsAny<CancellationToken>());
         }
 
         [TestMethod]
@@ -110,8 +109,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
                "SendAsync",
                Times.Exactly(2),
                ItExpr.IsAny<HttpRequestMessage>(),
-               ItExpr.IsAny<CancellationToken>()
-            );
+               ItExpr.IsAny<CancellationToken>());
         }
 
         [TestMethod]
@@ -130,8 +128,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
                "SendAsync",
                Times.Once(),
                ItExpr.IsAny<HttpRequestMessage>(),
-               ItExpr.IsAny<CancellationToken>()
-            );
+               ItExpr.IsAny<CancellationToken>());
         }
 
         [TestMethod]
@@ -150,8 +147,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
                "SendAsync",
                Times.Exactly(2),
                ItExpr.IsAny<HttpRequestMessage>(),
-               ItExpr.IsAny<CancellationToken>()
-            );
+               ItExpr.IsAny<CancellationToken>());
         }
 
         [TestMethod]


### PR DESCRIPTION
Updates the caching mechanism in IPyPiClient from using a ConcurrentDictionary to a Microsoft.Extensions.Caching.Memory MemoryCache which allows setting a maximum number of cache entries and a cache entry expiration time. By limiting the number of entries the memory usage will be lowered and because of expiration time if the tool has not finished by the time the cache is no longer being used memory will be freed before exiting the program.

For users that need additional configuration (potentially due to memory constraints), allow them to set a maximum number of cache entries using the PyPiMaxCacheEntries environment variable.

This resolves the issue #35 