### PR TITLE
Increase experimental detection timeout

### DIFF
--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/DetectorProcessingService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/DetectorProcessingService.cs
@@ -164,7 +164,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Services
 
             try
             {
-                return await AsyncExecution.ExecuteWithTimeoutAsync(detectionTaskGenerator, TimeSpan.FromMinutes(2), CancellationToken.None);
+                return await AsyncExecution.ExecuteWithTimeoutAsync(detectionTaskGenerator, TimeSpan.FromMinutes(4), CancellationToken.None);
             }
             catch (TimeoutException)
             {


### PR DESCRIPTION
## Context

There is ongoing work on a Conda detector, but the env dry runs make a scan to take longer. Let's slightly increase the experimental timeout to see how much timeouts do we still experience, otherwise we will need to redesign the Conda detector approach or come up with proper guardrails