### PR TITLE
Detect python components from Linux containers

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,7 @@
     <ItemGroup>
         <PackageVersion Include="CommandLineParser" Version="2.9.1"/>
         <PackageVersion Include="coverlet.msbuild" Version="3.1.2"/>
-        <PackageVersion Include="Docker.DotNet" Version="3.125.5"/>
+        <PackageVersion Include="Docker.DotNet" Version="3.125.10"/>
         <PackageVersion Include="FluentAssertions" Version="6.7.0"/>
         <PackageVersion Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9"/>
         <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="3.1.26" />

--- a/src/Microsoft.ComponentDetection.Common/Telemetry/Records/LinuxScannerSyftTelemetryRecord.cs
+++ b/src/Microsoft.ComponentDetection.Common/Telemetry/Records/LinuxScannerSyftTelemetryRecord.cs
@@ -4,7 +4,7 @@ namespace Microsoft.ComponentDetection.Common.Telemetry.Records
     {
         public override string RecordName => "LinuxScannerSyftTelemetry";
         
-        public string LinuxComponents { get; set; }
+        public string Components { get; set; }
 
         public string Exception { get; set; }
     }

--- a/src/Microsoft.ComponentDetection.Contracts/BcdeModels/LayerMappedLinuxComponents.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/BcdeModels/LayerMappedLinuxComponents.cs
@@ -5,7 +5,7 @@ namespace Microsoft.ComponentDetection.Contracts.BcdeModels
 {
         public class LayerMappedLinuxComponents 
         {
-            public IEnumerable<LinuxComponent> LinuxComponents { get; set; }
+            public IEnumerable<TypedComponent.TypedComponent> Components { get; set; }
 
             public DockerLayer DockerLayer { get; set; }
         }

--- a/src/Microsoft.ComponentDetection.Detectors/linux/LinuxContainerDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/linux/LinuxContainerDetector.cs
@@ -32,9 +32,9 @@ namespace Microsoft.ComponentDetection.Detectors.Linux
 
         public IEnumerable<string> Categories => new[] { Enum.GetName(typeof(DetectorClass), DetectorClass.Linux) };
 
-        public IEnumerable<ComponentType> SupportedComponentTypes => new[] { ComponentType.Linux };
+        public IEnumerable<ComponentType> SupportedComponentTypes => new[] { ComponentType.Linux, ComponentType.Pip };
 
-        public int Version => 4;
+        public int Version => 5;
 
         public bool NeedsAutomaticRootDependencyCalculation => false;
 
@@ -142,7 +142,7 @@ namespace Microsoft.ComponentDetection.Detectors.Linux
 
                     var layers = await LinuxScanner.ScanLinuxAsync(kvp.Value.ImageId, internalContainerDetails.Layers, baseImageLayerCount, cancellationToken);
 
-                    var components = layers.SelectMany(layer => layer.LinuxComponents.Select(linuxComponent => new DetectedComponent(linuxComponent,  null, internalContainerDetails.Id, layer.DockerLayer.LayerIndex)));
+                    var components = layers.SelectMany(layer => layer.Components.Select(component => new DetectedComponent(component,  null, internalContainerDetails.Id, layer.DockerLayer.LayerIndex)));
                     internalContainerDetails.Layers = layers.Select(layer => layer.DockerLayer);
                     var singleFileComponentRecorder = componentRecorder.CreateSingleFileComponentRecorder(kvp.Value.ImageId);
                     components.ToList().ForEach(detectedComponent => singleFileComponentRecorder.RegisterUsage(detectedComponent, true));

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/LinuxContainerDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/LinuxContainerDetectorTests.cs
@@ -23,12 +23,13 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         private const string NodeLatestImage = "node:latest";
         private const string NodeLatestDigest = "2a22e4a1a550";
         private const string BashPackageId = "Ubuntu 20.04 bash 5.0-6ubuntu1 - Linux";
+        private const string RequestsPackageId = "requests 2.18.4 - pip";
 
         private static readonly IEnumerable<LayerMappedLinuxComponents> LinuxComponents = new List<LayerMappedLinuxComponents>
             {
                 new LayerMappedLinuxComponents {
                     DockerLayer = new DockerLayer { },
-                    LinuxComponents = new List<LinuxComponent> { new LinuxComponent("Ubuntu", "20.04", "bash", "5.0-6ubuntu1") },
+                    Components = new List<TypedComponent> { new LinuxComponent("Ubuntu", "20.04", "bash", "5.0-6ubuntu1"), new PipComponent("requests", "2.18.4") },
                 },
             };
 
@@ -74,9 +75,11 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
             var detectedComponents = componentRecorder.GetDetectedComponents().ToList();
 
             scanResult.ResultCode.Should().Be(ProcessingResultCode.Success);
-            detectedComponents.Should().ContainSingle();
-            detectedComponents.First().Component.Id.Should().Be(BashPackageId);
-            scanResult.ContainerDetails.Should().ContainSingle();
+            detectedComponents.Should().HaveCount(2);
+            var bash = detectedComponents.Single(component => (component.Component is LinuxComponent));
+            bash.Component.Id.Should().Be(BashPackageId);
+            var requests = detectedComponents.Single(component => (component.Component is PipComponent));
+            requests.Component.Id.Should().Be(RequestsPackageId);
             detectedComponents.All(dc => dc.ContainerDetailIds.Contains(scanResult.ContainerDetails.First().Id)).Should().BeTrue();
             componentRecorder.GetDetectedComponents().Select(detectedComponent => detectedComponent.Component.Id)
                 .Should().BeEquivalentTo(detectedComponents.Select(detectedComponent => detectedComponent.Component.Id));
@@ -155,8 +158,11 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
             var detectedComponents = componentRecorder.GetDetectedComponents().ToList();
 
             scanResult.ResultCode.Should().Be(ProcessingResultCode.Success);
-            detectedComponents.Should().ContainSingle();
-            detectedComponents.First().Component.Id.Should().Be(BashPackageId);
+            detectedComponents.Should().HaveCount(2);
+            var bash = detectedComponents.Single(component => (component.Component is LinuxComponent));
+            bash.Component.Id.Should().Be(BashPackageId);
+            var requests = detectedComponents.Single(component => (component.Component is PipComponent));
+            requests.Component.Id.Should().Be(RequestsPackageId);
             scanResult.ContainerDetails.Should().HaveCount(1);
             detectedComponents.All(dc => dc.ContainerDetailIds.Contains(scanResult.ContainerDetails.First().Id)).Should().BeTrue();
         }
@@ -182,8 +188,11 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
 
             scanResult.ResultCode.Should().Be(ProcessingResultCode.Success);
             scanResult.ContainerDetails.Should().HaveCount(1);
-            detectedComponents.Should().HaveCount(1);
-            detectedComponents.First().Component.Id.Should().Be(BashPackageId);
+            detectedComponents.Should().HaveCount(2);
+            var bash = detectedComponents.Single(component => (component.Component is LinuxComponent));
+            bash.Component.Id.Should().Be(BashPackageId);
+            var requests = detectedComponents.Single(component => (component.Component is PipComponent));
+            requests.Component.Id.Should().Be(RequestsPackageId);
             detectedComponents.All(dc => dc.ContainerDetailIds.Contains(scanResult.ContainerDetails.First().Id)).Should().BeTrue();
             mockSyftLinuxScanner.Verify(scanner => scanner.ScanLinuxAsync(It.IsAny<string>(), It.IsAny<IEnumerable<DockerLayer>>(), It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Once);
         }

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/LinuxScannerTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/LinuxScannerTests.cs
@@ -6,6 +6,7 @@ using FluentAssertions;
 using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Contracts.BcdeModels;
 using Microsoft.ComponentDetection.Detectors.Linux;
+using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 
@@ -32,6 +33,25 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
                                 ""layerID"": ""sha256:f95fc50d21d981f1efe1f04109c2c3287c271794f5d9e4fdf9888851a174a971""
                             }
                         ]
+                    },
+                    {
+                        ""name"": ""requests"",
+                        ""version"": ""2.18.4"",
+                        ""type"":""python"",
+                        ""locations"": [
+                            {
+                                ""path"": ""/usr/lib/python3.6/site-packages/requests-2.18.4.dist-info/METADATA"",
+                                ""layerID"": ""sha256:f95fc50d21d981f1efe1f04109c2c3287c271794f5d9e4fdf9888851a174a971""
+                            },
+                            {
+                                ""path"": ""/usr/lib/python3.6/site-packages/requests-2.18.4.dist-info/RECORD"",
+                                ""layerID"": ""sha256:f95fc50d21d981f1efe1f04109c2c3287c271794f5d9e4fdf9888851a174a971""
+                            },
+                            {
+                                ""path"": ""/usr/lib/python3.6/site-packages/requests-2.18.4.dist-info/top_level.txt"",
+                                ""layerID"": ""sha256:f95fc50d21d981f1efe1f04109c2c3287c271794f5d9e4fdf9888851a174a971""
+                            }
+                        ],
                     }
                 ]
             }";
@@ -55,14 +75,18 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         [TestMethod]
         public async Task TestLinuxScanner()
         {
-            var result = (await linuxScanner.ScanLinuxAsync("fake_hash", new[] { new DockerLayer { LayerIndex = 0, DiffId = "sha256:f95fc50d21d981f1efe1f04109c2c3287c271794f5d9e4fdf9888851a174a971" } }, 0)).First().LinuxComponents;
+            var result = (await linuxScanner.ScanLinuxAsync("fake_hash", new[] { new DockerLayer { LayerIndex = 0, DiffId = "sha256:f95fc50d21d981f1efe1f04109c2c3287c271794f5d9e4fdf9888851a174a971" } }, 0)).First().Components.ToList();
 
-            result.Should().HaveCount(1);
-            var package = result.First();
+            result.Should().HaveCount(2);
+            var package = (LinuxComponent) result[0];
             package.Name.Should().Be("test");
             package.Version.Should().Be("1.0.0");
             package.Release.Should().Be("1.0.0");
             package.Distribution.Should().Be("test-distribution");
+
+            var pipPackage = (PipComponent) result[1];
+            pipPackage.Name.Should().Be("requests");
+            pipPackage.Version.Should().Be("2.18.4");
         }
     }
 }


### PR DESCRIPTION
Azure for Operators have many small teams producing Linux container images and sharing them with other teams. We want the consuming teams to be registering the components from those container images with Component Governance, in order for the consuming team to meet various OSS requirements.

To that end, we need component-detection to detect more component types in Linux containers than just OS packages.

This PR adds support for python package detection in containers as that is a) used by our teams b) supported by syft and component-detection. I expect we'll want to add more non-Linux types in future (e.g java, ruby gems).

Are you ok with this approach?
Should I put this behind a feature flag initially that we can enable in Azure for Operators? I'll update the docs/readme after we've decided these.