### PR TITLE
Packable TestUtilities project

### DIFF
--- a/test/Microsoft.ComponentDetection.TestsUtilities/Microsoft.ComponentDetection.TestsUtilities.csproj
+++ b/test/Microsoft.ComponentDetection.TestsUtilities/Microsoft.ComponentDetection.TestsUtilities.csproj
@@ -4,5 +4,7 @@
         <ProjectReference Include="..\..\src\Microsoft.ComponentDetection.Detectors\Microsoft.ComponentDetection.Detectors.csproj"/>
         <PackageReference Include="System.Reactive"/>
     </ItemGroup>
-
+    <PropertyGroup>
+        <IsPackable>true</IsPackable>
+    </PropertyGroup>
 </Project>


### PR DESCRIPTION
# Context
IsPackable property was removed recently with the assumption it didn't add value outside the tests in this repo, but it does, it helps wrappers and users do unit tests for the detectors without having to start from scratch.