### PR TITLE
Add SourceDirectory to ScanResult output

### DIFF
--- a/src/Microsoft.ComponentDetection.Contracts/BcdeModels/ScanResult.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/BcdeModels/ScanResult.cs
@@ -16,5 +16,7 @@ namespace Microsoft.ComponentDetection.Contracts.BcdeModels
 
         [JsonConverter(typeof(StringEnumConverter))]
         public ProcessingResultCode ResultCode { get; set; }
+
+        public string SourceDirectory { get; set; }
     }
 }

--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/GraphTranslation/DefaultGraphTranslationService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/GraphTranslation/DefaultGraphTranslationService.cs
@@ -36,6 +36,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Services.GraphTranslation
                                                                     .Select(tuple => tuple.recorder)
                                                                     .Where(x => x != null)
                                                                     .Select(x => x.GetDependencyGraphsByLocation())),
+                SourceDirectory = detectionArguments.SourceDirectory.ToString(),
             };
         }
 

--- a/test/Microsoft.ComponentDetection.Contracts.Tests/ScanResultSerializationTests.cs
+++ b/test/Microsoft.ComponentDetection.Contracts.Tests/ScanResultSerializationTests.cs
@@ -52,6 +52,7 @@ namespace Microsoft.ComponentDetection.Contracts.Tests
                         Version = 2,
                     },
                 },
+                SourceDirectory = "D:\\test\\directory",
             };
         }
 
@@ -62,6 +63,7 @@ namespace Microsoft.ComponentDetection.Contracts.Tests
             var actual = JsonConvert.DeserializeObject<ScanResult>(serializedResult);
 
             actual.ResultCode.Should().Be(ProcessingResultCode.PartialSuccess);
+            actual.SourceDirectory.Should().Be("D:\\test\\directory");
             actual.ComponentsFound.Count().Should().Be(1);
             var actualDetectedComponent = actual.ComponentsFound.First();
             actualDetectedComponent.DetectorId.Should().Be("NpmDetectorId");
@@ -93,6 +95,7 @@ namespace Microsoft.ComponentDetection.Contracts.Tests
             JObject json = JObject.Parse(serializedResult);
 
             json.Value<string>("resultCode").Should().Be("PartialSuccess");
+            json.Value<string>("sourceDirectory").Should().Be("D:\\test\\directory");
             var foundComponent = json["componentsFound"].First();
 
             foundComponent.Value<string>("detectorId").Should().Be("NpmDetectorId");

--- a/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/BcdeDevCommandServiceTests.cs
+++ b/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/BcdeDevCommandServiceTests.cs
@@ -42,6 +42,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Tests.Services
                 ComponentsFound = scannedComponents,
                 ContainerDetailsMap = new Dictionary<int, ContainerDetails>(),
                 ResultCode = ProcessingResultCode.Success,
+                SourceDirectory = "D:\\test\\directory",
             };
 
             scanExecutionServiceMock.Setup(x => x.ExecuteScanAsync(It.IsAny<IDetectionArguments>()))
@@ -60,6 +61,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Tests.Services
 
             var result = serviceUnderTest.Handle(args);
             result.Result.ResultCode.Should().Be(ProcessingResultCode.Success);
+            result.Result.SourceDirectory.Should().Be("D:\\test\\directory");
         }
     }
 }

--- a/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/BcdeScanExecutionServiceTests.cs
+++ b/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/BcdeScanExecutionServiceTests.cs
@@ -245,6 +245,9 @@ namespace Microsoft.ComponentDetection.Orchestrator.Tests.Services
 
             var result = DetectComponentsHappyPath(args, restrictions => { }, new List<ComponentRecorder> { componentRecorder });
 
+            result.SourceDirectory.Should().NotBeNull();
+            result.SourceDirectory.Should().Be(sourceDirectory.ToString());
+
             result.Result.Should().Be(ProcessingResultCode.Success);
             result.DependencyGraphs.Count.Should().Be(1);
             var matchingGraph = result.DependencyGraphs.First();
@@ -300,6 +303,9 @@ namespace Microsoft.ComponentDetection.Orchestrator.Tests.Services
             singleFileComponentRecorderB.RegisterUsage(detectedComponents[0], parentComponentId: detectedComponents[1].Component.Id);
 
             var result = DetectComponentsHappyPath(args, restrictions => { }, new List<ComponentRecorder> { componentRecorder });
+
+            result.SourceDirectory.Should().NotBeNull();
+            result.SourceDirectory.Should().Be(sourceDirectory.ToString());
 
             result.Result.Should().Be(ProcessingResultCode.Success);
             result.DependencyGraphs.Count.Should().Be(1);
@@ -617,6 +623,8 @@ namespace Microsoft.ComponentDetection.Orchestrator.Tests.Services
 
             var result = serviceUnderTest.ExecuteScanAsync(args).Result;
             result.ResultCode.Should().Be(ProcessingResultCode.Success);
+            result.SourceDirectory.Should().NotBeNull();
+            result.SourceDirectory.Should().Be(args.SourceDirectorySerialized);
 
             var testOutput = new TestOutput((DefaultGraphScanResult)result);
 
@@ -660,6 +668,8 @@ namespace Microsoft.ComponentDetection.Orchestrator.Tests.Services
 
             var result = serviceUnderTest.ExecuteScanAsync(args).Result;
             result.ResultCode.Should().Be(ProcessingResultCode.Success);
+            result.SourceDirectory.Should().NotBeNull();
+            result.SourceDirectory.Should().Be(args.SourceDirectorySerialized);
 
             return result;
         }
@@ -682,6 +692,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Tests.Services
                 DetectedComponents = result.ComponentsFound;
                 DetectorsInRun = result.DetectorsInScan;
                 DependencyGraphs = result.DependencyGraphs;
+                SourceDirectory = result.SourceDirectory;
             }
 
             internal ProcessingResultCode Result { get; set; }
@@ -691,6 +702,8 @@ namespace Microsoft.ComponentDetection.Orchestrator.Tests.Services
             internal IEnumerable<Detector> DetectorsInRun { get; set; }
 
             internal DependencyGraphCollection DependencyGraphs { get; set; }
+
+            internal string SourceDirectory { get; set; }
         }
     }
 }


### PR DESCRIPTION
The lightweight approach for resolving #124 by including the argument for SourceDirectory in the outputted ScanResult and ScanManifest.json file.

![image](https://user-images.githubusercontent.com/23140950/176254271-3dbb4996-b834-4fee-949c-11edec2f4268.png)

While normalizing to absolute path for `locationsFoundAt` was considered, there is tooling built around this being a relative path. Adding an absolute path companion matching `locationsFoundAt` was tested, but this drastically increased output size.