### PR TITLE
Fixed pnpm detector failing parsing link dependencies

### DIFF
--- a/docs/detectors/pnpm.md
+++ b/docs/detectors/pnpm.md
@@ -1,0 +1,23 @@
+# Pnpm detection
+
+## Known limitations
+
+The Pnpm detector doesn't support the resolution of local dependencies
+like:
+
+- Link dependencies
+```
+dependencies:
+      '@learningclient/common': link:../common
+```
+
+- File dependencies
+```
+dependencies:
+    file:./projects/gmc-bootstrapper.tgz
+```
+These kind of components are ignored by the Pnpm detector.
+
+In the case of `link` dependencies that refer to a folder with a `package.json` file
+the component is then going to be detected by the `NpmComponentDetector`. This is going to happen
+only if the folder is inside the path that is been use for scanning.

--- a/src/Microsoft.ComponentDetection.Detectors/pnpm/PnpmComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pnpm/PnpmComponentDetector.cs
@@ -20,7 +20,7 @@ namespace Microsoft.ComponentDetection.Detectors.Pnpm
 
         public override IEnumerable<ComponentType> SupportedComponentTypes { get; } = new[] { ComponentType.Npm };
 
-        public override int Version { get; } = 4;
+        public override int Version { get; } = 5;
 
         /// <inheritdoc />
         protected override IList<string> SkippedFolders => new List<string> { "node_modules", "pnpm-store" };
@@ -72,8 +72,8 @@ namespace Microsoft.ComponentDetection.Detectors.Pnpm
                 {
                     foreach (var dependency in packageKeyValue.Value.dependencies)
                     {
-                        // Ignore file: as these are local packages.
-                        if (dependency.Key.StartsWith("file:"))
+                        // Ignore local packages.
+                        if (IsLocalDependency(dependency))
                         {
                             continue;
                         }
@@ -96,6 +96,13 @@ namespace Microsoft.ComponentDetection.Detectors.Pnpm
                     singleFileComponentRecorder.RegisterUsage(component.Value, isDevelopmentDependency: graph.IsDevelopmentDependency(explicitReference));
                 }
             }
+        }
+
+        private bool IsLocalDependency(KeyValuePair<string, string> dependency)
+        {
+            // Local dependencies are dependencies that live in the file system
+            // this requires an extra parsing that is not supported yet
+            return dependency.Key.StartsWith("file:") || dependency.Value.StartsWith("file:") || dependency.Value.StartsWith("link:");
         }
 
         private string CreatePnpmPackagePathFromDependency(string dependencyName, string dependencyVersion)


### PR DESCRIPTION
When the detector found a link dependency it failed the detection and the rest of components where not scanned. This change ignore the link dependencies and allow the dectector to continue parsing the rest of the file.