### PR TITLE
In Go detector, Added error log to expose go cli error.

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/go/GoComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/go/GoComponentDetector.cs
@@ -125,7 +125,7 @@ namespace Microsoft.ComponentDetection.Detectors.Go
             if (goDependenciesProcess.ExitCode != 0)
             {
                 Logger.LogError($"Go CLI command \"go list -m -json all\" failed with error:\n {goDependenciesProcess.StdErr}");
-                Logger.LogError($"Go CLI could not get dependency build list at location: {location}. Fallback gyeso.sum/go.mod parsing will be used.");
+                Logger.LogError($"Go CLI could not get dependency build list at location: {location}. Fallback go.sum/go.mod parsing will be used.");
                 return false;
             }
 

--- a/src/Microsoft.ComponentDetection.Detectors/go/GoComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/go/GoComponentDetector.cs
@@ -124,7 +124,8 @@ namespace Microsoft.ComponentDetection.Detectors.Go
             var goDependenciesProcess = await CommandLineInvocationService.ExecuteCommand("go", null, workingDirectory: projectRootDirectory, new[] { "list", "-m", "-json", "all" });
             if (goDependenciesProcess.ExitCode != 0)
             {
-                Logger.LogError($"Go CLI could not get dependency build list at location: {location}. Fallback go.sum/go.mod parsing will be used.");
+                Logger.LogError($"Go CLI command \"go list -m -json all\" failed with error:\n {goDependenciesProcess.StdErr}");
+                Logger.LogError($"Go CLI could not get dependency build list at location: {location}. Fallback gyeso.sum/go.mod parsing will be used.");
                 return false;
             }
 


### PR DESCRIPTION
### Summary:
Added error message to expose go cli error in the build output. 

### Details: 
 - Go cli output:
   ```
   go: errors parsing go.mod:
   C:\Repos\component-detection\test\Microsoft.ComponentDetection.VerificationTests\resources\go\go.mod:5: unknown directive: requie
   ```

 - Build logs:
 ```
[ERROR] Go CLI command "go list -m -json all" failed with error:
go: errors parsing go.mod:
C:\Repos\component-detection\test\Microsoft.ComponentDetection.VerificationTests\resources\go\go.mod:5: unknown directive: requie
 ```