### PR TITLE
Bug Fix: While parsing maven scope, discard left-over string if present.

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/maven/MavenParsingUtilities.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/maven/MavenParsingUtilities.cs
@@ -59,7 +59,7 @@ namespace Microsoft.ComponentDetection.Detectors.Maven
             if (results.Length == 5)
             {
                 dependencyScope = MavenScopeToDependencyScopeMapping.TryGetValue(
-                    Regex.Match(results[4], @"^([\w\-]+)").Value,
+                    Regex.Match(results[4], @"^([\w]+)").Value,
                     out dependencyScope) 
                     ? dependencyScope 
                     : throw new InvalidOperationException($"Invalid scope ('{results[4]}') found for '{mavenComponentString}' found in generated dependency graph.");

--- a/src/Microsoft.ComponentDetection.Detectors/maven/MavenParsingUtilities.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/maven/MavenParsingUtilities.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net;
+using System.Text.RegularExpressions;
 using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Contracts.BcdeModels;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
@@ -57,7 +58,9 @@ namespace Microsoft.ComponentDetection.Detectors.Maven
             bool? isDevDependency = null;
             if (results.Length == 5)
             {
-                dependencyScope = MavenScopeToDependencyScopeMapping.TryGetValue(results[4], out dependencyScope) 
+                dependencyScope = MavenScopeToDependencyScopeMapping.TryGetValue(
+                    Regex.Match(results[4], @"^([\w\-]+)").Value,
+                    out dependencyScope) 
                     ? dependencyScope 
                     : throw new InvalidOperationException($"Invalid scope ('{results[4]}') found for '{mavenComponentString}' found in generated dependency graph.");
                 isDevDependency = dependencyScope == DependencyScope.MavenTest;

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/MavenParsingUtilitiesTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/MavenParsingUtilitiesTests.cs
@@ -55,6 +55,20 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         }
 
         [TestMethod]
+        public void GenerateDetectedComponentAndIsDeveDependencyAndDependencyScope_DiscardLeftoverStringWhileParsingScope()
+        {
+            var componentAndMetaData =
+                GenerateDetectedComponentAndMetadataFromMavenString("org.apache.maven:maven-artifact:jar:3.6.1-SNAPSHOT:provided (optional)");
+
+            Assert.IsNotNull(componentAndMetaData);
+            Assert.IsNotNull(componentAndMetaData.dependencyScope);
+
+            var actualComponent = (MavenComponent)componentAndMetaData.Component.Component;
+            Assert.IsInstanceOfType(actualComponent, typeof(MavenComponent));
+            Assert.AreEqual(DependencyScope.MavenProvided, componentAndMetaData.dependencyScope);
+        }
+
+        [TestMethod]
         public void GenerateDetectedComponentAndIsDeveDependencyAndDependencyScope_DevelopmentDependencyTrue()
         {
             var componentAndMetaData =


### PR DESCRIPTION
## Overview:
A bug was introduced in [this](https://github.com/microsoft/component-detection/commit/3a17feb7e1f5cf8acefc03a53adf932a2a5b7b5c) commit, 
which resulted in invalid scope if there was left over string in the scope substring.

an example [build break](https://github.com/microsoft/componentdetection-azdo/runs/5858218730?check_suite_focus=true) as a result of this was observed in azdo. 

## Testing
- new unit test for this special parsing use case.
- Tested locally to detect maven components. 
- All existing unit tests successfully passed. 
