### PR TITLE
Special case scratch base image

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,7 @@
     <ItemGroup>
         <PackageVersion Include="CommandLineParser" Version="2.9.1"/>
         <PackageVersion Include="coverlet.msbuild" Version="3.1.2"/>
-        <PackageVersion Include="Docker.DotNet" Version="3.125.5"/>
+        <PackageVersion Include="Docker.DotNet" Version="3.125.10"/>
         <PackageVersion Include="FluentAssertions" Version="6.7.0"/>
         <PackageVersion Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9"/>
         <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="3.1.26" />

--- a/src/Microsoft.ComponentDetection.Detectors/linux/LinuxContainerDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/linux/LinuxContainerDetector.cs
@@ -214,10 +214,14 @@ namespace Microsoft.ComponentDetection.Detectors.Linux
                 record.BaseImageLayerMessage = $"Base image annotations not found on image {image}, Results will not be mapped to base image layers";
                 Logger.LogInfo(record.BaseImageLayerMessage);
                 return 0;
+            } else if (scannedImageDetails.BaseImageRef == "scratch") {
+                record.BaseImageLayerMessage = $"{image} has no base image";
+                Logger.LogInfo(record.BaseImageLayerMessage);
+                return 0;
             }
 
             var baseImageDigest = scannedImageDetails.BaseImageDigest;
-            var refWithDigest = scannedImageDetails.BaseImageRef + (baseImageDigest != string.Empty ? $"@{baseImageDigest}" : string.Empty);
+            var refWithDigest = scannedImageDetails.BaseImageRef + (!string.IsNullOrEmpty(baseImageDigest) ? $"@{baseImageDigest}" : string.Empty);
             record.BaseImageDigest = baseImageDigest;
             record.BaseImageRef = scannedImageDetails.BaseImageRef;
 


### PR DESCRIPTION
If a container image has a image.base.ref.name of scratch then determine that there is no base image, rather than trying to pull "scratch".

In v1.1.9 component-detection tries to pull the "scratch@" image, which fails causing the following log to be displayed:
```
 [INFO] Base image scratch@ could not be found locally and could not be pulled. Results will not be mapped to base image layers 
```

In v1.2.4 component-detection still tries to pull the "scratch@" image but this time the TryPullImageAsync call at https://github.com/microsoft/component-detection/blob/0319816fabb129ec043a270bc0fb1d9763986101/src/Microsoft.ComponentDetection.Detectors/linux/LinuxContainerDetector.cs#L225 must be succeeding, as component-detection doesn't omit that log, but subsequently hits an error like
```
[WARN] Scanning of image sha256:26f452efc71ea50bb61043de65c4fbbfcda3677ca6f013690898bfd286f22081 failed with exception: Object reference not set to an instance of an object. 
```

Looking at the changes between those releases, possibly the bump of Docker.Dotnet from 3.125.4 to 3.124.5 caused this change of behaviour. I can't verify that easily though as I'm hitting https://github.com/dotnet/Docker.DotNet/issues/554, hence the bump to Docker.Dotnet to 3.125.10

Anyway, it seems sensible to special case scratch in this case.