### PR TITLE
Fix Go CLI cyclic dependency graph

### DIFF
--- a/test/Microsoft.ComponentDetection.Detectors.Tests/GoComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/GoComponentDetectorTests.cs
@@ -336,6 +336,34 @@ replace (
         }
 
         [TestMethod]
+        public async Task TestGoDetector_GoGraphCyclicDepndencies()
+        {
+            var goGraph = @"
+github.com/prometheus/common@v0.32.1 github.com/prometheus/client_golang@v1.11.0
+github.com/prometheus/client_golang@v1.12.1 github.com/prometheus/common@v0.32.1";
+            commandLineMock.Setup(x => x.CanCommandBeLocated("go", null, It.IsAny<DirectoryInfo>(), It.IsAny<string[]>()))
+                .ReturnsAsync(true);
+
+            commandLineMock.Setup(x => x.ExecuteCommand("go", null, It.IsAny<DirectoryInfo>(), new[] { "mod", "graph" }))
+                .ReturnsAsync(new CommandLineExecutionResult
+                {
+                    ExitCode = 0,
+                    StdOut = goGraph,
+                });
+
+            envVarService.Setup(x => x.DoesEnvironmentVariableExist("EnableGoCliScan")).Returns(true);
+
+            var (scanResult, componentRecorder) = await detectorTestUtility
+                                                    .WithFile("go.mod", string.Empty)
+                                                    .ExecuteDetector();
+
+            Assert.AreEqual(ProcessingResultCode.Success, scanResult.ResultCode);
+
+            var detectedComponents = componentRecorder.GetDetectedComponents();
+            Assert.AreEqual(3, detectedComponents.Count());
+        }
+
+        [TestMethod]
         public async Task TestGoDetector_GoCliRequiresEnvVarToRun()
         {
             await TestGoSumDetectorWithValidFile_ReturnsSuccessfully();

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/GoComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/GoComponentDetectorTests.cs
@@ -336,7 +336,7 @@ replace (
         }
 
         [TestMethod]
-        public async Task TestGoDetector_GoGraphCyclicDepndencies()
+        public async Task TestGoDetector_GoGraphCyclicDependencies()
         {
             var goGraph = @"
 github.com/prometheus/common@v0.32.1 github.com/prometheus/client_golang@v1.11.0


### PR DESCRIPTION
## Problem
A go package can have a cyclic dependency, for example:

```
github.com/prometheus/common@v0.4.1 github.com/gogo/protobuf@v1.1.1
github.com/prometheus/client_golang@v1.0.0 github.com/prometheus/common@v0.4.1
github.com/prometheus/common@v0.10.0 github.com/prometheus/client_golang@v1.0.0 
github.com/prometheus/client_golang@v1.7.1 github.com/prometheus/common@v0.10.0 
github.com/prometheus/common@v0.26.0 github.com/prometheus/client_golang@v1.7.1 
github.com/prometheus/client_golang@v1.11.0 github.com/prometheus/common@v0.26.0 
github.com/prometheus/common@v0.32.1 github.com/prometheus/client_golang@v1.11.0 
github.com/prometheus/client_golang@v1.12.1 github.com/prometheus/common@v0.32.1
```

Cyclic dependencies break how the current Go CLI detector works, causing it to break silently and fallback on go.sum direct parsing which is far less accurate.

## Solution

- Add parent component if it hasn't been registered already and continue parsing Go CLI output.
- Improve exception logs to easily pinpoint the issue