### PR TITLE
Add missing VcpkgComponent converter and use port version as int

### DIFF
--- a/src/Microsoft.ComponentDetection.Contracts/BcdeModels/TypedComponentConverter.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/BcdeModels/TypedComponentConverter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Newtonsoft.Json;
@@ -24,6 +24,7 @@ namespace Microsoft.ComponentDetection.Contracts.BcdeModels
             { ComponentType.Linux, typeof(LinuxComponent) },
             { ComponentType.Conda, typeof(CondaComponent) },
             { ComponentType.DockerReference, typeof(DockerReferenceComponent) },
+            { ComponentType.Vcpkg, typeof(VcpkgComponent) }
         };
 
         public override bool CanConvert(Type objectType)

--- a/src/Microsoft.ComponentDetection.Contracts/TypedComponent/VcpkgComponent.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/TypedComponent/VcpkgComponent.cs
@@ -1,4 +1,4 @@
-﻿using PackageUrl;
+using PackageUrl;
 
 namespace Microsoft.ComponentDetection.Contracts.TypedComponent
 {
@@ -11,10 +11,12 @@ namespace Microsoft.ComponentDetection.Contracts.TypedComponent
 
         public VcpkgComponent(string spdxid, string name, string version, string triplet = null, string portVersion = null, string description = null, string downloadLocation = null)
         {
+            int.TryParse(portVersion, out var port);
+
             SPDXID = ValidateRequiredInput(spdxid, nameof(SPDXID), nameof(ComponentType.Vcpkg));
             Name = ValidateRequiredInput(name, nameof(Name), nameof(ComponentType.Vcpkg));
             Version = version;
-            PortVersion = portVersion;
+            PortVersion = port;
             Triplet = triplet;
             Description = description;
             DownloadLocation = downloadLocation;
@@ -32,7 +34,7 @@ namespace Microsoft.ComponentDetection.Contracts.TypedComponent
 
         public string Description { get; set; }
 
-        public string PortVersion { get; set; }
+        public int PortVersion { get; set; }
 
         public override ComponentType Type => ComponentType.Vcpkg;
 
@@ -55,7 +57,7 @@ namespace Microsoft.ComponentDetection.Contracts.TypedComponent
         {
             get
             {
-                if (PortVersion != null)
+                if (PortVersion > 0)
                 {
                     return new PackageURL($"pkg:vcpkg/{Name}@{Version}?port_version={PortVersion}");
                 }

--- a/src/Microsoft.ComponentDetection.Contracts/TypedComponent/VcpkgComponent.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/TypedComponent/VcpkgComponent.cs
@@ -42,7 +42,7 @@ namespace Microsoft.ComponentDetection.Contracts.TypedComponent
         {
             get
             {
-                if (PortVersion != null)
+                if (PortVersion > 0)
                 {
                     return $"{Name} {Version}#{PortVersion} - {Type}";
                 }

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/VcpkgComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/VcpkgComponentDetectorTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         {
             ""name"": ""nlohmann-json"",
             ""SPDXID"": ""SPDXRef-port"",
-            ""versionInfo"": ""3.10.4"",
+            ""versionInfo"": ""3.10.4#5"",
             ""downloadLocation"": ""git+https://github.com/Microsoft/vcpkg#ports/nlohmann-json"",
             ""homepage"": ""https://github.com/nlohmann/json"",
             ""licenseConcluded"": ""NOASSERTION"",
@@ -67,10 +67,10 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
             Assert.AreEqual(1, components.Count());
             Assert.AreEqual("nlohmann-json", sbomComponent.Name);
             Assert.AreEqual("3.10.4", sbomComponent.Version);
-            Assert.AreEqual("0", sbomComponent.PortVersion);
+            Assert.AreEqual(5, sbomComponent.PortVersion);
             Assert.AreEqual("SPDXRef-port", sbomComponent.SPDXID);
             Assert.AreEqual("git+https://github.com/Microsoft/vcpkg#ports/nlohmann-json", sbomComponent.DownloadLocation);
-            Assert.AreEqual("pkg:vcpkg/nlohmann-json@3.10.4?port_version=0", sbomComponent.PackageUrl.ToString());
+            Assert.AreEqual("pkg:vcpkg/nlohmann-json@3.10.4?port_version=5", sbomComponent.PackageUrl.ToString());
         }
 
         [TestMethod]


### PR DESCRIPTION
## Context

VcpkgComponent detector is still in piloting phase, which means is disabled by default. We noticed we were missing the TypedComponentConverter for this new type, which was breaking any wrapper tool looking to deserialize the output json file.

We also noticed that port versions are set as integers on GitHub rather than string, hence we are updating the component to reflect this value.

See sample port version file in VCPKG Forge: https://github.com/microsoft/vcpkg/blob/master/versions/w-/wampcc.json