### PR TITLE
Enable GoCliDetector by default. Using env variable 'DisableGoCliDetector=true" to manually disable GoCliDetector.

### DIFF
--- a/docs/detectors/go.md
+++ b/docs/detectors/go.md
@@ -6,19 +6,9 @@ Go detection depends on the following to successfully run:
 
 - `go.mod` or `go.sum` files
 
-## Detection strategy
+## Default Detection strategy
 
-Go detection is performed by parsing any `go.mod` or `go.sum` found under the scan directory.
-
-Only root dependency information is generated instead of full graph.
-I.e. tags the top level component or explicit dependency a given transitive dependency was brought by.
-Given a dependency tree A -> B -> C, C's root dependency is A.
-
-### Improved detection accuracy via opt-in
-
-**To enable improved detection accuracy, create an environment variable named `EnableGoCliScan` with any value.**
-
-Improved go detection depends on the following to successfully run:
+Go detection depends on the following to successfully run:
 
 - Go v1.11+.
 
@@ -27,23 +17,30 @@ If no Go v1.11+ is present, fallback detection strategy is performed.
 
 Go detection is performed by parsing output from executing [go list -m -json all](1). To generate the graph, the command [go mod graph](2) is executed, this only adds edges between the components that were already registered by `go list`.
 
-As we validate this opt-in behavior, we will eventually graduate it to the default detection strategy.
+## Fallback Detection strategy
+Go detection is performed by parsing any `go.mod` or `go.sum` found under the scan directory.
+
+Only root dependency information is generated instead of full graph.
+I.e. tags the top level component or explicit dependency a given transitive dependency was brought by.
+Given a dependency tree A -> B -> C, C's root dependency is A.
+
+**To force fallback detection strategy, create set environment variable `DisableGoCliScan=true`.**
 
 ## Known limitations
+- If the default strategy is used and go modules are not present in the system before the detector is executed, the go cli will fetch all modules to generate the dependency graph. This will incur additional detector time execution.
 
-Dev dependency tagging is not supported.
+- Dev dependency tagging is not supported.
 
-Go detection will fallback if no Go v1.11+ is present.
+- Go detection will fallback if no Go v1.11+ is present.
 
-Due to the nature of `go.sum` containing references for all dependencies, including historical, no-longer-needed dependencies; the fallback strategy can result in over detection.
-Executing [go mod tidy](https://go.dev/ref/mod#go-mod-tidy) before detection via fallback is encouraged.
+- Due to the nature of `go.sum` containing references for all dependencies, including historical, no-longer-needed dependencies; the fallback strategy can result in over detection.
+Executing [go mod tidy](https://go.dev/ref/mod#go-mod-tidy) before detection via default strategy is encouraged.
 
-Some legacy dependencies may report stale transitive dependencies in their manifests, in this case you can remove them safely from your binaries by using [exclude directive](https://go.dev/doc/modules/gomod-ref#exclude).
+- Some legacy dependencies may report stale transitive dependencies in their manifests, in this case you can remove them safely from your binaries by using [exclude directive](https://go.dev/doc/modules/gomod-ref#exclude).
 
 ## Environment Variables
 
-If the environment variable `EnableGoCliScan` is set, to any value, the Go detector uses [`go list -m -json all`][1] to discover Go dependencies.
-If the environment variable is not present, we fall back to parsing `go.mod` and `go.sum` ourselves.
+If the environment variable `DisableGoCliScan` is set to `true`, the Go detector parses `go.mod` and `go.sum` to discover dependencies. otherwise, it executes default strategy.
 
 [1]: https://go.dev/ref/mod#go-list-m
 [2]: https://go.dev/ref/mod#go-mod-graph

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -2,10 +2,10 @@
 
 Environment variables are sometimes used to control experimental features or advanced options
 
-## `EnableGoCliScan`
+## `DisableGoCliScan`
 
-If the environment variable `EnableGoCliScan` is set, to any value, the Go detector uses [`go mod graph`][1] to discover Go dependencies.
-If the environment variable is not set, we fall back to parsing `go.mod` and `go.sum` ourselves.
+If the environment variable `DisableGoCliScan` is set to "true", we fall back to parsing `go.mod` and `go.sum` ourselves. 
+Otherwise, the Go detector uses go-cli command: `go list -m all` to discover Go dependencies.
 
 ## `PyPiMaxCacheEntries`
 

--- a/src/Microsoft.ComponentDetection.Common/EnvironmentVariableService.cs
+++ b/src/Microsoft.ComponentDetection.Common/EnvironmentVariableService.cs
@@ -24,5 +24,11 @@ namespace Microsoft.ComponentDetection.Common
 
             return caseInsensitiveName != null ? Environment.GetEnvironmentVariable(caseInsensitiveName) : null;
         }
+
+        public bool IsEnvironmentVariableValueTrue(string name)
+        {
+            _ = bool.TryParse(GetEnvironmentVariable(name), out bool result);
+            return result;
+        }
     }
 }

--- a/src/Microsoft.ComponentDetection.Contracts/IEnvironmentVariableService.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/IEnvironmentVariableService.cs
@@ -5,5 +5,7 @@ namespace Microsoft.ComponentDetection.Contracts
         bool DoesEnvironmentVariableExist(string name);
 
         string GetEnvironmentVariable(string name);
+
+        bool IsEnvironmentVariableValueTrue(string name);
     }
 }

--- a/src/Microsoft.ComponentDetection.Detectors/go/GoComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/go/GoComponentDetector.cs
@@ -59,7 +59,7 @@ namespace Microsoft.ComponentDetection.Detectors.Go
                 } else
                 {
                     Logger.LogInfo("Go cli scan was manually disabled, fallback strategy performed." +
-                        " More info: https://docs.opensource.microsoft.com/tools/cg/reference/feature-coverage/#go");
+                        " More info: https://github.com/microsoft/component-detection/blob/main/docs/detectors/go.md#fallback-detection-strategy");
                 }
             }
             catch (Exception ex)
@@ -118,7 +118,7 @@ namespace Microsoft.ComponentDetection.Detectors.Go
             }
 
             Logger.LogInfo("Go CLI was found in system and will be used to generate dependency graph. " +
-                "Detection time may be improved by activating fallback strategy (https://docs.opensource.microsoft.com/tools/cg/reference/feature-coverage/#go). " +
+                "Detection time may be improved by activating fallback strategy (https://github.com/microsoft/component-detection/blob/main/docs/detectors/go.md#fallback-detection-strategy). " +
                 "But, it will introduce noise into the detected components.");
             var goDependenciesProcess = await CommandLineInvocationService.ExecuteCommand("go", null, workingDirectory: projectRootDirectory, new[] { "list", "-m", "-json", "all" });
             if (goDependenciesProcess.ExitCode != 0)

--- a/src/Microsoft.ComponentDetection.Detectors/go/GoComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/go/GoComponentDetector.cs
@@ -56,7 +56,8 @@ namespace Microsoft.ComponentDetection.Detectors.Go
                 if (!IsGoCliManuallyDisabled())
                 {
                     wasGoCliScanSuccessful = await UseGoCliToScan(file.Location, singleFileComponentRecorder);
-                } else
+                }
+                else
                 {
                     Logger.LogInfo("Go cli scan was manually disabled, fallback strategy performed." +
                         " More info: https://github.com/microsoft/component-detection/blob/main/docs/detectors/go.md#fallback-detection-strategy");

--- a/src/Microsoft.ComponentDetection.Detectors/go/GoComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/go/GoComponentDetector.cs
@@ -35,7 +35,7 @@ namespace Microsoft.ComponentDetection.Detectors.Go
 
         public override IEnumerable<ComponentType> SupportedComponentTypes { get; } = new[] { ComponentType.Go };
 
-        public override int Version => 5;
+        public override int Version => 6;
 
         private HashSet<string> projectRoots = new HashSet<string>();
 

--- a/src/Microsoft.ComponentDetection.Detectors/go/GoComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/go/GoComponentDetector.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Composition;
 using System.IO;
 using System.Linq;
+using System.Security.Cryptography.X509Certificates;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.ComponentDetection.Common.Telemetry.Records;
@@ -52,10 +53,12 @@ namespace Microsoft.ComponentDetection.Detectors.Go
             var wasGoCliScanSuccessful = false;
             try
             {
-                if (IsGoCliManuallyEnabled())
+                if (!IsGoCliManuallyDisabled())
                 {
-                    Logger.LogInfo("Go cli scan was manually enabled");
                     wasGoCliScanSuccessful = await UseGoCliToScan(file.Location, singleFileComponentRecorder);
+                } else
+                {
+                    Logger.LogInfo("Go cli scan was manually disabled.");
                 }
             }
             catch (Exception ex)
@@ -307,9 +310,9 @@ namespace Microsoft.ComponentDetection.Detectors.Go
             return true;
         }
 
-        private bool IsGoCliManuallyEnabled()
+        private bool IsGoCliManuallyDisabled()
         {
-            return EnvVarService.DoesEnvironmentVariableExist("EnableGoCliScan");
+            return EnvVarService.IsEnvironmentVariableValueTrue("DisableGoCliScan");
         }
 
         private class GoBuildModule

--- a/src/Microsoft.ComponentDetection.Detectors/go/GoComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/go/GoComponentDetector.cs
@@ -58,7 +58,8 @@ namespace Microsoft.ComponentDetection.Detectors.Go
                     wasGoCliScanSuccessful = await UseGoCliToScan(file.Location, singleFileComponentRecorder);
                 } else
                 {
-                    Logger.LogInfo("Go cli scan was manually disabled.");
+                    Logger.LogInfo("Go cli scan was manually disabled, fallback strategy performed." +
+                        " More info: https://docs.opensource.microsoft.com/tools/cg/reference/feature-coverage/#go");
                 }
             }
             catch (Exception ex)
@@ -116,6 +117,9 @@ namespace Microsoft.ComponentDetection.Detectors.Go
                 return false;
             }
 
+            Logger.LogInfo("Go CLI was found in system and will be used to generate dependency graph. " +
+                "Detection time may be improved by activating fallback strategy (https://docs.opensource.microsoft.com/tools/cg/reference/feature-coverage/#go). " +
+                "But, it will introduce noise into the detected components.");
             var goDependenciesProcess = await CommandLineInvocationService.ExecuteCommand("go", null, workingDirectory: projectRootDirectory, new[] { "list", "-m", "-json", "all" });
             if (goDependenciesProcess.ExitCode != 0)
             {

--- a/src/Microsoft.ComponentDetection.Orchestrator/Orchestrator.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Orchestrator.cs
@@ -247,6 +247,9 @@ namespace Microsoft.ComponentDetection.Orchestrator
                     catch (TimeoutException timeoutException)
                     {
                         Logger.LogError(timeoutException.Message);
+
+                        // TODO: remove the below message after go cli detector improvement has been stabilized.  
+                        Logger.LogWarning("If your repository contains Go packages, your build time may be improved by activating fallback strategy: https://aka.ms/go-detection-fallback-strategy");
                         scanResult.ResultCode = ProcessingResultCode.TimeoutError;
                     }
 

--- a/src/Microsoft.ComponentDetection.Orchestrator/Orchestrator.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Orchestrator.cs
@@ -247,9 +247,6 @@ namespace Microsoft.ComponentDetection.Orchestrator
                     catch (TimeoutException timeoutException)
                     {
                         Logger.LogError(timeoutException.Message);
-
-                        // TODO: remove the below message after go cli detector improvement has been stabilized.  
-                        Logger.LogWarning("If your repository contains Go packages, your build time may be improved by activating fallback strategy: https://aka.ms/go-detection-fallback-strategy");
                         scanResult.ResultCode = ProcessingResultCode.TimeoutError;
                     }
 

--- a/test/Microsoft.ComponentDetection.Common.Tests/EnvironmentVariableServiceTests.cs
+++ b/test/Microsoft.ComponentDetection.Common.Tests/EnvironmentVariableServiceTests.cs
@@ -9,10 +9,12 @@ namespace Microsoft.ComponentDetection.Common.Tests
     public class EnvironmentVariableServiceTests
     {
         public const string MyEnvVar = nameof(MyEnvVar);
+        private EnvironmentVariableService testSubject;
 
         [TestInitialize]
         public void TestInitialize()
         {
+            testSubject = new EnvironmentVariableService();
             Environment.SetEnvironmentVariable(EnvironmentVariableServiceTests.MyEnvVar, "true");
         }
 
@@ -23,15 +25,74 @@ namespace Microsoft.ComponentDetection.Common.Tests
         }
 
         [TestMethod]
-        public void EnvironmentVariableService_ChecksAreCaseInsensitive()
-        {
-            var testSubject = new EnvironmentVariableService();
-
+        public void DoesEnvironmentVariableExist_ChecksAreCaseInsensitive()
+        { 
             Assert.IsFalse(testSubject.DoesEnvironmentVariableExist("THIS_ENVIRONMENT_VARIABLE_DOES_NOT_EXIST"));
 
             Assert.IsTrue(testSubject.DoesEnvironmentVariableExist(MyEnvVar));
             Assert.IsTrue(testSubject.DoesEnvironmentVariableExist(MyEnvVar.ToLower()));
             Assert.IsTrue(testSubject.DoesEnvironmentVariableExist(MyEnvVar.ToUpper()));
+        }
+        
+        [TestMethod]
+        public void GetEnvironmentVariable_returnNullIfVariableDoesNotExist()
+        {
+            Assert.IsNull(testSubject.GetEnvironmentVariable("NonExistentVar"));
+        }
+
+        [TestMethod]
+        public void GetEnvironmentVariable_returnCorrectValue()
+        {
+            string envVariableKey = nameof(envVariableKey);
+            string envVariableValue = nameof(envVariableValue);
+            Environment.SetEnvironmentVariable(envVariableKey, envVariableValue);
+            var result = testSubject.GetEnvironmentVariable(envVariableKey);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(envVariableValue, result);
+            Environment.SetEnvironmentVariable(envVariableKey, null);
+        }
+
+        [TestMethod]
+        public void IsEnvironmentVariableValueTrue_returnsTrueForValidKey_caseInsensitive()
+        {
+            string envVariableKey1 = nameof(envVariableKey1);
+            string envVariableKey2 = nameof(envVariableKey2);
+            Environment.SetEnvironmentVariable(envVariableKey1, "True");
+            Environment.SetEnvironmentVariable(envVariableKey2, "tRuE");
+            var result1 = testSubject.IsEnvironmentVariableValueTrue(envVariableKey1);
+            var result2 = testSubject.IsEnvironmentVariableValueTrue(envVariableKey1);
+            Assert.IsTrue(result1);
+            Assert.IsTrue(result2);
+            Environment.SetEnvironmentVariable(envVariableKey1, null);
+            Environment.SetEnvironmentVariable(envVariableKey2, null);
+        }
+
+        [TestMethod]
+        public void IsEnvironmentVariableValueTrue_returnsFalseForValidKey_caseInsensitive()
+        {
+            string envVariableKey1 = nameof(envVariableKey1);
+            string envVariableKey2 = nameof(envVariableKey2);
+            Environment.SetEnvironmentVariable(envVariableKey1, "False");
+            Environment.SetEnvironmentVariable(envVariableKey2, "fAlSe");
+            var result1 = testSubject.IsEnvironmentVariableValueTrue(envVariableKey1);
+            var result2 = testSubject.IsEnvironmentVariableValueTrue(envVariableKey1);
+            Assert.IsFalse(result1);
+            Assert.IsFalse(result2);
+            Environment.SetEnvironmentVariable(envVariableKey1, null);
+            Environment.SetEnvironmentVariable(envVariableKey2, null);
+        }
+
+        [TestMethod]
+        public void IsEnvironmentVariableValueTrue_returnsFalseForInvalidAndNull()
+        {
+            string envVariableKey1 = nameof(envVariableKey1);
+            string nonExistentKey = nameof(nonExistentKey);
+            Environment.SetEnvironmentVariable(envVariableKey1, "notABoolean");
+            var result1 = testSubject.IsEnvironmentVariableValueTrue(envVariableKey1);
+            var result2 = testSubject.IsEnvironmentVariableValueTrue(nonExistentKey);
+            Assert.IsFalse(result1);
+            Assert.IsFalse(result2);
+            Environment.SetEnvironmentVariable(envVariableKey1, null);
         }
     }
 }

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/GoComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/GoComponentDetectorTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
 
             var loggerMock = new Mock<ILogger>();
 
-            envVarService.Setup(x => x.DoesEnvironmentVariableExist("EnableGoCliScan")).Returns(false);
+            envVarService.Setup(x => x.IsEnvironmentVariableValueTrue("DisableGoCliScan")).Returns(true);
 
             var detector = new GoComponentDetector
             {
@@ -261,7 +261,7 @@ replace (
             commandLineMock.Setup(x => x.CanCommandBeLocated("go", null, It.IsAny<DirectoryInfo>(), It.IsAny<string[]>()))
                 .ReturnsAsync(false);
 
-            envVarService.Setup(x => x.DoesEnvironmentVariableExist("EnableGoCliScan")).Returns(true);
+            envVarService.Setup(x => x.IsEnvironmentVariableValueTrue("DisableGoCliScan")).Returns(false);
 
             await TestGoSumDetectorWithValidFile_ReturnsSuccessfully();
         }
@@ -272,7 +272,7 @@ replace (
             commandLineMock.Setup(x => x.CanCommandBeLocated("go", null, It.IsAny<DirectoryInfo>(), It.IsAny<string[]>()))
                 .ReturnsAsync(() => throw new Exception("Some horrible error occured"));
 
-            envVarService.Setup(x => x.DoesEnvironmentVariableExist("EnableGoCliScan")).Returns(true);
+            envVarService.Setup(x => x.IsEnvironmentVariableValueTrue("DisableGoCliScan")).Returns(false);
 
             await TestGoSumDetectorWithValidFile_ReturnsSuccessfully();
         }
@@ -289,7 +289,7 @@ replace (
                     ExitCode = 1,
                 });
 
-            envVarService.Setup(x => x.DoesEnvironmentVariableExist("EnableGoCliScan")).Returns(true);
+            envVarService.Setup(x => x.IsEnvironmentVariableValueTrue("DisableGoCliScan")).Returns(false);
 
             await TestGoSumDetectorWithValidFile_ReturnsSuccessfully();
         }
@@ -303,7 +303,7 @@ replace (
             commandLineMock.Setup(x => x.ExecuteCommand("go mod graph", null, It.IsAny<DirectoryInfo>(), It.IsAny<string>()))
                 .ReturnsAsync(() => throw new Exception("Some horrible error occured"));
 
-            envVarService.Setup(x => x.DoesEnvironmentVariableExist("EnableGoCliScan")).Returns(true);
+            envVarService.Setup(x => x.IsEnvironmentVariableValueTrue("DisableGoCliScan")).Returns(false);
 
             await TestGoSumDetectorWithValidFile_ReturnsSuccessfully();
         }
@@ -359,7 +359,7 @@ replace (
                     StdOut = goGraph,
                 });
 
-            envVarService.Setup(x => x.DoesEnvironmentVariableExist("EnableGoCliScan")).Returns(true);
+            envVarService.Setup(x => x.IsEnvironmentVariableValueTrue("DisableGoCliScan")).Returns(false);
 
             var (scanResult, componentRecorder) = await detectorTestUtility
                                                     .WithFile("go.mod", string.Empty)
@@ -421,7 +421,7 @@ github.com/prometheus/client_golang@v1.12.1 github.com/prometheus/common@v0.32.1
                     StdOut = goGraph,
                 });
 
-            envVarService.Setup(x => x.DoesEnvironmentVariableExist("EnableGoCliScan")).Returns(true);
+            envVarService.Setup(x => x.IsEnvironmentVariableValueTrue("DisableGoCliScan")).Returns(false);
 
             var (scanResult, componentRecorder) = await detectorTestUtility
                                                     .WithFile("go.mod", string.Empty)


### PR DESCRIPTION
## Summary:
Enabling Go cli detector by default.

## Details
Previously, the Go-Detector by default scanned the manifest and generated components. We were using `EnableGoCliScan` env. variable to activate the Go Cli Detector. With this change, the use of `EnableGoCliScan` is removed. The Go detector by default uses Cli scan. 

To manually override this behavior, new env. variable `DisableGoCliScan` is introduced. 

## How was this tested. 
- Unit tests
- Locally, ran the component-detection on [componentdetection-verification/tree/main/projects/go/helm](https://github.com/microsoft/componentdetection-verification/tree/main/projects/go/helm)
  - without setting the env. variable, validated that go cli scan was ran. approx. 400 components generated. 
  - when `DisableGoCliScan=true` env. variable, validated that GoDetector with manifest scan was ran. Approx. 700 component generated. 

## Why is verification test failing in this PR ? 
This PR changes default go detection to use the Go cli. This results in overall noise reduction in the detected go components. 
The verification test uses  [windows-2022](https://github.com/actions/virtual-environments/blob/main/images/win/Windows2022-Readme.md) which includes Go cli. Hence its expected that verification test will fail for go detection. 

