### PR TITLE
fix: dockerfile detector detector class type

### DIFF
--- a/src/Microsoft.ComponentDetection.Contracts/DetectorClass.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/DetectorClass.cs
@@ -41,5 +41,8 @@
 
         /// <summary>Indicates a detector applies to Vcpkg packages.</summary>
         Vcpkg,
+
+        /// <summary>Indicates a detector applies to Docker references.</summary>
+        DockerReference,
     }
 }

--- a/src/Microsoft.ComponentDetection.Detectors/dockerfile/DockerfileComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/dockerfile/DockerfileComponentDetector.cs
@@ -24,7 +24,7 @@ namespace Microsoft.ComponentDetection.Detectors.Dockerfile
 
         public override string Id { get; } = "DockerReference";
 
-        public override IEnumerable<string> Categories => new[] { Enum.GetName(typeof(DetectorClass), DetectorClass.GoMod) };
+        public override IEnumerable<string> Categories => new[] { Enum.GetName(typeof(DetectorClass), DetectorClass.DockerReference) };
 
         public override IList<string> SearchPatterns { get; } = new List<string> { "dockerfile", "dockerfile.*", "*.dockerfile" };
 


### PR DESCRIPTION
Previously it was incorrectly listed as `GoMod`. It requires a new `DockerReference` type instead.