### PR TITLE
chore: add basic renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+﻿{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:base"]
+}


### PR DESCRIPTION
As part of a pilot rollout of [Renovate](https://github.com/renovatebot/renovate/), I've enrolled our repository. This configuration is a minimal configuration, that imports the [`config:base`](https://docs.renovatebot.com/presets-config/#configbase) preset.