### PR TITLE
Go CLI detector enhancement (`go list -m all`)

### DIFF
--- a/docs/detectors/go.md
+++ b/docs/detectors/go.md
@@ -22,9 +22,10 @@ Improved go detection depends on the following to successfully run:
 
 - Go v1.11+.
 
-Go detection is performed by parsing output from executing `go mod graph`.
 Full dependency graph generation is supported if Go v1.11+ is present on the build agent.
 If no Go v1.11+ is present, fallback detection strategy is performed.
+
+Go detection is performed by parsing output from executing [go list -m -json all](1). To generate the graph, the command [go mod graph](2) is executed, this only adds edges between the components that were already registered by `go list`.
 
 As we validate this opt-in behavior, we will eventually graduate it to the default detection strategy.
 
@@ -35,11 +36,13 @@ Dev dependency tagging is not supported.
 Go detection will fallback if no Go v1.11+ is present.
 
 Due to the nature of `go.sum` containing references for all dependencies, including historical, no-longer-needed dependencies; the fallback strategy can result in over detection.
-Executing `go mod tidy` before detection via fallback is encouraged.
+Executing [go mod tidy](https://go.dev/ref/mod#go-mod-tidy) before detection via fallback is encouraged.
+Some legacy dependencies may report stale transitive dependencies in their manifests, in this case you can exclude them safely from your binaries by using [exclude directive](https://go.dev/doc/modules/gomod-ref#exclude).
 
 ## Environment Variables
 
-If the environment variable `EnableGoCliScan` is set, to any value, the Go detector uses [`go mod graph`][1] to discover Go dependencies.
+If the environment variable `EnableGoCliScan` is set, to any value, the Go detector uses [`go list -m -json all`][1] to discover Go dependencies.
 If the environment variable is not present, we fall back to parsing `go.mod` and `go.sum` ourselves.
 
-[1]: https://go.dev/ref/mod#go-mod-graph
+[1]: https://go.dev/ref/mod#go-list-m
+[2]: https://go.dev/ref/mod#go-mod-graph

--- a/docs/detectors/go.md
+++ b/docs/detectors/go.md
@@ -37,7 +37,8 @@ Go detection will fallback if no Go v1.11+ is present.
 
 Due to the nature of `go.sum` containing references for all dependencies, including historical, no-longer-needed dependencies; the fallback strategy can result in over detection.
 Executing [go mod tidy](https://go.dev/ref/mod#go-mod-tidy) before detection via fallback is encouraged.
-Some legacy dependencies may report stale transitive dependencies in their manifests, in this case you can exclude them safely from your binaries by using [exclude directive](https://go.dev/doc/modules/gomod-ref#exclude).
+
+Some legacy dependencies may report stale transitive dependencies in their manifests, in this case you can remove them safely from your binaries by using [exclude directive](https://go.dev/doc/modules/gomod-ref#exclude).
 
 ## Environment Variables
 

--- a/docs/feature-overview.md
+++ b/docs/feature-overview.md
@@ -6,7 +6,7 @@
 | Conda (Python) (Beta) | <ul><li>environment.yml</li><li>environment.yaml</li></ul> | <ul><li>Conda v4.10.2+</li></ul> | ❌ | ❌ |
 | Linux (Debian, Alpine, Rhel, Centos, Fedora, Ubuntu)| <ul><li>(via [syft](https://github.com/anchore/syft))</li></ul> | - | - | - | - |
 | Gradle | <ul><li>*.lockfile</li></ul> | <ul><li>Gradle 7 or prior using [Single File lock](https://docs.gradle.org/6.8.1/userguide/dependency_locking.html#single_lock_file_per_project)</li></ul> | ❌ | ❌ |
-| Go | <ul><li>*go mod graph*</li></ul>Fallback</br><ul><li>go.mod</li><li>go.sum</li></ul> | <ul><li>Go 1.11+ (will fallback if not present)</li></ul> | ❌ | ✔ (root idenditication only for fallback) |
+| Go | <ul><li>*go list -m -json all*</li><li>*go mod graph* (edge information only)</li></ul>Fallback</br><ul><li>go.mod</li><li>go.sum</li></ul> | <ul><li>Go 1.11+ (will fallback if not present)</li></ul> | ❌ | ✔ (root idenditication only for fallback) |
 | Maven | <ul><li>pom.xml</li><li>*mvn dependency:tree -f {pom.xml}*</li></ul> | <ul><li>Maven</li><li>Maven Dependency Plugin (auto-installed with Maven)</li></ul> | ✔ (test dependency scope) | ✔ |
 | NPM | <ul><li>package.json</li><li>package-lock.json</li><li>npm-shrinkwrap.json</li><li>lerna.json</li></ul> | - | ✔ (dev-dependencies in package.json, dev flag in package-lock.json) | ✔ |
 | Yarn (v1, v2) | <ul><li>package.json</li><li>yarn.lock</li></ul> | - | ✔ (dev-dependencies in package.json) | ✔ |

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/GoComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/GoComponentDetectorTests.cs
@@ -311,10 +311,46 @@ replace (
         [TestMethod]
         public async Task TestGoDetector_GoGraphHappyPath()
         {
-            var goGraph = "example.com/mainModule some-package@v1.2.3\nsome-package@v1.2.3 other@v1.0.0\nsome-package@v1.2.3 test@v2.0.0\ntest@v2.0.0 a@v1.5.0";
+            var buildDependencies = @"{
+    ""Path"": ""some-package"",
+    ""Version"": ""v1.2.3"",
+    ""Time"": ""2021-12-06T23:04:27Z"",
+    ""Indirect"": true,
+    ""GoMod"": ""C:\\test\\go.mod"",
+    ""GoVersion"": ""1.11""
+}" + "\n" + @"{
+    ""Path"": ""test"",
+    ""Version"": ""v2.0.0"",
+    ""Time"": ""2021-12-06T23:04:27Z"",
+    ""Indirect"": true,
+    ""GoMod"": ""C:\\test\\go.mod"",
+    ""GoVersion"": ""1.11""
+}" + "\n" + @"{
+    ""Path"": ""other"",
+    ""Version"": ""v1.2.0"",
+    ""Time"": ""2021-12-06T23:04:27Z"",
+    ""Indirect"": true,
+    ""GoMod"": ""C:\\test\\go.mod"",
+    ""GoVersion"": ""1.11""
+}" + "\n" + @"{
+    ""Path"": ""a"",
+    ""Version"": ""v1.5.0"",
+    ""Time"": ""2020-05-19T17:02:07Z"",
+    ""Indirect"": true,
+    ""GoMod"": ""C:\\test\\go.mod"",
+    ""GoVersion"": ""1.11""
+}";
+            var goGraph = "example.com/mainModule some-package@v1.2.3\nsome-package@v1.2.3 other@v1.0.0\nsome-package@v1.2.3 other@v1.2.0\ntest@v2.0.0 a@v1.5.0";
 
             commandLineMock.Setup(x => x.CanCommandBeLocated("go", null, It.IsAny<DirectoryInfo>(), It.IsAny<string[]>()))
                 .ReturnsAsync(true);
+
+            commandLineMock.Setup(x => x.ExecuteCommand("go", null, It.IsAny<DirectoryInfo>(), new[] { "list", "-m", "-json", "all" }))
+                .ReturnsAsync(new CommandLineExecutionResult
+                {
+                    ExitCode = 0,
+                    StdOut = buildDependencies,
+                });
 
             commandLineMock.Setup(x => x.ExecuteCommand("go", null, It.IsAny<DirectoryInfo>(), new[] { "mod", "graph" }))
                 .ReturnsAsync(new CommandLineExecutionResult
@@ -333,16 +369,50 @@ replace (
 
             var detectedComponents = componentRecorder.GetDetectedComponents();
             Assert.AreEqual(4, detectedComponents.Count());
+            detectedComponents.Where(component => component.Component.Id == "other v1.0.0 - Go").Should().HaveCount(0);
+            detectedComponents.Where(component => component.Component.Id == "other v1.2.0 - Go").Should().HaveCount(1);
+            detectedComponents.Where(component => component.Component.Id == "some-package v1.2.3 - Go").Should().HaveCount(1);
+            detectedComponents.Where(component => component.Component.Id == "test v2.0.0 - Go").Should().HaveCount(1);
+            detectedComponents.Where(component => component.Component.Id == "a v1.5.0 - Go").Should().HaveCount(1);
         }
 
         [TestMethod]
         public async Task TestGoDetector_GoGraphCyclicDependencies()
         {
+            var buildDependencies = @"{
+    ""Path"": ""github.com/prometheus/common"",
+    ""Version"": ""v0.32.1"",
+    ""Time"": ""2021-12-06T23:04:27Z"",
+    ""Indirect"": true,
+    ""GoMod"": ""C:\\test\\go.mod"",
+    ""GoVersion"": ""1.11""
+}" + "\n" + @"{
+    ""Path"": ""github.com/prometheus/client_golang"",
+    ""Version"": ""v1.11.0"",
+    ""Time"": ""2021-12-06T23:04:27Z"",
+    ""Indirect"": true,
+    ""GoMod"": ""C:\\test\\go.mod"",
+    ""GoVersion"": ""1.11""
+}" + "\n" + @"{
+    ""Path"": ""github.com/prometheus/client_golang"",
+    ""Version"": ""v1.12.1"",
+    ""Time"": ""2021-12-06T23:04:27Z"",
+    ""Indirect"": true,
+    ""GoMod"": ""C:\\test\\go.mod"",
+    ""GoVersion"": ""1.11""
+}";
             var goGraph = @"
 github.com/prometheus/common@v0.32.1 github.com/prometheus/client_golang@v1.11.0
 github.com/prometheus/client_golang@v1.12.1 github.com/prometheus/common@v0.32.1";
             commandLineMock.Setup(x => x.CanCommandBeLocated("go", null, It.IsAny<DirectoryInfo>(), It.IsAny<string[]>()))
                 .ReturnsAsync(true);
+
+            commandLineMock.Setup(x => x.ExecuteCommand("go", null, It.IsAny<DirectoryInfo>(), new[] { "list", "-m", "-json", "all" }))
+                .ReturnsAsync(new CommandLineExecutionResult
+                {
+                    ExitCode = 0,
+                    StdOut = buildDependencies,
+                });
 
             commandLineMock.Setup(x => x.ExecuteCommand("go", null, It.IsAny<DirectoryInfo>(), new[] { "mod", "graph" }))
                 .ReturnsAsync(new CommandLineExecutionResult


### PR DESCRIPTION
## Problem
Currently for Golang projects component detection works by scanning the go.sum file or using `go mod graph` command as an alternative, but results should be the same as using go.sum file because go mod graph prints out all the versions in the graph. This means we are over detecting modules of versions that are no longer included in the build binaries.

## Solution
Use [go list -m all](https://go.dev/ref/mod#go-list-m) command to find the actual versions of the components [used during a build](https://go.dev/ref/mod#glos-build-list) as it uses the [minimal version selection](https://go.dev/ref/mod#minimal-version-selection) algorithm. That command does not generate a graph for us, hence by running both `go mod graph` and `go list -m all`, we are able to prune all the dependencies that were not included in the build list and keep the dependency graph in of Go's main module.