### PR TITLE
feat: add `NuGetPackagesConfigDetector`

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/nuget/NuGetPackagesConfigDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/nuget/NuGetPackagesConfigDetector.cs
@@ -1,0 +1,44 @@
+﻿namespace Microsoft.ComponentDetection.Detectors.NuGet
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Composition;
+    using System.Threading.Tasks;
+    using global::NuGet.Packaging;
+    using Microsoft.ComponentDetection.Contracts;
+    using Microsoft.ComponentDetection.Contracts.Internal;
+    using Microsoft.ComponentDetection.Contracts.TypedComponent;
+
+    [Export(typeof(IComponentDetector))]
+    public class NuGetPackagesConfigDetector : FileComponentDetector, IExperimentalDetector
+    {
+        public override IList<string> SearchPatterns => new[] { "packages.config" };
+
+        public override string Id => "NuGetPackagesConfig";
+
+        public override IEnumerable<string> Categories =>
+            new[] { Enum.GetName(typeof(DetectorClass), DetectorClass.NuGet) };
+
+        public override IEnumerable<ComponentType> SupportedComponentTypes => new[] { ComponentType.NuGet };
+
+        public override int Version => 1;
+
+        protected override Task OnFileFound(ProcessRequest processRequest, IDictionary<string, string> detectorArgs)
+        {
+            var packagesConfig = new PackagesConfigReader(processRequest.ComponentStream.Stream);
+            foreach (var package in packagesConfig.GetPackages())
+            {
+                processRequest.SingleFileComponentRecorder.RegisterUsage(
+                    new DetectedComponent(
+                        new NuGetComponent(
+                            package.PackageIdentity.Id,
+                            package.PackageIdentity.Version.ToNormalizedString())),
+                    true,
+                    null,
+                    package.IsDevelopmentDependency);
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/Microsoft.ComponentDetection.Detectors.Tests.csproj
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/Microsoft.ComponentDetection.Detectors.Tests.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <ItemGroup Label="Project References">
-        <ProjectReference Include="..\Microsoft.ComponentDetection.TestsUtilities\Microsoft.ComponentDetection.TestsUtilities.csproj"/>
+        <ProjectReference Include="..\Microsoft.ComponentDetection.TestsUtilities\Microsoft.ComponentDetection.TestsUtilities.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="NuGet.Versioning"/>
-        <PackageReference Include="System.Reactive"/>
-        <PackageReference Include="packageurl-dotnet"/>
+        <PackageReference Include="NuGet.Versioning" />
+        <PackageReference Include="System.Reactive" />
+        <PackageReference Include="packageurl-dotnet" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/nuget/NuGetPackagesConfigDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/nuget/NuGetPackagesConfigDetectorTests.cs
@@ -1,0 +1,45 @@
+﻿namespace Microsoft.ComponentDetection.Detectors.Tests.NuGet
+{
+    using System.Threading.Tasks;
+    using Contracts;
+    using Contracts.TypedComponent;
+    using Detectors.NuGet;
+    using FluentAssertions;
+    using TestsUtilities;
+    using VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class NuGetPackagesConfigDetectorTests
+    {
+        private DetectorTestUtility<NuGetPackagesConfigDetector> detectorTestUtility;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            var detector = new NuGetPackagesConfigDetector();
+            this.detectorTestUtility = new DetectorTestUtility<NuGetPackagesConfigDetector>().WithDetector(detector);
+        }
+
+        [TestMethod]
+        public async Task Should_Work()
+        {
+            var packagesConfig =
+                @"<?xml version=""1.0"" encoding=""utf-8""?>
+                <packages>
+                    <package id=""jQuery"" version=""3.1.1"" targetFramework=""net46"" />
+                    <package id=""NLog"" version=""4.3.10"" targetFramework=""net46"" />
+                </packages>";
+
+            var (scanResult, componentRecorder) = await this.detectorTestUtility
+                .WithFile("packages.config", packagesConfig)
+                .ExecuteDetector()
+                .ConfigureAwait(true);
+
+            var detectedComponents = componentRecorder.GetDetectedComponents();
+            detectedComponents.Should().NotBeEmpty()
+                .And.HaveCount(2)
+                .And.ContainEquivalentOf(new DetectedComponent(new NuGetComponent("jQuery", "3.1.1")))
+                .And.ContainEquivalentOf(new DetectedComponent(new NuGetComponent("NLog", "4.3.10")));
+        }
+    }
+}

--- a/test/Microsoft.ComponentDetection.VerificationTests/resources/nuget/packages-config/packages.config
+++ b/test/Microsoft.ComponentDetection.VerificationTests/resources/nuget/packages-config/packages.config
@@ -1,0 +1,67 @@
+﻿<!-- https://github.com/dotnet/Kerberos.NET/blob/559bec87d6eb1fb8698418c3aacafbbc7c32bdec/Samples/KerberosWebSample/packages.config -->
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net452" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net452" />
+  <package id="Microsoft.AspNet.WebApi.Owin" version="5.2.3" targetFramework="net452" />
+  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net452" />
+  <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="1.0.7" targetFramework="net462" />
+  <package id="Microsoft.Extensions.Caching.Abstractions" version="2.0.0" targetFramework="net462" />
+  <package id="Microsoft.Extensions.Caching.Memory" version="2.0.0" targetFramework="net462" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.0.0" targetFramework="net462" />
+  <package id="Microsoft.Extensions.Options" version="2.0.0" targetFramework="net462" />
+  <package id="Microsoft.Extensions.Primitives" version="2.0.0" targetFramework="net462" />
+  <package id="Microsoft.Net.Compilers" version="2.3.1" targetFramework="net462" developmentDependency="true" />
+  <package id="Microsoft.NETCore.Platforms" version="2.0.0" targetFramework="net462" />
+  <package id="Microsoft.Owin" version="3.1.0" targetFramework="net462" />
+  <package id="Microsoft.Owin.Host.SystemWeb" version="3.1.0" targetFramework="net462" />
+  <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net462" />
+  <package id="NETStandard.Library" version="2.0.0" targetFramework="net462" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net462" />
+  <package id="Owin" version="1.0" targetFramework="net452" />
+  <package id="System.AppContext" version="4.3.0" targetFramework="net462" />
+  <package id="System.Collections" version="4.3.0" targetFramework="net462" />
+  <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net462" />
+  <package id="System.ComponentModel" version="4.3.0" targetFramework="net462" />
+  <package id="System.Console" version="4.3.0" targetFramework="net462" />
+  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net462" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.1" targetFramework="net462" />
+  <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net462" />
+  <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net462" />
+  <package id="System.Globalization" version="4.3.0" targetFramework="net462" />
+  <package id="System.Globalization.Calendars" version="4.3.0" targetFramework="net462" />
+  <package id="System.IO" version="4.3.0" targetFramework="net462" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net462" />
+  <package id="System.IO.Compression.ZipFile" version="4.3.0" targetFramework="net462" />
+  <package id="System.IO.FileSystem" version="4.3.0" targetFramework="net462" />
+  <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net462" />
+  <package id="System.Linq" version="4.3.0" targetFramework="net462" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net462" />
+  <package id="System.Net.Http" version="4.3.4" targetFramework="net462" />
+  <package id="System.Net.Primitives" version="4.3.0" targetFramework="net462" />
+  <package id="System.Net.Sockets" version="4.3.0" targetFramework="net462" />
+  <package id="System.ObjectModel" version="4.3.0" targetFramework="net462" />
+  <package id="System.Reflection" version="4.3.0" targetFramework="net462" />
+  <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net462" />
+  <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="net462" />
+  <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net462" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="net462" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.4.0" targetFramework="net462" />
+  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net462" />
+  <package id="System.Runtime.Handles" version="4.3.0" targetFramework="net462" />
+  <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net462" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net462" />
+  <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net462" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net462" />
+  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net462" />
+  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net462" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net462" />
+  <package id="System.Text.Encoding" version="4.3.0" targetFramework="net462" />
+  <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net462" />
+  <package id="System.Text.RegularExpressions" version="4.3.1" targetFramework="net462" />
+  <package id="System.Threading" version="4.3.0" targetFramework="net462" />
+  <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net462" />
+  <package id="System.Threading.Timer" version="4.3.0" targetFramework="net462" />
+  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net462" />
+  <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net462" />
+</packages>


### PR DESCRIPTION
This change adds a new `NuGetPackagesConfigDetector` for 'old-style' NuGet projects that use `packages.config`. The intention is to replace the `NuGetComponentDetector` with this detector, as it is overreporting NuGet components (due to how nuget restores packages on disk).

TODO:
- [x] Add snapshot test
- [ ] Update documentation
- [x] More local testing
  - See https://github.com/search?q=org%3Adotnet+filename%3Apackages.config

References:
- [packages.config reference](https://docs.microsoft.com/en-us/nuget/reference/packages-config)
- [Migrate from packages.config to PackageReference](https://docs.microsoft.com/en-us/nuget/consume-packages/migrate-packages-config-to-package-reference)

Signed-off-by: Jamie Magee <jamagee@microsoft.com>