### PR TITLE
refactor: use `var` in place of explicit types

### DIFF
--- a/src/Microsoft.ComponentDetection.Common/AsyncExecution.cs
+++ b/src/Microsoft.ComponentDetection.Common/AsyncExecution.cs
@@ -13,9 +13,9 @@ namespace Microsoft.ComponentDetection.Common
                 throw new ArgumentNullException(nameof(toExecute));
             }
 
-            Task<T> work = Task.Run(toExecute);
+            var work = Task.Run(toExecute);
 
-            bool completedInTime = await Task.Run(() => work.Wait(timeout));
+            var completedInTime = await Task.Run(() => work.Wait(timeout));
             if (!completedInTime)
             {
                 throw new TimeoutException($"The execution did not complete in the alotted time ({timeout.TotalSeconds} seconds) and has been terminated prior to completion");
@@ -31,8 +31,8 @@ namespace Microsoft.ComponentDetection.Common
                 throw new ArgumentNullException(nameof(toExecute));
             }
 
-            Task work = Task.Run(toExecute);
-            bool completedInTime = await Task.Run(() => work.Wait(timeout));
+            var work = Task.Run(toExecute);
+            var completedInTime = await Task.Run(() => work.Wait(timeout));
             if (!completedInTime)
             {
                 throw new TimeoutException($"The execution did not complete in the alotted time ({timeout.TotalSeconds} seconds) and has been terminated prior to completion");

--- a/src/Microsoft.ComponentDetection.Common/CommandLineInvocationService.cs
+++ b/src/Microsoft.ComponentDetection.Common/CommandLineInvocationService.cs
@@ -22,7 +22,7 @@ namespace Microsoft.ComponentDetection.Common
             additionalCandidateCommands = additionalCandidateCommands ?? Enumerable.Empty<string>();
             parameters = parameters ?? new string[0];
             var allCommands = new[] { command }.Concat(additionalCandidateCommands);
-            if (!this.commandLocatableCache.TryGetValue(command, out string validCommand))
+            if (!this.commandLocatableCache.TryGetValue(command, out var validCommand))
             {
                 foreach (var commandToTry in allCommands)
                 {
@@ -119,8 +119,8 @@ namespace Microsoft.ComponentDetection.Common
                 process.StartInfo.WorkingDirectory = workingDirectory.FullName;
             }
 
-            string errorText = string.Empty;
-            string stdOutText = string.Empty;
+            var errorText = string.Empty;
+            var stdOutText = string.Empty;
 
             var t1 = new Task(() =>
             {

--- a/src/Microsoft.ComponentDetection.Common/ComponentStreamEnumerableFactory.cs
+++ b/src/Microsoft.ComponentDetection.Common/ComponentStreamEnumerableFactory.cs
@@ -18,13 +18,13 @@ namespace Microsoft.ComponentDetection.Common
 
         public IEnumerable<IComponentStream> GetComponentStreams(DirectoryInfo directory, IEnumerable<string> searchPatterns, ExcludeDirectoryPredicate directoryExclusionPredicate, bool recursivelyScanDirectories = true)
         {
-            SafeFileEnumerable enumerable = new SafeFileEnumerable(directory, searchPatterns, this.Logger, this.PathUtilityService, directoryExclusionPredicate, recursivelyScanDirectories);
+            var enumerable = new SafeFileEnumerable(directory, searchPatterns, this.Logger, this.PathUtilityService, directoryExclusionPredicate, recursivelyScanDirectories);
             return new ComponentStreamEnumerable(enumerable, this.Logger);
         }
 
         public IEnumerable<IComponentStream> GetComponentStreams(DirectoryInfo directory, Func<FileInfo, bool> fileMatchingPredicate, ExcludeDirectoryPredicate directoryExclusionPredicate, bool recursivelyScanDirectories = true)
         {
-            SafeFileEnumerable enumerable = new SafeFileEnumerable(directory, fileMatchingPredicate, this.Logger, this.PathUtilityService, directoryExclusionPredicate, recursivelyScanDirectories);
+            var enumerable = new SafeFileEnumerable(directory, fileMatchingPredicate, this.Logger, this.PathUtilityService, directoryExclusionPredicate, recursivelyScanDirectories);
             return new ComponentStreamEnumerable(enumerable, this.Logger);
         }
     }

--- a/src/Microsoft.ComponentDetection.Common/DependencyGraph/ComponentRecorder.cs
+++ b/src/Microsoft.ComponentDetection.Common/DependencyGraph/ComponentRecorder.cs
@@ -164,7 +164,7 @@ namespace Microsoft.ComponentDetection.Common.DependencyGraph
                 }
 #endif
 
-                string componentId = detectedComponent.Component.Id;
+                var componentId = detectedComponent.Component.Id;
                 DetectedComponent storedComponent = null;
                 lock (this.registerUsageLock)
                 {

--- a/src/Microsoft.ComponentDetection.Common/DockerReference/DigestUtility.cs
+++ b/src/Microsoft.ComponentDetection.Common/DockerReference/DigestUtility.cs
@@ -26,7 +26,7 @@ namespace Microsoft.ComponentDetection.Common
                 return false;
             }
 
-            string algorithm = digest.Substring(0, indexOfColon);
+            var algorithm = digest.Substring(0, indexOfColon);
 
             if (!AlgorithmsSizes.ContainsKey(algorithm))
             {

--- a/src/Microsoft.ComponentDetection.Common/DockerReference/DockerReferenceUtility.cs
+++ b/src/Microsoft.ComponentDetection.Common/DockerReference/DockerReferenceUtility.cs
@@ -39,7 +39,7 @@ namespace Microsoft.ComponentDetection.Common
 
         public static DockerReference ParseQualifiedName(string qualifiedName)
         {
-            Regex regexp = DockerRegex.ReferenceRegexp;
+            var regexp = DockerRegex.ReferenceRegexp;
             if (!regexp.IsMatch(qualifiedName))
             {
                 if (string.IsNullOrWhiteSpace(qualifiedName))
@@ -63,7 +63,7 @@ namespace Microsoft.ComponentDetection.Common
                 throw new ReferenceNameTooLongException(name);
             }
 
-            Reference reference = new Reference();
+            var reference = new Reference();
 
             var nameMatch = DockerRegex.AnchoredNameRegexp.Match(name).Groups;
             if (nameMatch.Count == 3)
@@ -93,7 +93,7 @@ namespace Microsoft.ComponentDetection.Common
             string domain;
             string reminder;
 
-            int indexOfSlash = name.IndexOf('/');
+            var indexOfSlash = name.IndexOf('/');
             if (indexOfSlash == -1 || !(
                 name.LastIndexOf('.', indexOfSlash) != -1 ||
                 name.LastIndexOf(':', indexOfSlash) != -1 ||
@@ -128,10 +128,10 @@ namespace Microsoft.ComponentDetection.Common
                 throw new ReferenceNameNotCanonicalException(name);
             }
 
-            (string domain, string remainder) = SplitDockerDomain(name);
+            (var domain, var remainder) = SplitDockerDomain(name);
 
             string remoteName;
-            int tagSeparatorIndex = remainder.IndexOf(':');
+            var tagSeparatorIndex = remainder.IndexOf(':');
             if (tagSeparatorIndex > -1)
             {
                 remoteName = remainder.Substring(0, tagSeparatorIndex);

--- a/src/Microsoft.ComponentDetection.Common/EnvironmentVariableService.cs
+++ b/src/Microsoft.ComponentDetection.Common/EnvironmentVariableService.cs
@@ -27,7 +27,7 @@ namespace Microsoft.ComponentDetection.Common
 
         public bool IsEnvironmentVariableValueTrue(string name)
         {
-            _ = bool.TryParse(this.GetEnvironmentVariable(name), out bool result);
+            _ = bool.TryParse(this.GetEnvironmentVariable(name), out var result);
             return result;
         }
     }

--- a/src/Microsoft.ComponentDetection.Common/Logger.cs
+++ b/src/Microsoft.ComponentDetection.Common/Logger.cs
@@ -97,7 +97,7 @@ namespace Microsoft.ComponentDetection.Common
             [CallerMemberName] string callerMemberName = "",
             [CallerLineNumber] int callerLineNumber = 0)
         {
-            string tag = isError ? "[ERROR]" : "[INFO]";
+            var tag = isError ? "[ERROR]" : "[INFO]";
 
             var fullExceptionText = $"{tag} Exception encountered." + NewLine +
                 $"CallerMember: [{callerMemberName} : {callerLineNumber}]" + NewLine +

--- a/src/Microsoft.ComponentDetection.Common/PathUtilityService.cs
+++ b/src/Microsoft.ComponentDetection.Common/PathUtilityService.cs
@@ -135,22 +135,22 @@ namespace Microsoft.ComponentDetection.Common
                 return path;
             }
 
-            if (this.resolvedPaths.TryGetValue(path, out string cachedPath))
+            if (this.resolvedPaths.TryGetValue(path, out var cachedPath))
             {
                 return cachedPath;
             }
 
-            DirectoryInfo symlink = new DirectoryInfo(path);
+            var symlink = new DirectoryInfo(path);
 
-            using SafeFileHandle directoryHandle = CreateFile(symlink.FullName, 0, 2, IntPtr.Zero, CreationDispositionRead, FileFlagBackupSemantics, IntPtr.Zero);
+            using var directoryHandle = CreateFile(symlink.FullName, 0, 2, IntPtr.Zero, CreationDispositionRead, FileFlagBackupSemantics, IntPtr.Zero);
 
             if (directoryHandle.IsInvalid)
             {
                 return path;
             }
 
-            StringBuilder resultBuilder = new StringBuilder(InitalPathBufferSize);
-            int mResult = GetFinalPathNameByHandle(directoryHandle.DangerousGetHandle(), resultBuilder, resultBuilder.Capacity, 0);
+            var resultBuilder = new StringBuilder(InitalPathBufferSize);
+            var mResult = GetFinalPathNameByHandle(directoryHandle.DangerousGetHandle(), resultBuilder, resultBuilder.Capacity, 0);
 
             // If GetFinalPathNameByHandle needs a bigger buffer, it will tell us the size it needs (including the null terminator) in finalPathNameResultCode
             if (mResult > InitalPathBufferSize)
@@ -164,7 +164,7 @@ namespace Microsoft.ComponentDetection.Common
                 return path;
             }
 
-            string result = resultBuilder.ToString();
+            var result = resultBuilder.ToString();
 
             result = result.StartsWith(LongPathPrefix) ? result.Substring(LongPathPrefix.Length) : result;
 
@@ -180,7 +180,7 @@ namespace Microsoft.ComponentDetection.Common
                 throw new PlatformNotSupportedException("Attempted to call a function that makes linux-only library calls");
             }
 
-            IntPtr pointer = IntPtr.Zero;
+            var pointer = IntPtr.Zero;
             try
             {
                 pointer = RealPathLinux(path, IntPtr.Zero);
@@ -218,7 +218,7 @@ namespace Microsoft.ComponentDetection.Common
 
             // This isn't the best way to do this in C#, but netstandard doesn't seem to support the service api calls
             // that we need to do this without shelling out
-            Process process = new Process()
+            var process = new Process()
             {
                 StartInfo = new ProcessStartInfo
                 {
@@ -231,7 +231,7 @@ namespace Microsoft.ComponentDetection.Common
                 },
             };
 
-            StringBuilder sb = new StringBuilder();
+            var sb = new StringBuilder();
             process.Start();
 
             while (!process.HasExited)

--- a/src/Microsoft.ComponentDetection.Common/TabularStringFormat.cs
+++ b/src/Microsoft.ComponentDetection.Common/TabularStringFormat.cs
@@ -27,7 +27,7 @@ namespace Microsoft.ComponentDetection.Common
 
         public string GenerateString(IEnumerable<IList<object>> rows)
         {
-            StringBuilder sb = new StringBuilder();
+            var sb = new StringBuilder();
             if (!string.IsNullOrWhiteSpace(this.tableTitle))
             {
                 this.PrintTitleSection(sb);

--- a/src/Microsoft.ComponentDetection.Contracts/BcdeModels/TypedComponentConverter.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/BcdeModels/TypedComponentConverter.cs
@@ -36,7 +36,7 @@ namespace Microsoft.ComponentDetection.Contracts.BcdeModels
             JsonReader reader,
             Type objectType, object existingValue, JsonSerializer serializer)
         {
-            JToken jo = JToken.Load(reader);
+            var jo = JToken.Load(reader);
 
             var value = (ComponentType)Enum.Parse(typeof(ComponentType), (string)jo["type"]);
             var targetType = this.componentTypesToTypes[value];

--- a/src/Microsoft.ComponentDetection.Contracts/TypedComponent/GoComponent.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/TypedComponent/GoComponent.cs
@@ -36,7 +36,7 @@ namespace Microsoft.ComponentDetection.Contracts.TypedComponent
 
         public override bool Equals(object other)
         {
-            GoComponent otherComponent = other as GoComponent;
+            var otherComponent = other as GoComponent;
             return otherComponent != null && this.Equals(otherComponent);
         }
 

--- a/src/Microsoft.ComponentDetection.Detectors/cocoapods/PodComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/cocoapods/PodComponentDetector.cs
@@ -205,7 +205,7 @@ namespace Microsoft.ComponentDetection.Detectors.CocoaPods
                 // Check if the pod is a root component and add it to the list of discovered components
                 if (rootPodspecs.Contains(pod.Podspec))
                 {
-                    if (nonRootComponents.TryGetValue(key, out DetectedComponent existingComponent))
+                    if (nonRootComponents.TryGetValue(key, out var existingComponent))
                     {
                         rootComponents.TryAdd(key, existingComponent);
                         nonRootComponents.Remove(key);
@@ -241,9 +241,9 @@ namespace Microsoft.ComponentDetection.Detectors.CocoaPods
                 // Check if the Podspec comes from a git repository or not
                 TypedComponent typedComponent;
                 string key;
-                if (podfileLock.CheckoutOptions.TryGetValue(pod.Podspec, out IDictionary<string, string> checkoutOptions)
-                    && checkoutOptions.TryGetValue(":git", out string gitOption)
-                    && checkoutOptions.TryGetValue(":commit", out string commitOption))
+                if (podfileLock.CheckoutOptions.TryGetValue(pod.Podspec, out var checkoutOptions)
+                    && checkoutOptions.TryGetValue(":git", out var gitOption)
+                    && checkoutOptions.TryGetValue(":commit", out var commitOption))
                 {
                     // Create the Git component
                     gitOption = NormalizePodfileGitUri(gitOption);
@@ -265,7 +265,7 @@ namespace Microsoft.ComponentDetection.Detectors.CocoaPods
                 // Check if the pod is a root component and add it to the list of discovered components
                 if (rootPodspecs.Contains(pod.Podspec))
                 {
-                    if (nonRootComponents.TryGetValue(key, out DetectedComponent existingComponent))
+                    if (nonRootComponents.TryGetValue(key, out var existingComponent))
                     {
                         rootComponents.TryAdd(key, existingComponent);
                         nonRootComponents.Remove(key);
@@ -284,7 +284,7 @@ namespace Microsoft.ComponentDetection.Detectors.CocoaPods
                 podSpecs.TryAdd(pod.Podspec, key);
 
                 // Update the pod dependencies map
-                if (podDependencies.TryGetValue(key, out List<PodDependency> dependencies))
+                if (podDependencies.TryGetValue(key, out var dependencies))
                 {
                     dependencies.AddRange(pod.Dependencies);
                 }
@@ -301,7 +301,7 @@ namespace Microsoft.ComponentDetection.Detectors.CocoaPods
 
                 foreach (var dependency in pod.Value)
                 {
-                    if (podSpecs.TryGetValue(dependency.Podspec, out string dependencyKey))
+                    if (podSpecs.TryGetValue(dependency.Podspec, out var dependencyKey))
                     {
                         if (dependencyKey != pod.Key)
                         {
@@ -335,7 +335,7 @@ namespace Microsoft.ComponentDetection.Detectors.CocoaPods
                 {
                     var dependency = dependencies.Dequeue();
 
-                    if (rootComponents.TryGetValue(dependency, out DetectedComponent detectedRootComponent))
+                    if (rootComponents.TryGetValue(dependency, out var detectedRootComponent))
                     {
                         // Found another root component
                         singleFileComponentRecorder.RegisterUsage(
@@ -343,7 +343,7 @@ namespace Microsoft.ComponentDetection.Detectors.CocoaPods
                             isExplicitReferencedDependency: true,
                             parentComponentId: rootComponent.Value.Component.Id);
                     }
-                    else if (nonRootComponents.TryGetValue(dependency, out DetectedComponent detectedComponent))
+                    else if (nonRootComponents.TryGetValue(dependency, out var detectedComponent))
                     {
                         singleFileComponentRecorder.RegisterUsage(
                             detectedComponent,
@@ -351,7 +351,7 @@ namespace Microsoft.ComponentDetection.Detectors.CocoaPods
                             parentComponentId: rootComponent.Value.Component.Id);
 
                         // Add the new dependecies to the queue
-                        if (dependenciesMap.TryGetValue(dependency, out HashSet<string> newDependencies))
+                        if (dependenciesMap.TryGetValue(dependency, out var newDependencies))
                         {
                             newDependencies.ToList().ForEach(dependencies.Enqueue);
                         }
@@ -385,9 +385,9 @@ namespace Microsoft.ComponentDetection.Detectors.CocoaPods
                 // Check if the Podspec comes from a git repository or not
                 TypedComponent typedComponent;
                 string key;
-                if (podfileLock.CheckoutOptions.TryGetValue(pod.Podspec, out IDictionary<string, string> checkoutOptions)
-                    && checkoutOptions.TryGetValue(":git", out string gitOption)
-                    && checkoutOptions.TryGetValue(":commit", out string commitOption))
+                if (podfileLock.CheckoutOptions.TryGetValue(pod.Podspec, out var checkoutOptions)
+                    && checkoutOptions.TryGetValue(":git", out var gitOption)
+                    && checkoutOptions.TryGetValue(":commit", out var commitOption))
                 {
                     // Create the Git component
                     gitOption = NormalizePodfileGitUri(gitOption);

--- a/src/Microsoft.ComponentDetection.Detectors/dockerfile/DockerfileComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/dockerfile/DockerfileComponentDetector.cs
@@ -103,7 +103,7 @@ namespace Microsoft.ComponentDetection.Detectors.Dockerfile
             var tokens = construct.Tokens.ToArray();
             var resolvedFromStatement = construct.ResolveVariables(escapeChar).TrimEnd();
             var fromInstruction = (FromInstruction)construct;
-            string reference = fromInstruction.ImageName;
+            var reference = fromInstruction.ImageName;
             if (string.IsNullOrWhiteSpace(resolvedFromStatement) || string.IsNullOrEmpty(reference))
             {
                 return null;

--- a/src/Microsoft.ComponentDetection.Detectors/go/GoComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/go/GoComponentDetector.cs
@@ -147,7 +147,7 @@ namespace Microsoft.ComponentDetection.Detectors.Go
         {
             using var reader = new StreamReader(file.Stream);
 
-            string line = reader.ReadLine();
+            var line = reader.ReadLine();
             while (line != null && !line.StartsWith("require ("))
             {
                 line = reader.ReadLine();
@@ -208,7 +208,7 @@ namespace Microsoft.ComponentDetection.Detectors.Go
 
         private bool TryToCreateGoComponentFromSumLine(string line, out GoComponent goComponent)
         {
-            Match m = GoSumRegex.Match(line);
+            var m = GoSumRegex.Match(line);
             if (m.Success)
             {
                 goComponent = new GoComponent(m.Groups["name"].Value, m.Groups["version"].Value, m.Groups["hash"].Value);

--- a/src/Microsoft.ComponentDetection.Detectors/ivy/IvyDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/ivy/IvyDetector.cs
@@ -102,7 +102,7 @@ namespace Microsoft.ComponentDetection.Detectors.Ivy
         {
             try
             {
-                string workingDirectory = Path.Combine(Path.GetTempPath(), "ComponentDetection_Ivy");
+                var workingDirectory = Path.Combine(Path.GetTempPath(), "ComponentDetection_Ivy");
                 this.Logger.LogVerbose($"Preparing temporary Ivy project in {workingDirectory}");
                 if (Directory.Exists(workingDirectory))
                 {
@@ -112,7 +112,7 @@ namespace Microsoft.ComponentDetection.Detectors.Ivy
                 this.InitTemporaryAntProject(workingDirectory, ivyXmlFile, ivySettingsXmlFile);
                 if (await this.RunAntToDetectDependenciesAsync(workingDirectory))
                 {
-                    string instructionsFile = Path.Combine(workingDirectory, "target", "RegisterUsage.json");
+                    var instructionsFile = Path.Combine(workingDirectory, "target", "RegisterUsage.json");
                     this.RegisterUsagesFromFile(singleFileComponentRecorder, instructionsFile);
                 }
 
@@ -138,15 +138,15 @@ namespace Microsoft.ComponentDetection.Detectors.Ivy
 
             var assembly = Assembly.GetExecutingAssembly();
 
-            using (Stream fileIn = assembly.GetManifestResourceStream("Microsoft.ComponentDetection.Detectors.ivy.Resources.build.xml"))
-            using (FileStream fileOut = File.Create(Path.Combine(workingDirectory, "build.xml")))
+            using (var fileIn = assembly.GetManifestResourceStream("Microsoft.ComponentDetection.Detectors.ivy.Resources.build.xml"))
+            using (var fileOut = File.Create(Path.Combine(workingDirectory, "build.xml")))
             {
                 fileIn.CopyTo(fileOut);
             }
 
             Directory.CreateDirectory(Path.Combine(workingDirectory, "java-src"));
-            using (Stream fileIn = assembly.GetManifestResourceStream("Microsoft.ComponentDetection.Detectors.ivy.Resources.java_src.IvyComponentDetectionAntTask.java"))
-            using (FileStream fileOut = File.Create(Path.Combine(workingDirectory, "java-src", "IvyComponentDetectionAntTask.java")))
+            using (var fileIn = assembly.GetManifestResourceStream("Microsoft.ComponentDetection.Detectors.ivy.Resources.java_src.IvyComponentDetectionAntTask.java"))
+            using (var fileOut = File.Create(Path.Combine(workingDirectory, "java-src", "IvyComponentDetectionAntTask.java")))
             {
                 fileIn.CopyTo(fileOut);
             }
@@ -161,9 +161,9 @@ namespace Microsoft.ComponentDetection.Detectors.Ivy
 
         private async Task<bool> RunAntToDetectDependenciesAsync(string workingDirectory)
         {
-            bool ret = false;
+            var ret = false;
             this.Logger.LogVerbose($"Executing command `ant resolve-dependencies` in directory {workingDirectory}");
-            CommandLineExecutionResult result = await this.CommandLineInvocationService.ExecuteCommand(PrimaryCommand, additionalCandidateCommands: AdditionalValidCommands, "-buildfile", workingDirectory, "resolve-dependencies");
+            var result = await this.CommandLineInvocationService.ExecuteCommand(PrimaryCommand, additionalCandidateCommands: AdditionalValidCommands, "-buildfile", workingDirectory, "resolve-dependencies");
             if (result.ExitCode == 0)
             {
                 this.Logger.LogVerbose("Ant command succeeded");
@@ -210,14 +210,14 @@ namespace Microsoft.ComponentDetection.Detectors.Ivy
 
         private void RegisterUsagesFromFile(ISingleFileComponentRecorder singleFileComponentRecorder, string instructionsFile)
         {
-            JObject instructionsJson = JObject.Parse(File.ReadAllText(instructionsFile));
-            JContainer instructionsList = (JContainer)instructionsJson["RegisterUsage"];
-            foreach (JToken dep in instructionsList)
+            var instructionsJson = JObject.Parse(File.ReadAllText(instructionsFile));
+            var instructionsList = (JContainer)instructionsJson["RegisterUsage"];
+            foreach (var dep in instructionsList)
             {
-                MavenComponent component = JsonGavToComponent(dep["gav"]);
-                bool isDevDependency = dep.Value<bool>("DevelopmentDependency");
-                MavenComponent parentComponent = JsonGavToComponent(dep["parent_gav"]);
-                bool isResolved = dep.Value<bool>("resolved");
+                var component = JsonGavToComponent(dep["gav"]);
+                var isDevDependency = dep.Value<bool>("DevelopmentDependency");
+                var parentComponent = JsonGavToComponent(dep["parent_gav"]);
+                var isResolved = dep.Value<bool>("resolved");
                 if (isResolved)
                 {
                     singleFileComponentRecorder.RegisterUsage(

--- a/src/Microsoft.ComponentDetection.Detectors/linux/LinuxContainerDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/linux/LinuxContainerDetector.cs
@@ -130,7 +130,7 @@ namespace Microsoft.ComponentDetection.Detectors.Linux
                 {
                     var internalContainerDetails = kvp.Value;
                     var image = kvp.Key;
-                    int baseImageLayerCount = await this.GetBaseImageLayerCount(internalContainerDetails, image, cancellationToken);
+                    var baseImageLayerCount = await this.GetBaseImageLayerCount(internalContainerDetails, image, cancellationToken);
 
                     //Update the layer information to specify if a layer was fond in the specified baseImage
                     internalContainerDetails.Layers = internalContainerDetails.Layers.Select(layer => new DockerLayer

--- a/src/Microsoft.ComponentDetection.Detectors/maven/MavenCommandService.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/maven/MavenCommandService.cs
@@ -46,7 +46,7 @@ namespace Microsoft.ComponentDetection.Detectors.Maven
 
         public void ParseDependenciesFile(ProcessRequest processRequest)
         {
-            using StreamReader sr = new StreamReader(processRequest.ComponentStream.Stream);
+            using var sr = new StreamReader(processRequest.ComponentStream.Stream);
 
             var lines = sr.ReadToEnd().Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
             this.ParserService.Parse(lines, processRequest.SingleFileComponentRecorder);

--- a/src/Microsoft.ComponentDetection.Detectors/maven/MavenParsingUtilities.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/maven/MavenParsingUtilities.cs
@@ -50,7 +50,7 @@ namespace Microsoft.ComponentDetection.Detectors.Maven
             }
 
             // 'MavenCompile' is a default scope for maven dependencies.
-            DependencyScope dependencyScope = DependencyScope.MavenCompile;
+            var dependencyScope = DependencyScope.MavenCompile;
             var groupId = results[0];
             var artifactId = results[1];
             var version = results[3];

--- a/src/Microsoft.ComponentDetection.Detectors/maven/MvnCliComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/maven/MvnCliComponentDetector.cs
@@ -83,15 +83,15 @@ namespace Microsoft.ComponentDetection.Detectors.Maven
 
         private IObservable<ProcessRequest> RemoveNestedPomXmls(IObservable<ProcessRequest> componentStreams)
         {
-            List<DirectoryItemFacade> directoryItemFacades = new List<DirectoryItemFacade>();
-            Dictionary<string, DirectoryItemFacade> directoryItemFacadesByPath = new Dictionary<string, DirectoryItemFacade>();
+            var directoryItemFacades = new List<DirectoryItemFacade>();
+            var directoryItemFacadesByPath = new Dictionary<string, DirectoryItemFacade>();
             return Observable.Create<ProcessRequest>(s =>
             {
                 return componentStreams.Subscribe(
                     processRequest =>
                 {
                     var item = processRequest.ComponentStream;
-                    string currentDir = item.Location;
+                    var currentDir = item.Location;
                     DirectoryItemFacade last = null;
                     do
                     {

--- a/src/Microsoft.ComponentDetection.Detectors/npm/NpmComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/npm/NpmComponentDetector.cs
@@ -90,7 +90,7 @@ namespace Microsoft.ComponentDetection.Detectors.Npm
                 return false;
             }
 
-            NpmComponent npmComponent = new NpmComponent(name, version, author: this.GetAuthor(authorToken, name, filePath));
+            var npmComponent = new NpmComponent(name, version, author: this.GetAuthor(authorToken, name, filePath));
 
             singleFileComponentRecorder.RegisterUsage(new DetectedComponent(npmComponent));
             return true;
@@ -106,8 +106,8 @@ namespace Microsoft.ComponentDetection.Detectors.Npm
 
             string authorName;
             string authorEmail;
-            string authorSingleStringPattern = @"^(?<name>([^<(]+?)?)[ \t]*(?:<(?<email>([^>(]+?))>)?[ \t]*(?:\(([^)]+?)\)|$)";
-            Match authorMatch = new Regex(authorSingleStringPattern).Match(authorString);
+            var authorSingleStringPattern = @"^(?<name>([^<(]+?)?)[ \t]*(?:<(?<email>([^>(]+?))>)?[ \t]*(?:\(([^)]+?)\)|$)";
+            var authorMatch = new Regex(authorSingleStringPattern).Match(authorString);
 
             /*
              * for parsing author in Json Format

--- a/src/Microsoft.ComponentDetection.Detectors/npm/NpmComponentUtilities.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/npm/NpmComponentUtilities.cs
@@ -19,8 +19,8 @@ namespace Microsoft.ComponentDetection.Detectors.Npm
 
         public static void TraverseAndRecordComponents(JProperty currentDependency, ISingleFileComponentRecorder singleFileComponentRecorder, TypedComponent component, TypedComponent explicitReferencedDependency, string parentComponentId = null)
         {
-            JValue devJValue = currentDependency.Value["dev"] as JValue;
-            bool isDevDependency = devJValue == null ? false : (bool)devJValue;
+            var devJValue = currentDependency.Value["dev"] as JValue;
+            var isDevDependency = devJValue == null ? false : (bool)devJValue;
             AddOrUpdateDetectedComponent(singleFileComponentRecorder, component, isDevDependency, parentComponentId, isExplicitReferencedDependency: string.Equals(component.Id, explicitReferencedDependency.Id));
         }
 
@@ -38,9 +38,9 @@ namespace Microsoft.ComponentDetection.Detectors.Npm
 
         public static TypedComponent GetTypedComponent(JProperty currentDependency, string npmRegistryHost, ILogger logger)
         {
-            string name = currentDependency.Name;
-            string version = currentDependency.Value["version"].ToString();
-            string hash = currentDependency.Value["integrity"]?.ToString(); // https://docs.npmjs.com/configuring-npm/package-lock-json.html#integrity
+            var name = currentDependency.Name;
+            var version = currentDependency.Value["version"].ToString();
+            var hash = currentDependency.Value["integrity"]?.ToString(); // https://docs.npmjs.com/configuring-npm/package-lock-json.html#integrity
 
             if (!IsPackageNameValid(name))
             {
@@ -48,7 +48,7 @@ namespace Microsoft.ComponentDetection.Detectors.Npm
                 return null;
             }
 
-            if (!SemanticVersion.TryParse(version, out SemanticVersion result) && !TryParseNpmVersion(npmRegistryHost, name, version, out result))
+            if (!SemanticVersion.TryParse(version, out var result) && !TryParseNpmVersion(npmRegistryHost, name, version, out result))
             {
                 logger.LogInfo($"Version string {version} for component {name} is invalid or unsupported and a component will not be recorded.");
                 return null;
@@ -61,7 +61,7 @@ namespace Microsoft.ComponentDetection.Detectors.Npm
 
         public static bool TryParseNpmVersion(string npmRegistryHost, string packageName, string versionString, out SemanticVersion version)
         {
-            if (Uri.TryCreate(versionString, UriKind.Absolute, out Uri parsedUri))
+            if (Uri.TryCreate(versionString, UriKind.Absolute, out var parsedUri))
             {
                 if (string.Equals(npmRegistryHost, parsedUri.Host, StringComparison.OrdinalIgnoreCase))
                 {
@@ -77,8 +77,8 @@ namespace Microsoft.ComponentDetection.Detectors.Npm
         {
             try
             {
-                string file = Path.GetFileNameWithoutExtension(versionString.LocalPath);
-                string potentialVersion = file.Replace($"{packageName}-", string.Empty);
+                var file = Path.GetFileNameWithoutExtension(versionString.LocalPath);
+                var potentialVersion = file.Replace($"{packageName}-", string.Empty);
 
                 return SemanticVersion.TryParse(potentialVersion, out version);
             }
@@ -93,8 +93,8 @@ namespace Microsoft.ComponentDetection.Detectors.Npm
         {
             yarnWorkspaces = new List<string>();
 
-            using StreamReader file = new StreamReader(stream);
-            using JsonTextReader reader = new JsonTextReader(file);
+            using var file = new StreamReader(stream);
+            using var reader = new JsonTextReader(file);
 
             IDictionary<string, string> dependencies = new Dictionary<string, string>();
             IDictionary<string, string> devDependencies = new Dictionary<string, string>();
@@ -132,7 +132,7 @@ namespace Microsoft.ComponentDetection.Detectors.Npm
                     returnedDependencies[item.Key] = new Dictionary<string, bool>();
                 }
 
-                if (returnedDependencies[item.Key].TryGetValue(item.Value, out bool wasDev))
+                if (returnedDependencies[item.Key].TryGetValue(item.Value, out var wasDev))
                 {
                     returnedDependencies[item.Key][item.Value] = wasDev && isDev;
                 }

--- a/src/Microsoft.ComponentDetection.Detectors/nuget/NuGetNuspecUtilities.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/nuget/NuGetNuspecUtilities.cs
@@ -24,7 +24,7 @@ namespace Microsoft.ComponentDetection.Detectors.NuGet
                 using var archive = new ZipArchive(nupkgStream, ZipArchiveMode.Read, true);
 
                 // get the first entry ending in .nuspec at the root of the package
-                ZipArchiveEntry nuspecEntry =
+                var nuspecEntry =
                     archive.Entries.FirstOrDefault(x =>
                         x.Name.EndsWith(".nuspec", StringComparison.OrdinalIgnoreCase)
                         && x.FullName.IndexOf('/') == -1);
@@ -51,8 +51,8 @@ namespace Microsoft.ComponentDetection.Detectors.NuGet
 
         public static async Task<byte[]> GetNuspecBytesFromNuspecStream(Stream nuspecStream, long nuspecLength)
         {
-            byte[] nuspecBytes = new byte[nuspecLength];
-            int bytesReadSoFar = 0;
+            var nuspecBytes = new byte[nuspecLength];
+            var bytesReadSoFar = 0;
             while (bytesReadSoFar < nuspecBytes.Length)
             {
                 bytesReadSoFar += await nuspecStream.ReadAsync(nuspecBytes, bytesReadSoFar, nuspecBytes.Length - bytesReadSoFar);

--- a/src/Microsoft.ComponentDetection.Detectors/nuget/NuGetProjectModelProjectCentricComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/nuget/NuGetProjectModelProjectCentricComponentDetector.cs
@@ -52,7 +52,7 @@ namespace Microsoft.ComponentDetection.Detectors.NuGet
                     throw new FormatException("Lockfile did not contain a PackageSpec");
                 }
 
-                HashSet<string> frameworkComponents = this.GetFrameworkComponents(lockFile);
+                var frameworkComponents = this.GetFrameworkComponents(lockFile);
                 var explicitReferencedDependencies = this.GetTopLevelLibraries(lockFile)
                     .Select(x => this.GetLibraryComponentWithDependencyLookup(lockFile.Libraries, x.name, x.version, x.versionRange))
                     .ToList();
@@ -217,7 +217,7 @@ namespace Microsoft.ComponentDetection.Detectors.NuGet
             if (matchingLibrary == null)
             {
                 matchingLibrary = matchingLibraryNames.First();
-                string logMessage = $"Couldn't satisfy lookup for {(versionRange != null ? versionRange.ToNormalizedString() : version.ToString())}. Falling back to first found component for {matchingLibrary.Name}, resolving to version {matchingLibrary.Version}.";
+                var logMessage = $"Couldn't satisfy lookup for {(versionRange != null ? versionRange.ToNormalizedString() : version.ToString())}. Falling back to first found component for {matchingLibrary.Name}, resolving to version {matchingLibrary.Version}.";
                 if (!this.alreadyLoggedWarnings.Contains(logMessage))
                 {
                     this.Logger.LogWarning(logMessage);
@@ -243,7 +243,7 @@ namespace Microsoft.ComponentDetection.Detectors.NuGet
                         foreach (var target in lockFile.Targets)
                         {
                             var matchingLibrary = target.Libraries.FirstOrDefault(x => x.Name == name);
-                            HashSet<string> dependencyComponents = this.GetDependencyComponentIds(lockFile, target, matchingLibrary.Dependencies);
+                            var dependencyComponents = this.GetDependencyComponentIds(lockFile, target, matchingLibrary.Dependencies);
                             frameworkDependencies.UnionWith(dependencyComponents);
                         }
                     }
@@ -261,7 +261,7 @@ namespace Microsoft.ComponentDetection.Detectors.NuGet
         private HashSet<string> GetDependencyComponentIds(LockFile lockFile, LockFileTarget target, IList<PackageDependency> dependencies, HashSet<string> visited = null)
         {
             visited = visited ?? new HashSet<string>();
-            HashSet<string> currentComponents = new HashSet<string>();
+            var currentComponents = new HashSet<string>();
             foreach (var dependency in dependencies)
             {
                 if (visited.Contains(dependency.Id))

--- a/src/Microsoft.ComponentDetection.Detectors/pip/IPyPiClient.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/IPyPiClient.cs
@@ -137,7 +137,7 @@ namespace Microsoft.ComponentDetection.Detectors.Pip
                 return dependencies;
             }
 
-            ZipArchive package = new ZipArchive(await response.Content.ReadAsStreamAsync());
+            var package = new ZipArchive(await response.Content.ReadAsStreamAsync());
 
             var entry = package.GetEntry($"{name.Replace('-', '_')}-{version}.dist-info/METADATA");
 
@@ -147,7 +147,7 @@ namespace Microsoft.ComponentDetection.Detectors.Pip
                 return dependencies;
             }
 
-            List<string> content = new List<string>();
+            var content = new List<string>();
             using (var stream = entry.Open())
             {
                 using var streamReader = new StreamReader(stream);

--- a/src/Microsoft.ComponentDetection.Detectors/pip/PipComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/PipComponentDetector.cs
@@ -31,7 +31,7 @@ namespace Microsoft.ComponentDetection.Detectors.Pip
 
         protected override async Task<IObservable<ProcessRequest>> OnPrepareDetection(IObservable<ProcessRequest> processRequests, IDictionary<string, string> detectorArgs)
         {
-            this.CurrentScanRequest.DetectorArgs.TryGetValue("Pip.PythonExePath", out string pythonExePath);
+            this.CurrentScanRequest.DetectorArgs.TryGetValue("Pip.PythonExePath", out var pythonExePath);
             if (!await this.PythonCommandService.PythonExists(pythonExePath))
             {
                 this.Logger.LogInfo($"No python found on system. Python detection will not run.");
@@ -44,7 +44,7 @@ namespace Microsoft.ComponentDetection.Detectors.Pip
 
         protected override async Task OnFileFound(ProcessRequest processRequest, IDictionary<string, string> detectorArgs)
         {
-            this.CurrentScanRequest.DetectorArgs.TryGetValue("Pip.PythonExePath", out string pythonExePath);
+            this.CurrentScanRequest.DetectorArgs.TryGetValue("Pip.PythonExePath", out var pythonExePath);
             var singleFileComponentRecorder = processRequest.SingleFileComponentRecorder;
             var file = processRequest.ComponentStream;
 

--- a/src/Microsoft.ComponentDetection.Detectors/pip/PipDependencySpecification.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/PipDependencySpecification.cs
@@ -79,7 +79,7 @@ namespace Microsoft.ComponentDetection.Detectors.Pip
             {
                 var distMatch = RequiresDistRegex.Match(packageString);
 
-                for (int i = 1; i < distMatch.Groups.Count; i++)
+                for (var i = 1; i < distMatch.Groups.Count; i++)
                 {
                     if (string.IsNullOrWhiteSpace(distMatch.Groups[i].Value))
                     {

--- a/src/Microsoft.ComponentDetection.Detectors/pip/PythonCommandService.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/PythonCommandService.cs
@@ -128,7 +128,7 @@ namespace Microsoft.ComponentDetection.Detectors.Pip
 
         private async Task<string> ResolvePython(string pythonPath = null)
         {
-            string pythonCommand = string.IsNullOrEmpty(pythonPath) ? "python" : pythonPath;
+            var pythonCommand = string.IsNullOrEmpty(pythonPath) ? "python" : pythonPath;
 
             if (await this.CanCommandBeLocated(pythonCommand))
             {

--- a/src/Microsoft.ComponentDetection.Detectors/pip/PythonVersion.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/PythonVersion.cs
@@ -56,7 +56,7 @@ namespace Microsoft.ComponentDetection.Detectors.Pip
             var groups = this.match.Groups;
 
             // Epoch is optional, implicitly 0 if not present
-            if (groups["epoch"].Success && int.TryParse(groups["epoch"].Value, out int epoch))
+            if (groups["epoch"].Success && int.TryParse(groups["epoch"].Value, out var epoch))
             {
                 this.Epoch = epoch;
             }
@@ -68,17 +68,17 @@ namespace Microsoft.ComponentDetection.Detectors.Pip
             this.Release = groups["release"].Success ? groups["release"].Value : string.Empty;
             this.PreReleaseLabel = groups["pre_l"].Success ? groups["pre_l"].Value : string.Empty;
 
-            if (groups["pre_n"].Success && int.TryParse(groups["pre_n"].Value, out int preReleaseNumber))
+            if (groups["pre_n"].Success && int.TryParse(groups["pre_n"].Value, out var preReleaseNumber))
             {
                 this.PreReleaseNumber = preReleaseNumber;
             }
 
-            if (groups["post_n1"].Success && int.TryParse(groups["post_n1"].Value, out int postRelease1))
+            if (groups["post_n1"].Success && int.TryParse(groups["post_n1"].Value, out var postRelease1))
             {
                 this.PostNumber = postRelease1;
             }
 
-            if (groups["post_n2"].Success && int.TryParse(groups["post_n2"].Value, out int postRelease2))
+            if (groups["post_n2"].Success && int.TryParse(groups["post_n2"].Value, out var postRelease2))
             {
                 this.PostNumber = postRelease2;
             }
@@ -89,7 +89,7 @@ namespace Microsoft.ComponentDetection.Detectors.Pip
                 this.DevNumber = 0;
             }
 
-            if (groups["dev_n"].Success && int.TryParse(groups["dev_n"].Value, out int devNumber))
+            if (groups["dev_n"].Success && int.TryParse(groups["dev_n"].Value, out var devNumber))
             {
                 this.DevNumber = devNumber;
             }
@@ -135,28 +135,28 @@ namespace Microsoft.ComponentDetection.Detectors.Pip
 
             if (!string.Equals(this.Release, other.Release, StringComparison.OrdinalIgnoreCase))
             {
-                int result = CompareReleaseVersions(this, other);
+                var result = CompareReleaseVersions(this, other);
                 if (result != 0)
                 {
                     return result;
                 }
             }
 
-            int preReleaseComparison = ComparePreRelease(this, other);
+            var preReleaseComparison = ComparePreRelease(this, other);
 
             if (preReleaseComparison != 0)
             {
                 return preReleaseComparison;
             }
 
-            int postNumberComparison = ComparePostNumbers(this, other);
+            var postNumberComparison = ComparePostNumbers(this, other);
 
             if (postNumberComparison != 0)
             {
                 return postNumberComparison;
             }
 
-            int devNumberComparison = CompareDevValues(this, other);
+            var devNumberComparison = CompareDevValues(this, other);
 
             return devNumberComparison;
         }
@@ -277,8 +277,8 @@ namespace Microsoft.ComponentDetection.Detectors.Pip
 
         private static int CompareReleaseVersions(PythonVersion a, PythonVersion b)
         {
-            List<int> aSplit = a.Release.Split('.').Select(x => int.Parse(x)).ToList();
-            List<int> bSplit = b.Release.Split('.').Select(x => int.Parse(x)).ToList();
+            var aSplit = a.Release.Split('.').Select(x => int.Parse(x)).ToList();
+            var bSplit = b.Release.Split('.').Select(x => int.Parse(x)).ToList();
 
             int longer;
             int shorter;
@@ -307,7 +307,7 @@ namespace Microsoft.ComponentDetection.Detectors.Pip
                 lengthCompare = 0;
             }
 
-            for (int i = 0; i < shorter; i++)
+            for (var i = 0; i < shorter; i++)
             {
                 if (aSplit[i] > bSplit[i])
                 {

--- a/src/Microsoft.ComponentDetection.Detectors/pip/PythonVersionComparer.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/PythonVersionComparer.cs
@@ -6,8 +6,8 @@ namespace Microsoft.ComponentDetection.Detectors.Pip
     {
         public int Compare(string x, string y)
         {
-            PythonVersion xVer = new PythonVersion(x);
-            PythonVersion yVer = new PythonVersion(y);
+            var xVer = new PythonVersion(x);
+            var yVer = new PythonVersion(y);
 
             return xVer.CompareTo(yVer);
         }

--- a/src/Microsoft.ComponentDetection.Detectors/pip/PythonVersionUtilities.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/PythonVersionUtilities.cs
@@ -28,16 +28,16 @@ namespace Microsoft.ComponentDetection.Detectors.Pip
 
         private static bool VersionValidForSpec(string version, string spec)
         {
-            char[] opChars = new char[] { '=', '<', '>', '~', '!' };
+            var opChars = new char[] { '=', '<', '>', '~', '!' };
             var specArray = spec.ToCharArray();
 
-            int i = 0;
+            var i = 0;
             while (i < spec.Length && i < 3 && opChars.Contains(specArray[i]))
             {
                 i++;
             }
 
-            string op = spec.Substring(0, i);
+            var op = spec.Substring(0, i);
 
             var targetVer = new PythonVersion(version);
             var specVer = new PythonVersion(spec.Substring(i));
@@ -84,7 +84,7 @@ namespace Microsoft.ComponentDetection.Detectors.Pip
                 return true;
             }
 
-            int i = 0;
+            var i = 0;
             var splitVersion = version.Split('.');
             var splitSpecVer = specVer.Split('.');
 
@@ -93,7 +93,7 @@ namespace Microsoft.ComponentDetection.Detectors.Pip
                 if (fuzzy && i == (splitSpecVer.Length - 1))
                 {
                     // Fuzzy matching excludes everything after first two
-                    if (splitVersion.Length > i && int.TryParse(splitVersion[i], out int lVer) && int.TryParse(splitSpecVer[i], out int rVer) && lVer >= rVer)
+                    if (splitVersion.Length > i && int.TryParse(splitVersion[i], out var lVer) && int.TryParse(splitSpecVer[i], out var rVer) && lVer >= rVer)
                     {
                         return true;
                     }

--- a/src/Microsoft.ComponentDetection.Detectors/pnpm/PnpmComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pnpm/PnpmComponentDetector.cs
@@ -36,7 +36,7 @@ namespace Microsoft.ComponentDetection.Detectors.Pnpm
             var file = processRequest.ComponentStream;
 
             this.Logger.LogVerbose("Found yaml file: " + file.Location);
-            string skippedFolder = this.SkippedFolders.FirstOrDefault(folder => file.Location.Contains(folder));
+            var skippedFolder = this.SkippedFolders.FirstOrDefault(folder => file.Location.Contains(folder));
             if (!string.IsNullOrEmpty(skippedFolder))
             {
                 this.Logger.LogVerbose($"Skipping found file, it was detected as being within a {skippedFolder} folder.");
@@ -64,7 +64,7 @@ namespace Microsoft.ComponentDetection.Detectors.Pnpm
                 }
 
                 var parentDetectedComponent = PnpmParsingUtilities.CreateDetectedComponentFromPnpmPath(pnpmPackagePath: packageKeyValue.Key);
-                bool isDevDependency = packageKeyValue.Value != null && PnpmParsingUtilities.IsPnpmPackageDevDependency(packageKeyValue.Value);
+                var isDevDependency = packageKeyValue.Value != null && PnpmParsingUtilities.IsPnpmPackageDevDependency(packageKeyValue.Value);
                 singleFileComponentRecorder.RegisterUsage(parentDetectedComponent, isDevelopmentDependency: isDevDependency);
                 parentDetectedComponent = singleFileComponentRecorder.GetComponent(parentDetectedComponent.Component.Id);
 

--- a/src/Microsoft.ComponentDetection.Detectors/pnpm/PnpmParsingUtilities.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pnpm/PnpmParsingUtilities.cs
@@ -39,7 +39,7 @@ namespace Microsoft.ComponentDetection.Detectors.Pnpm
         private static (string Name, string Version) ExtractNameAndVersionFromPnpmPackagePath(string pnpmPackagePath)
         {
             var pnpmComponentDefSections = pnpmPackagePath.Trim('/').Split('/');
-            (string packageVersion, int indexVersionIsAt) = GetPackageVersion(pnpmComponentDefSections);
+            (var packageVersion, var indexVersionIsAt) = GetPackageVersion(pnpmComponentDefSections);
             if (indexVersionIsAt == -1)
             {
                 // No version = not expected input

--- a/src/Microsoft.ComponentDetection.Detectors/ruby/RubyComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/ruby/RubyComponentDetector.cs
@@ -142,7 +142,7 @@ namespace Microsoft.ComponentDetection.Detectors.Ruby
                             var name = "bundler";
 
                             // Nothing in the lockfile tells us where bundler came from
-                            DetectedComponent addComponent = new DetectedComponent(new RubyGemsComponent(name, line, "unknown"));
+                            var addComponent = new DetectedComponent(new RubyGemsComponent(name, line, "unknown"));
                             components.TryAdd<string, DetectedComponent>(string.Format("{0}:{1}", name, file.Location), addComponent);
                             dependencies.TryAdd(string.Format("{0}:{1}", name, file.Location), new List<Dependency>());
                             break;
@@ -165,9 +165,9 @@ namespace Microsoft.ComponentDetection.Detectors.Ruby
                 singleFileComponentRecorder.RegisterUsage(detectedComponent);
             }
 
-            foreach (string key in dependencies.Keys)
+            foreach (var key in dependencies.Keys)
             {
-                foreach (Dependency dependency in dependencies[key])
+                foreach (var dependency in dependencies[key])
                 {
                     // there are cases that we ommit the dependency
                     // because its version is not valid like for example
@@ -188,7 +188,7 @@ namespace Microsoft.ComponentDetection.Detectors.Ruby
             string name, remote, revision;
             name = remote = revision = string.Empty;
 
-            bool wasParentDependencyExcluded = false;
+            var wasParentDependencyExcluded = false;
 
             while (lines.Count > 0)
             {
@@ -246,8 +246,8 @@ namespace Microsoft.ComponentDetection.Detectors.Ruby
                                 newComponent = new GitComponent(new Uri(remote), revision);
                             }
 
-                            DetectedComponent addComponent = new DetectedComponent(newComponent);
-                            string lookupKey = string.Format("{0}:{1}", name, file.Location);
+                            var addComponent = new DetectedComponent(newComponent);
+                            var lookupKey = string.Format("{0}:{1}", name, file.Location);
 
                             if (components.ContainsKey(lookupKey))
                             {

--- a/src/Microsoft.ComponentDetection.Detectors/rust/DependencySpecification.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/rust/DependencySpecification.cs
@@ -45,7 +45,7 @@ namespace Microsoft.ComponentDetection.Detectors.Rust
                 var allSatisfied = true;
                 foreach (var range in ranges)
                 {
-                    if (SemVersion.TryParse(package.version, out SemVersion sv))
+                    if (SemVersion.TryParse(package.version, out var sv))
                     {
                         if (!range.IsSatisfied(sv))
                         {

--- a/src/Microsoft.ComponentDetection.Detectors/rust/RustCrateDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/rust/RustCrateDetector.cs
@@ -41,19 +41,19 @@ namespace Microsoft.ComponentDetection.Detectors.Rust
                     return Task.CompletedTask;
                 }
 
-                FileInfo lockFileInfo = new FileInfo(cargoLockFile.Location);
-                IEnumerable<IComponentStream> cargoTomlComponentStream = this.ComponentStreamEnumerableFactory.GetComponentStreams(lockFileInfo.Directory, new List<string> { RustCrateUtilities.CargoTomlSearchPattern }, (name, directoryName) => false, recursivelyScanDirectories: false);
+                var lockFileInfo = new FileInfo(cargoLockFile.Location);
+                var cargoTomlComponentStream = this.ComponentStreamEnumerableFactory.GetComponentStreams(lockFileInfo.Directory, new List<string> { RustCrateUtilities.CargoTomlSearchPattern }, (name, directoryName) => false, recursivelyScanDirectories: false);
 
-                CargoDependencyData cargoDependencyData = RustCrateUtilities.ExtractRootDependencyAndWorkspaceSpecifications(cargoTomlComponentStream, singleFileComponentRecorder);
+                var cargoDependencyData = RustCrateUtilities.ExtractRootDependencyAndWorkspaceSpecifications(cargoTomlComponentStream, singleFileComponentRecorder);
 
                 // If workspaces have been defined in the root cargo.toml file, scan for specified cargo.toml manifests
-                int numWorkspaceComponentStreams = 0;
-                int expectedWorkspaceTomlCount = cargoDependencyData.CargoWorkspaces.Count;
+                var numWorkspaceComponentStreams = 0;
+                var expectedWorkspaceTomlCount = cargoDependencyData.CargoWorkspaces.Count;
                 if (expectedWorkspaceTomlCount > 0)
                 {
-                    string rootCargoTomlLocation = Path.Combine(lockFileInfo.DirectoryName, "Cargo.toml");
+                    var rootCargoTomlLocation = Path.Combine(lockFileInfo.DirectoryName, "Cargo.toml");
 
-                    IEnumerable<IComponentStream> cargoTomlWorkspaceComponentStreams = this.ComponentStreamEnumerableFactory.GetComponentStreams(
+                    var cargoTomlWorkspaceComponentStreams = this.ComponentStreamEnumerableFactory.GetComponentStreams(
                         lockFileInfo.Directory,
                         new List<string> { RustCrateUtilities.CargoTomlSearchPattern },
                         RustCrateUtilities.BuildExcludeDirectoryPredicateFromWorkspaces(lockFileInfo, cargoDependencyData.CargoWorkspaces, cargoDependencyData.CargoWorkspaceExclusions),

--- a/src/Microsoft.ComponentDetection.Detectors/rust/RustCrateUtilities.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/rust/RustCrateUtilities.cs
@@ -44,7 +44,7 @@ namespace Microsoft.ComponentDetection.Detectors.Rust
         /// </returns>
         public static CargoDependencyData ExtractRootDependencyAndWorkspaceSpecifications(IEnumerable<IComponentStream> cargoTomlComponentStream, ISingleFileComponentRecorder singleFileComponentRecorder)
         {
-            CargoDependencyData cargoDependencyData = new CargoDependencyData();
+            var cargoDependencyData = new CargoDependencyData();
 
             // The file handle is disposed if you call .First() on cargoTomlComponentStream
             // Since multiple Cargo.toml files for 1 Cargo.lock file obviously doesn't make sense
@@ -58,10 +58,10 @@ namespace Microsoft.ComponentDetection.Detectors.Rust
                 // Extract the workspaces present, if any
                 if (cargoToml.ContainsKey(WorkspaceKey))
                 {
-                    TomlTable workspaces = cargoToml.Get<TomlTable>(WorkspaceKey);
+                    var workspaces = cargoToml.Get<TomlTable>(WorkspaceKey);
 
-                    TomlObject workspaceMembers = workspaces.ContainsKey(WorkspaceMemberKey) ? workspaces[WorkspaceMemberKey] : null;
-                    TomlObject workspaceExclusions = workspaces.ContainsKey(WorkspaceExcludeKey) ? workspaces[WorkspaceExcludeKey] : null;
+                    var workspaceMembers = workspaces.ContainsKey(WorkspaceMemberKey) ? workspaces[WorkspaceMemberKey] : null;
+                    var workspaceExclusions = workspaces.ContainsKey(WorkspaceExcludeKey) ? workspaces[WorkspaceExcludeKey] : null;
 
                     if (workspaceMembers != null)
                     {
@@ -146,15 +146,15 @@ namespace Microsoft.ComponentDetection.Detectors.Rust
         /// <returns></returns>
         public static ExcludeDirectoryPredicate BuildExcludeDirectoryPredicateFromWorkspaces(FileInfo rootLockFileInfo, HashSet<string> definedWorkspaces, HashSet<string> definedExclusions)
         {
-            Dictionary<string, Glob> workspaceGlobs = BuildGlobMatchingFromWorkspaces(rootLockFileInfo, definedWorkspaces);
+            var workspaceGlobs = BuildGlobMatchingFromWorkspaces(rootLockFileInfo, definedWorkspaces);
 
             // Since the paths come in as relative, make them fully qualified
-            HashSet<string> fullyQualifiedExclusions = definedExclusions.Select(x => Path.Combine(rootLockFileInfo.DirectoryName, x)).ToHashSet();
+            var fullyQualifiedExclusions = definedExclusions.Select(x => Path.Combine(rootLockFileInfo.DirectoryName, x)).ToHashSet();
 
             // The predicate will be evaluated with the current directory name to search and the full path of its parent. Return true when it should be excluded from search.
             return (ReadOnlySpan<char> nameOfDirectoryToConsider, ReadOnlySpan<char> pathOfParentOfDirectoryToConsider) =>
             {
-                string currentPath = Path.Combine(pathOfParentOfDirectoryToConsider.ToString(), nameOfDirectoryToConsider.ToString());
+                var currentPath = Path.Combine(pathOfParentOfDirectoryToConsider.ToString(), nameOfDirectoryToConsider.ToString());
 
                 return !workspaceGlobs.Values.Any(x => x.IsMatch(currentPath)) || fullyQualifiedExclusions.Contains(currentPath);
             };
@@ -168,22 +168,22 @@ namespace Microsoft.ComponentDetection.Detectors.Rust
         /// <returns></returns>
         private static Dictionary<string, Glob> BuildGlobMatchingFromWorkspaces(FileInfo rootLockFileInfo, HashSet<string> definedWorkspaces)
         {
-            Dictionary<string, Glob> directoryGlobs = new Dictionary<string, Glob>
+            var directoryGlobs = new Dictionary<string, Glob>
             {
                 { rootLockFileInfo.DirectoryName, Glob.Parse(rootLockFileInfo.DirectoryName) },
             };
 
             // For the given workspaces, add their paths to search list
-            foreach (string workspace in definedWorkspaces)
+            foreach (var workspace in definedWorkspaces)
             {
-                string currentPath = rootLockFileInfo.DirectoryName;
-                string[] directoryPathParts = workspace.Split('/');
+                var currentPath = rootLockFileInfo.DirectoryName;
+                var directoryPathParts = workspace.Split('/');
 
                 // When multiple levels of subdirectory are present, each directory parent must be added or the directory will not be reached
                 // For example, ROOT/test-space/first-test/src/Cargo.toml requires the following directories be matched:
                 // ROOT/test-space, ROOT/test-space/first-test, ROOT/test-space/first-test, ROOT/test-space/first-test/src
                 // Each directory is matched explicitly instead of performing a StartsWith due to the potential of Glob character matching
-                foreach (string pathPart in directoryPathParts)
+                foreach (var pathPart in directoryPathParts)
                 {
                     currentPath = Path.Combine(currentPath, pathPart);
                     directoryGlobs[currentPath] = Glob.Parse(currentPath);
@@ -251,7 +251,7 @@ namespace Microsoft.ComponentDetection.Detectors.Rust
                         var regexMatch = DependencyFormatRegex.Match(dependency);
                         if (regexMatch.Success)
                         {
-                            if (SemVersion.TryParse(regexMatch.Groups[2].Value, out SemVersion sv))
+                            if (SemVersion.TryParse(regexMatch.Groups[2].Value, out var sv))
                             {
                                 var name = regexMatch.Groups[1].Value;
                                 var version = sv.ToString();
@@ -420,7 +420,7 @@ namespace Microsoft.ComponentDetection.Detectors.Rust
             var regexMatch = DependencyFormatRegex.Match(depString);
             if (regexMatch.Success)
             {
-                if (SemVersion.TryParse(regexMatch.Groups[2].Value, out SemVersion sv))
+                if (SemVersion.TryParse(regexMatch.Groups[2].Value, out var sv))
                 {
                     var dependencyPackage = new CargoPackage
                     {

--- a/src/Microsoft.ComponentDetection.Detectors/rust/RustCrateV2Detector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/rust/RustCrateV2Detector.cs
@@ -41,19 +41,19 @@ namespace Microsoft.ComponentDetection.Detectors.Rust
                     return Task.CompletedTask;
                 }
 
-                FileInfo lockFileInfo = new FileInfo(cargoLockFile.Location);
-                IEnumerable<IComponentStream> cargoTomlComponentStream = this.ComponentStreamEnumerableFactory.GetComponentStreams(lockFileInfo.Directory, new List<string> { RustCrateUtilities.CargoTomlSearchPattern }, (name, directoryName) => false, recursivelyScanDirectories: false);
+                var lockFileInfo = new FileInfo(cargoLockFile.Location);
+                var cargoTomlComponentStream = this.ComponentStreamEnumerableFactory.GetComponentStreams(lockFileInfo.Directory, new List<string> { RustCrateUtilities.CargoTomlSearchPattern }, (name, directoryName) => false, recursivelyScanDirectories: false);
 
-                CargoDependencyData cargoDependencyData = RustCrateUtilities.ExtractRootDependencyAndWorkspaceSpecifications(cargoTomlComponentStream, singleFileComponentRecorder);
+                var cargoDependencyData = RustCrateUtilities.ExtractRootDependencyAndWorkspaceSpecifications(cargoTomlComponentStream, singleFileComponentRecorder);
 
                 // If workspaces have been defined in the root cargo.toml file, scan for specified cargo.toml manifests
-                int numWorkspaceComponentStreams = 0;
-                int expectedWorkspaceTomlCount = cargoDependencyData.CargoWorkspaces.Count;
+                var numWorkspaceComponentStreams = 0;
+                var expectedWorkspaceTomlCount = cargoDependencyData.CargoWorkspaces.Count;
                 if (expectedWorkspaceTomlCount > 0)
                 {
-                    string rootCargoTomlLocation = Path.Combine(lockFileInfo.DirectoryName, "Cargo.toml");
+                    var rootCargoTomlLocation = Path.Combine(lockFileInfo.DirectoryName, "Cargo.toml");
 
-                    IEnumerable<IComponentStream> cargoTomlWorkspaceComponentStreams = this.ComponentStreamEnumerableFactory.GetComponentStreams(
+                    var cargoTomlWorkspaceComponentStreams = this.ComponentStreamEnumerableFactory.GetComponentStreams(
                         lockFileInfo.Directory,
                         new List<string> { RustCrateUtilities.CargoTomlSearchPattern },
                         RustCrateUtilities.BuildExcludeDirectoryPredicateFromWorkspaces(lockFileInfo, cargoDependencyData.CargoWorkspaces, cargoDependencyData.CargoWorkspaceExclusions),

--- a/src/Microsoft.ComponentDetection.Detectors/rust/SemVer/ComparatorSet.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/rust/SemVer/ComparatorSet.cs
@@ -28,12 +28,12 @@ namespace Microsoft.ComponentDetection.Detectors.Rust.SemVer
                 spec = "*";
             }
 
-            int position = 0;
-            int end = spec.Length;
+            var position = 0;
+            var end = spec.Length;
 
             while (position < end)
             {
-                int iterStartPosition = position;
+                var iterStartPosition = position;
 
                 // A comparator set might be an advanced range specifier
                 // like ~1.2.3, ^1.2, or 1.*.
@@ -77,7 +77,7 @@ namespace Microsoft.ComponentDetection.Detectors.Rust.SemVer
 
         public bool IsSatisfied(SemVersion version)
         {
-            bool satisfied = this.comparators.All(c => c.IsSatisfied(version));
+            var satisfied = this.comparators.All(c => c.IsSatisfied(version));
             if (version.Prerelease != string.Empty)
             {
                 // If the version is a pre-release, then one of the

--- a/src/Microsoft.ComponentDetection.Detectors/rust/SemVer/Desugarer.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/rust/SemVer/Desugarer.cs
@@ -147,7 +147,7 @@ namespace Microsoft.ComponentDetection.Detectors.Rust.SemVer
             // Lower range has any non-supplied values replaced with zero
             var minVersion = minPartialVersion.ToZeroVersion();
 
-            Comparator.Operator maxOperator = maxPartialVersion.IsFull()
+            var maxOperator = maxPartialVersion.IsFull()
                 ? Comparator.Operator.LessThanOrEqual : Comparator.Operator.LessThan;
 
             SemVersion maxVersion = null;

--- a/src/Microsoft.ComponentDetection.Detectors/rust/SemVer/Range.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/rust/SemVer/Range.cs
@@ -63,7 +63,7 @@ namespace Microsoft.ComponentDetection.Detectors.Rust.SemVer
         {
             try
             {
-                SemVersion.TryParse(versionString, out SemVersion version, loose);
+                SemVersion.TryParse(versionString, out var version, loose);
                 return this.IsSatisfied(version);
             }
             catch (ArgumentException)

--- a/src/Microsoft.ComponentDetection.Detectors/yarn/Parsers/YarnBlockFile.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/yarn/Parsers/YarnBlockFile.cs
@@ -75,8 +75,8 @@ namespace Microsoft.ComponentDetection.Detectors.Yarn.Parsers
                 throw new ArgumentNullException(nameof(stream));
             }
 
-            List<string> fileLines = new List<string>();
-            using (StreamReader reader = new StreamReader(stream))
+            var fileLines = new List<string>();
+            using (var reader = new StreamReader(stream))
             {
                 while (!reader.EndOfStream)
                 {
@@ -122,7 +122,7 @@ namespace Microsoft.ComponentDetection.Detectors.Yarn.Parsers
                             this.VersionHeader = this.fileLines[this.fileLineIndex];
                             this.YarnLockVersion = YarnLockVersion.V2;
 
-                            YarnBlock metadataBlock = this.ParseBlock();
+                            var metadataBlock = this.ParseBlock();
 
                             if (metadataBlock.Values.ContainsKey("version") && metadataBlock.Values.ContainsKey("cacheKey"))
                             {
@@ -149,14 +149,14 @@ namespace Microsoft.ComponentDetection.Detectors.Yarn.Parsers
         /// <returns></returns>
         private YarnBlock ParseBlock(int level = 0)
         {
-            string currentLevelDelimiter = "  ";
-            for (int i = 0; i < level; i++)
+            var currentLevelDelimiter = "  ";
+            for (var i = 0; i < level; i++)
             {
                 currentLevelDelimiter = currentLevelDelimiter + "  ";
             }
 
             // Assuming the pointer has been set up to a block
-            YarnBlock block = new YarnBlock { Title = this.fileLines[this.fileLineIndex].TrimEnd(':').Trim('\"').Trim() };
+            var block = new YarnBlock { Title = this.fileLines[this.fileLineIndex].TrimEnd(':').Trim('\"').Trim() };
 
             while (this.IncrementIndex())
             {
@@ -172,7 +172,7 @@ namespace Microsoft.ComponentDetection.Detectors.Yarn.Parsers
                 }
                 else
                 {
-                    string toParse = this.fileLines[this.fileLineIndex].Trim();
+                    var toParse = this.fileLines[this.fileLineIndex].Trim();
 
                     // Yarn V1 and V2 have slightly different formats, where V2 adds a : between property name and value
                     // Match on the specified version

--- a/src/Microsoft.ComponentDetection.Detectors/yarn/Parsers/YarnLockParser.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/yarn/Parsers/YarnLockParser.cs
@@ -33,18 +33,18 @@ namespace Microsoft.ComponentDetection.Detectors.Yarn.Parsers
                 throw new ArgumentNullException(nameof(blockFile));
             }
 
-            YarnLockFile file = new YarnLockFile { LockVersion = blockFile.YarnLockVersion };
+            var file = new YarnLockFile { LockVersion = blockFile.YarnLockVersion };
             IList<YarnEntry> entries = new List<YarnEntry>();
 
             foreach (var block in blockFile)
             {
-                YarnEntry yarnEntry = new YarnEntry();
+                var yarnEntry = new YarnEntry();
                 var satisfiedPackages = block.Title.Split(',').Select(x => x.Trim())
                     .Select(this.GenerateBlockTitleNormalizer(block));
 
                 foreach (var package in satisfiedPackages)
                 {
-                    if (!this.TryReadNameAndSatisfiedVersion(package, out Tuple<string, string> parsed))
+                    if (!this.TryReadNameAndSatisfiedVersion(package, out var parsed))
                     {
                         continue;
                     }
@@ -63,7 +63,7 @@ namespace Microsoft.ComponentDetection.Detectors.Yarn.Parsers
                     continue;
                 }
 
-                if (!block.Values.TryGetValue(VersionString, out string version))
+                if (!block.Values.TryGetValue(VersionString, out var version))
                 {
                     logger.LogWarning($"Failed to read a version for {yarnEntry.Name}. The entry will be skipped.");
                     continue;
@@ -71,7 +71,7 @@ namespace Microsoft.ComponentDetection.Detectors.Yarn.Parsers
 
                 yarnEntry.Version = version;
 
-                if (block.Values.TryGetValue(Resolved, out string resolved))
+                if (block.Values.TryGetValue(Resolved, out var resolved))
                 {
                     yarnEntry.Resolved = resolved;
                 }
@@ -131,25 +131,25 @@ namespace Microsoft.ComponentDetection.Detectors.Yarn.Parsers
         private bool TryReadNameAndSatisfiedVersion(string nameVersionPairing, out Tuple<string, string> output)
         {
             output = null;
-            string workingString = nameVersionPairing;
+            var workingString = nameVersionPairing;
             workingString = workingString.TrimEnd(':');
             workingString = workingString.Trim('\"');
-            bool startsWithAtSign = false;
+            var startsWithAtSign = false;
             if (workingString.StartsWith("@"))
             {
                 startsWithAtSign = true;
                 workingString = workingString.TrimStart('@');
             }
 
-            string[] parts = workingString.Split('@');
+            var parts = workingString.Split('@');
 
             if (parts.Length != 2)
             {
                 return false;
             }
 
-            string at = startsWithAtSign ? "@" : string.Empty;
-            string name = $"{at}{parts[0]}";
+            var at = startsWithAtSign ? "@" : string.Empty;
+            var name = $"{at}{parts[0]}";
 
             output = new Tuple<string, string>(name, parts[1]);
             return true;

--- a/src/Microsoft.ComponentDetection.Detectors/yarn/YarnLockComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/yarn/YarnLockComponentDetector.cs
@@ -35,7 +35,7 @@ namespace Microsoft.ComponentDetection.Detectors.Yarn
             var singleFileComponentRecorder = processRequest.SingleFileComponentRecorder;
             var file = processRequest.ComponentStream;
 
-            string skippedFolder = this.SkippedFolders.FirstOrDefault(folder => file.Location.Contains(folder));
+            var skippedFolder = this.SkippedFolders.FirstOrDefault(folder => file.Location.Contains(folder));
             if (!string.IsNullOrEmpty(skippedFolder))
             {
                 this.Logger.LogInfo($"Yarn.Lock file {file.Location} was found in a {skippedFolder} folder and will be skipped.");
@@ -58,7 +58,7 @@ namespace Microsoft.ComponentDetection.Detectors.Yarn
 
         private void DetectComponents(YarnLockFile file, string location, ISingleFileComponentRecorder singleFileComponentRecorder)
         {
-            Dictionary<string, YarnEntry> yarnPackages = new Dictionary<string, YarnEntry>();
+            var yarnPackages = new Dictionary<string, YarnEntry>();
 
             // Iterate once and build our provider lookup for all possible yarn packages requests
             // Each entry can satisfy more than one request in a Yarn.Lock file
@@ -78,7 +78,7 @@ namespace Microsoft.ComponentDetection.Detectors.Yarn
                 }
             }
 
-            if (yarnPackages.Count == 0 || !this.TryReadPeerPackageJsonRequestsAsYarnEntries(location, yarnPackages, out List<YarnEntry> yarnRoots))
+            if (yarnPackages.Count == 0 || !this.TryReadPeerPackageJsonRequestsAsYarnEntries(location, yarnPackages, out var yarnRoots))
             {
                 return;
             }
@@ -116,16 +116,16 @@ namespace Microsoft.ComponentDetection.Detectors.Yarn
         /// <param name="singleFileComponentRecorder">The component recorder for file that is been processed.</param>
         private void ParseTreeWithAssignedRoot(YarnEntry root, Dictionary<string, YarnEntry> providerTable, ISingleFileComponentRecorder singleFileComponentRecorder)
         {
-            Queue<(YarnEntry, YarnEntry)> queue = new Queue<(YarnEntry, YarnEntry)>();
+            var queue = new Queue<(YarnEntry, YarnEntry)>();
 
             queue.Enqueue((root, null));
-            HashSet<string> processed = new HashSet<string>();
+            var processed = new HashSet<string>();
 
             while (queue.Count > 0)
             {
                 var (currentEntry, parentEntry) = queue.Dequeue();
-                DetectedComponent currentComponent = singleFileComponentRecorder.GetComponent(this.YarnEntryToComponentId(currentEntry));
-                DetectedComponent parentComponent = parentEntry != null ? singleFileComponentRecorder.GetComponent(this.YarnEntryToComponentId(parentEntry)) : null;
+                var currentComponent = singleFileComponentRecorder.GetComponent(this.YarnEntryToComponentId(currentEntry));
+                var parentComponent = parentEntry != null ? singleFileComponentRecorder.GetComponent(this.YarnEntryToComponentId(parentEntry)) : null;
 
                 if (currentComponent != null)
                 {
@@ -179,7 +179,7 @@ namespace Microsoft.ComponentDetection.Detectors.Yarn
 
             IDictionary<string, IDictionary<string, bool>> combinedDependencies = new Dictionary<string, IDictionary<string, bool>>();
 
-            int pkgJsonCount = 0;
+            var pkgJsonCount = 0;
 
             IList<string> yarnWorkspaces = new List<string>();
             foreach (var pkgJson in pkgJsons)
@@ -203,7 +203,7 @@ namespace Microsoft.ComponentDetection.Detectors.Yarn
             // into the appropriate yarn package
             foreach (var dependency in combinedDependencies)
             {
-                string name = dependency.Key;
+                var name = dependency.Key;
                 foreach (var version in dependency.Value)
                 {
                     var entryKey = $"{name}@npm:{version.Key}";
@@ -265,7 +265,7 @@ namespace Microsoft.ComponentDetection.Detectors.Yarn
 
             foreach (var item in newDependency.Value)
             {
-                if (existingDependency.TryGetValue(item.Key, out bool wasDev))
+                if (existingDependency.TryGetValue(item.Key, out var wasDev))
                 {
                     existingDependency[item.Key] = wasDev && item.Value;
                 }

--- a/src/Microsoft.ComponentDetection.Detectors/yarn/YarnLockFileFactory.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/yarn/YarnLockFileFactory.cs
@@ -17,7 +17,7 @@ namespace Microsoft.ComponentDetection.Detectors.Yarn
 
         public static async Task<YarnLockFile> ParseYarnLockFileAsync(Stream file, ILogger logger)
         {
-            YarnBlockFile blockFile = await YarnBlockFile.CreateBlockFileAsync(file);
+            var blockFile = await YarnBlockFile.CreateBlockFileAsync(file);
 
             foreach (var parser in Parsers)
             {

--- a/src/Microsoft.ComponentDetection.Orchestrator/ArgumentHelper.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/ArgumentHelper.cs
@@ -24,7 +24,7 @@ namespace Microsoft.ComponentDetection.Orchestrator
 
         public ParserResult<T> ParseArguments<T>(string[] args, bool ignoreInvalidArgs = false)
         {
-            Parser p = new Parser(x =>
+            var p = new Parser(x =>
             {
                 x.IgnoreUnknownArguments = ignoreInvalidArgs;
 

--- a/src/Microsoft.ComponentDetection.Orchestrator/Orchestrator.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Orchestrator.cs
@@ -29,7 +29,7 @@ namespace Microsoft.ComponentDetection.Orchestrator
 
         public ScanResult Load(string[] args)
         {
-            ArgumentHelper argumentHelper = new ArgumentHelper { ArgumentSets = new[] { new BaseArguments() } };
+            var argumentHelper = new ArgumentHelper { ArgumentSets = new[] { new BaseArguments() } };
             BaseArguments baseArguments = null;
             var parserResult = argumentHelper.ParseArguments<BaseArguments>(args, true);
             parserResult.WithParsed(x => baseArguments = x);
@@ -39,7 +39,7 @@ namespace Microsoft.ComponentDetection.Orchestrator
                 baseArguments = new BaseArguments();
             }
 
-            IEnumerable<string> additionalDITargets = baseArguments.AdditionalDITargets ?? Enumerable.Empty<string>();
+            var additionalDITargets = baseArguments.AdditionalDITargets ?? Enumerable.Empty<string>();
 
             // Load all types from Common (where Logger lives) and our executing assembly.
             var configuration = new ContainerConfiguration()
@@ -62,7 +62,7 @@ namespace Microsoft.ComponentDetection.Orchestrator
 
             TelemetryRelay.Instance.SetTelemetryMode(baseArguments.DebugTelemetry ? TelemetryMode.Debug : TelemetryMode.Production);
 
-            bool shouldFailureBeSuppressed = false;
+            var shouldFailureBeSuppressed = false;
 
             // Don't use the using pattern here so we can take care not to clobber the stack
             var returnResult = BcdeExecutionTelemetryRecord.Track(
@@ -188,7 +188,7 @@ namespace Microsoft.ComponentDetection.Orchestrator
                     var getLibSslPackages = Task.Run(() =>
                     {
                         var startInfo = new ProcessStartInfo("apt", "list --installed") { RedirectStandardOutput = true };
-                        Process process = new Process { StartInfo = startInfo };
+                        var process = new Process { StartInfo = startInfo };
                         process.Start();
                         string aptListResult = null;
                         var task = Task.Run(() => aptListResult = process.StandardOutput.ReadToEnd());
@@ -288,7 +288,7 @@ namespace Microsoft.ComponentDetection.Orchestrator
                     Logger.LogError($"There was an unexpected error: ");
                     Logger.LogException(e, isError: true);
 
-                    StringBuilder errorMessage = new StringBuilder();
+                    var errorMessage = new StringBuilder();
                     errorMessage.AppendLine(e.ToString());
                     if (e is ReflectionTypeLoadException refEx && refEx.LoaderExceptions != null)
                     {

--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/BcdeScanCommandService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/BcdeScanCommandService.cs
@@ -26,7 +26,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Services
 
         public async Task<ScanResult> Handle(IScanArguments arguments)
         {
-            BcdeArguments bcdeArguments = (BcdeArguments)arguments;
+            var bcdeArguments = (BcdeArguments)arguments;
             var result = await this.BcdeScanExecutionService.ExecuteScanAsync(bcdeArguments);
             this.WriteComponentManifest(bcdeArguments, result);
             return result;

--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/BcdeScanExecutionService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/BcdeScanExecutionService.cs
@@ -55,7 +55,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Services
                 throw new NoDetectorsFoundException();
             }
 
-            DetectorRestrictions detectorRestrictions = this.GetDetectorRestrictions(detectionArguments);
+            var detectorRestrictions = this.GetDetectorRestrictions(detectionArguments);
             var detectors = this.DetectorRestrictionService.ApplyRestrictions(detectorRestrictions, initialDetectors).ToImmutableList();
 
             this.Logger.LogVerbose($"Finished applying restrictions to detectors.");

--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/DetectorProcessingService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/DetectorProcessingService.cs
@@ -38,21 +38,21 @@ namespace Microsoft.ComponentDetection.Orchestrator.Services
             this.Logger.LogCreateLoggingGroup();
             this.Logger.LogInfo($"Finding components...");
 
-            Stopwatch stopwatch = Stopwatch.StartNew();
+            var stopwatch = Stopwatch.StartNew();
             var exitCode = ProcessingResultCode.Success;
 
             // Run the scan on all protocol scanners and union the results
-            ConcurrentDictionary<string, DetectorRunResult> providerElapsedTime = new ConcurrentDictionary<string, DetectorRunResult>();
+            var providerElapsedTime = new ConcurrentDictionary<string, DetectorRunResult>();
             var detectorArguments = GetDetectorArgs(detectionArguments.DetectorArgs);
 
-            ExcludeDirectoryPredicate exclusionPredicate = this.IsOSLinuxOrMac()
+            var exclusionPredicate = this.IsOSLinuxOrMac()
                 ? this.GenerateDirectoryExclusionPredicate(detectionArguments.SourceDirectory.ToString(), detectionArguments.DirectoryExclusionList, detectionArguments.DirectoryExclusionListObsolete, allowWindowsPaths: false, ignoreCase: false)
                 : this.GenerateDirectoryExclusionPredicate(detectionArguments.SourceDirectory.ToString(), detectionArguments.DirectoryExclusionList, detectionArguments.DirectoryExclusionListObsolete, allowWindowsPaths: true, ignoreCase: true);
 
             IEnumerable<Task<(IndividualDetectorScanResult, ComponentRecorder, IComponentDetector)>> scanTasks = detectors
                 .Select(async detector =>
                 {
-                    Stopwatch providerStopwatch = new Stopwatch();
+                    var providerStopwatch = new Stopwatch();
                     providerStopwatch.Start();
 
                     var componentRecorder = new ComponentRecorder(this.Logger, !detector.NeedsAutomaticRootDependencyCalculation);
@@ -118,7 +118,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Services
 
             var results = await Task.WhenAll(scanTasks);
 
-            DetectorProcessingResult detectorProcessingResult = this.ConvertDetectorResultsIntoResult(results, exitCode);
+            var detectorProcessingResult = this.ConvertDetectorResultsIntoResult(results, exitCode);
 
             var totalElapsedTime = stopwatch.Elapsed.TotalSeconds;
             this.LogTabularOutput(this.Logger, providerElapsedTime, totalElapsedTime);
@@ -190,7 +190,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Services
 
         private void LogTabularOutput(ILogger logger, ConcurrentDictionary<string, DetectorRunResult> providerElapsedTime, double totalElapsedTime)
         {
-            TabularStringFormat tsf = new TabularStringFormat(new Column[]
+            var tsf = new TabularStringFormat(new Column[]
                         {
                             new Column { Header = "Component Detector Id", Width = 30 },
                             new Column { Header = "Detection Time", Width = 30, Format = "{0:g2} seconds" },
@@ -271,8 +271,8 @@ namespace Microsoft.ComponentDetection.Orchestrator.Services
 
                 return (ReadOnlySpan<char> nameOfDirectoryToConsiderSpan, ReadOnlySpan<char> pathOfParentOfDirectoryToConsiderSpan) =>
                 {
-                    string pathOfParentOfDirectoryToConsider = pathOfParentOfDirectoryToConsiderSpan.ToString();
-                    string nameOfDirectoryToConsider = nameOfDirectoryToConsiderSpan.ToString();
+                    var pathOfParentOfDirectoryToConsider = pathOfParentOfDirectoryToConsiderSpan.ToString();
+                    var nameOfDirectoryToConsider = nameOfDirectoryToConsiderSpan.ToString();
 
                     foreach (var valueTuple in directories)
                     {
@@ -292,7 +292,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Services
                 };
             }
 
-            Dictionary<string, Glob> minimatchers = new Dictionary<string, Glob>();
+            var minimatchers = new Dictionary<string, Glob>();
 
             var globOptions = new GlobOptions()
             {

--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/DetectorRegistryService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/DetectorRegistryService.cs
@@ -27,7 +27,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Services
             var executableLocation = Assembly.GetEntryAssembly().Location;
             var searchPath = Path.Combine(Path.GetDirectoryName(executableLocation), "Plugins");
 
-            List<DirectoryInfo> directoriesToSearch = new List<DirectoryInfo> { new DirectoryInfo(searchPath) };
+            var directoriesToSearch = new List<DirectoryInfo> { new DirectoryInfo(searchPath) };
 
             if (additionalSearchDirectories != null)
             {
@@ -58,7 +58,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Services
 
         private IList<IComponentDetector> GetComponentDetectors(IEnumerable<DirectoryInfo> searchPaths, IEnumerable<string> extraDetectorAssemblies)
         {
-            List<IComponentDetector> detectors = new List<IComponentDetector>();
+            var detectors = new List<IComponentDetector>();
 
             using (var record = new LoadComponentDetectorsTelemetryRecord())
             {
@@ -130,7 +130,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Services
         // Plugin producers may include files we have already loaded
         private IList<Assembly> SafeLoadAssemblies(IEnumerable<string> files)
         {
-            List<Assembly> assemblyList = new List<Assembly>();
+            var assemblyList = new List<Assembly>();
 
             foreach (var file in files)
             {

--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/DetectorRestrictionService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/DetectorRestrictionService.cs
@@ -25,7 +25,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Services
             // If someone specifies an "allow list", use it, otherwise assume everything is allowed
             if (argSpecifiedRestrictions.AllowedDetectorIds != null && argSpecifiedRestrictions.AllowedDetectorIds.Any())
             {
-                IEnumerable<string> allowedIds = argSpecifiedRestrictions.AllowedDetectorIds;
+                var allowedIds = argSpecifiedRestrictions.AllowedDetectorIds;
 
                 // If we have retired detectors in the arg specified list and don't have the new detector, add the new detector
                 if (allowedIds.Where(a => this.oldDetectorIds.Contains(a, StringComparer.OrdinalIgnoreCase)).Any() && !allowedIds.Contains(this.newDetectorId, StringComparer.OrdinalIgnoreCase))

--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/GraphTranslation/DefaultGraphTranslationService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/GraphTranslation/DefaultGraphTranslationService.cs
@@ -103,7 +103,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Services.GraphTranslation
 
         private List<DetectedComponent> FlattenAndMergeComponents(IEnumerable<DetectedComponent> components)
         {
-            List<DetectedComponent> flattenedAndMergedComponents = new List<DetectedComponent>();
+            var flattenedAndMergedComponents = new List<DetectedComponent>();
             foreach (var grouping in components.GroupBy(x => x.Component.Id + x.DetectedBy.Id))
             {
                 flattenedAndMergedComponents.Add(this.MergeComponents(grouping));
@@ -189,7 +189,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Services.GraphTranslation
             }
 
             // Make relative Uri needs a trailing separator to ensure that we turn "directory we are scanning" into "/"
-            string rootDirectoryFullName = rootDirectory.FullName;
+            var rootDirectoryFullName = rootDirectory.FullName;
             if (!rootDirectory.FullName.EndsWith(Path.DirectorySeparatorChar.ToString()) && !rootDirectory.FullName.EndsWith(Path.AltDirectorySeparatorChar.ToString()))
             {
                 rootDirectoryFullName += Path.DirectorySeparatorChar;

--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/GraphTranslation/GraphTranslationUtility.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/GraphTranslation/GraphTranslationUtility.cs
@@ -35,7 +35,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Services.GraphTranslation
                         var componentDependencies = graphByLocation.Value.GetDependenciesForComponent(componentId);
 
                         // We set dependencies to null basically to make the serialized output look more consistent (instead of empty arrays). If another location gets merged that has dependencies, it needs to create and set the key to non-null.
-                        if (!graphWithMetadata.Graph.TryGetValue(componentId, out HashSet<string> dependencies))
+                        if (!graphWithMetadata.Graph.TryGetValue(componentId, out var dependencies))
                         {
                             dependencies = componentDependencies != null && componentDependencies.Any() ? new HashSet<string>() : null;
                             graphWithMetadata.Graph[componentId] = dependencies;

--- a/src/Microsoft.ComponentDetection/Program.cs
+++ b/src/Microsoft.ComponentDetection/Program.cs
@@ -30,7 +30,7 @@ namespace Microsoft.ComponentDetection.Loader
 
                 var result = orchestrator.Load(args);
 
-                int exitCode = (int)result.ResultCode;
+                var exitCode = (int)result.ResultCode;
                 if (result.ResultCode == ProcessingResultCode.Error || result.ResultCode == ProcessingResultCode.InputError)
                 {
                     exitCode = -1;

--- a/test/Microsoft.ComponentDetection.Common.Tests/CommandLineInvocationServiceTests.cs
+++ b/test/Microsoft.ComponentDetection.Common.Tests/CommandLineInvocationServiceTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.ComponentDetection.Common.Tests
         {
             var isLocated = await this.commandLineService.CanCommandBeLocated("cmd.exe", default, "/C");
             Assert.IsTrue(isLocated);
-            StringBuilder largeStringBuilder = new StringBuilder();
+            var largeStringBuilder = new StringBuilder();
             while (largeStringBuilder.Length < 8100) // Cmd.exe command limit is in the 8100s
             {
                 largeStringBuilder.Append("Some sample text");
@@ -72,7 +72,7 @@ namespace Microsoft.ComponentDetection.Common.Tests
         {
             var isLocated = await this.commandLineService.CanCommandBeLocated("cmd.exe", default, "/C");
             Assert.IsTrue(isLocated);
-            StringBuilder largeStringBuilder = new StringBuilder();
+            var largeStringBuilder = new StringBuilder();
             while (largeStringBuilder.Length < 9000) // Pick a command that is "too big" for cmd.
             {
                 largeStringBuilder.Append("Some sample text");
@@ -89,7 +89,7 @@ namespace Microsoft.ComponentDetection.Common.Tests
         {
             var isLocated = await this.commandLineService.CanCommandBeLocated("cmd.exe", default, "/C");
             Assert.IsTrue(isLocated);
-            string tempDirectoryPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            var tempDirectoryPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
             var tempDirectory = Directory.CreateDirectory(tempDirectoryPath);
 
             var taskResult = await this.commandLineService.ExecuteCommand("cmd.exe", default, workingDirectory: tempDirectory, "/C cd");

--- a/test/Microsoft.ComponentDetection.Common.Tests/DependencyScopeComparerTests.cs
+++ b/test/Microsoft.ComponentDetection.Common.Tests/DependencyScopeComparerTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.ComponentDetection.Common.Tests
         [TestMethod]
         public void GetMergedDependencyScope_returnSecondIfFirstNulll()
         {
-            DependencyScope randomDependencyScope = Faker.Enum.Random<DependencyScope>();
+            var randomDependencyScope = Faker.Enum.Random<DependencyScope>();
             GetMergedDependencyScope(null, randomDependencyScope)
                 .Should()
                 .Be(randomDependencyScope);
@@ -28,7 +28,7 @@ namespace Microsoft.ComponentDetection.Common.Tests
         [TestMethod]
         public void GetMergedDependencyScope_returnFirstIfSecondNulll()
         {
-            DependencyScope randomDependencyScope = Faker.Enum.Random<DependencyScope>();
+            var randomDependencyScope = Faker.Enum.Random<DependencyScope>();
             GetMergedDependencyScope(randomDependencyScope, null)
                 .Should()
                 .Be(randomDependencyScope);

--- a/test/Microsoft.ComponentDetection.Common.Tests/SafeFileEnumerableTests.cs
+++ b/test/Microsoft.ComponentDetection.Common.Tests/SafeFileEnumerableTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.ComponentDetection.Common.Tests
         public void GetEnumerator_WorksOverExpectedFiles()
         {
             var subDir = Directory.CreateDirectory(Path.Combine(this.temporaryDirectory, "SubDir"));
-            string name = string.Format("{0}.txt", Guid.NewGuid());
+            var name = string.Format("{0}.txt", Guid.NewGuid());
 
             var file0 = Path.Combine(this.temporaryDirectory, name);
             var subFile0 = Path.Combine(this.temporaryDirectory, "SubDir", name);
@@ -52,7 +52,7 @@ namespace Microsoft.ComponentDetection.Common.Tests
 
             var enumerable = new SafeFileEnumerable(new DirectoryInfo(this.temporaryDirectory), searchPatterns, this.loggerMock.Object, this.pathUtilityServiceMock.Object, (directoryName, span) => false, true);
 
-            int filesFound = 0;
+            var filesFound = 0;
             foreach (var file in enumerable)
             {
                 file.File.FullName.Should().BeOneOf(file0, subFile0);
@@ -66,7 +66,7 @@ namespace Microsoft.ComponentDetection.Common.Tests
         public void GetEnumerator_IgnoresSubDirectories()
         {
             var subDir = Directory.CreateDirectory(Path.Combine(this.temporaryDirectory, "SubDir"));
-            string name = string.Format("{0}.txt", Guid.NewGuid());
+            var name = string.Format("{0}.txt", Guid.NewGuid());
 
             var file0 = Path.Combine(this.temporaryDirectory, name);
 
@@ -79,7 +79,7 @@ namespace Microsoft.ComponentDetection.Common.Tests
 
             var enumerable = new SafeFileEnumerable(new DirectoryInfo(this.temporaryDirectory), searchPatterns, this.loggerMock.Object, this.pathUtilityServiceMock.Object, (directoryName, span) => false, false);
 
-            int filesFound = 0;
+            var filesFound = 0;
             foreach (var file in enumerable)
             {
                 file.File.FullName.Should().BeOneOf(file0);
@@ -94,7 +94,7 @@ namespace Microsoft.ComponentDetection.Common.Tests
         {
             Assert.Inconclusive("Need actual symlinks to accurately test this");
             var subDir = Directory.CreateDirectory(Path.Combine(this.temporaryDirectory, "SubDir"));
-            string name = string.Format("{0}.txt", Guid.NewGuid());
+            var name = string.Format("{0}.txt", Guid.NewGuid());
             File.Create(Path.Combine(this.temporaryDirectory, name)).Close();
             File.Create(Path.Combine(this.temporaryDirectory, "SubDir", name)).Close();
 
@@ -117,8 +117,8 @@ namespace Microsoft.ComponentDetection.Common.Tests
 
             var subDir = Directory.CreateDirectory(Path.Combine(this.temporaryDirectory, "SubDir"));
             var fakeSymlink = Directory.CreateDirectory(Path.Combine(this.temporaryDirectory, "FakeSymlink"));
-            string name = string.Format("{0}.txt", Guid.NewGuid());
-            string canary = string.Format("{0}.txt", Guid.NewGuid());
+            var name = string.Format("{0}.txt", Guid.NewGuid());
+            var canary = string.Format("{0}.txt", Guid.NewGuid());
             File.Create(Path.Combine(this.temporaryDirectory, name)).Close();
             File.Create(Path.Combine(this.temporaryDirectory, "SubDir", name)).Close();
             File.Create(Path.Combine(this.temporaryDirectory, "FakeSymlink", canary)).Close();
@@ -141,7 +141,7 @@ namespace Microsoft.ComponentDetection.Common.Tests
 
         private string GetTemporaryDirectory()
         {
-            string tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            var tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
             Directory.CreateDirectory(tempDirectory);
             return tempDirectory;
         }

--- a/test/Microsoft.ComponentDetection.Common.Tests/TabularStringFormatTests.cs
+++ b/test/Microsoft.ComponentDetection.Common.Tests/TabularStringFormatTests.cs
@@ -56,7 +56,7 @@ namespace Microsoft.ComponentDetection.Common.Tests
 
             // Second row has the headers
             var headerCells = splitStrings[1].Split(new[] { TabularStringFormat.DefaultVerticalLineChar }, StringSplitOptions.RemoveEmptyEntries);
-            for (int i = 0; i < this.columns.Length; i++)
+            for (var i = 0; i < this.columns.Length; i++)
             {
                 headerCells[i]
                     .Should().Contain(this.columns[i].Header);
@@ -71,7 +71,7 @@ namespace Microsoft.ComponentDetection.Common.Tests
 
             // Fourth row should have some info
             var rowCells = splitStrings[3].Split(new[] { TabularStringFormat.DefaultVerticalLineChar }, StringSplitOptions.RemoveEmptyEntries);
-            for (int i = 0; i < this.columns.Length; i++)
+            for (var i = 0; i < this.columns.Length; i++)
             {
                 rowCells[i]
                     .Should().Contain(this.rows[0][i].ToString());

--- a/test/Microsoft.ComponentDetection.Contracts.Tests/DetectedComponentTests.cs
+++ b/test/Microsoft.ComponentDetection.Contracts.Tests/DetectedComponentTests.cs
@@ -11,11 +11,11 @@ namespace Microsoft.ComponentDetection.Contracts.Tests
         [TestMethod]
         public void AddComponentFilePath_AddsPathsCorrectly()
         {
-            string componentName = "express";
-            string componentVersion = "1.0.0";
-            string filePathToAdd = @"C:\some\fake\file\path.txt";
+            var componentName = "express";
+            var componentVersion = "1.0.0";
+            var filePathToAdd = @"C:\some\fake\file\path.txt";
 
-            DetectedComponent component = new DetectedComponent(new NpmComponent(componentName, componentVersion));
+            var component = new DetectedComponent(new NpmComponent(componentName, componentVersion));
 
             Assert.IsNotNull(component.FilePaths);
             Assert.AreEqual(0, component.FilePaths.Count);

--- a/test/Microsoft.ComponentDetection.Contracts.Tests/ScanResultSerializationTests.cs
+++ b/test/Microsoft.ComponentDetection.Contracts.Tests/ScanResultSerializationTests.cs
@@ -92,7 +92,7 @@ namespace Microsoft.ComponentDetection.Contracts.Tests
         public void ScanResultSerialization_ExpectedJsonFormat()
         {
             var serializedResult = JsonConvert.SerializeObject(this.scanResultUnderTest);
-            JObject json = JObject.Parse(serializedResult);
+            var json = JObject.Parse(serializedResult);
 
             json.Value<string>("resultCode").Should().Be("PartialSuccess");
             json.Value<string>("sourceDirectory").Should().Be("D:\\test\\directory");

--- a/test/Microsoft.ComponentDetection.Contracts.Tests/TypedComponentSerializationTests.cs
+++ b/test/Microsoft.ComponentDetection.Contracts.Tests/TypedComponentSerializationTests.cs
@@ -29,8 +29,8 @@ namespace Microsoft.ComponentDetection.Contracts.Tests
         [TestMethod]
         public void TypedComponent_Serialization_NuGet()
         {
-            string testComponentName = "SomeNuGetComponent";
-            string testVersion = "1.2.3";
+            var testComponentName = "SomeNuGetComponent";
+            var testVersion = "1.2.3";
             string[] testAuthors = { "John Doe", "Jane Doe" };
             TypedComponent.TypedComponent tc = new NuGetComponent(testComponentName, testVersion, testAuthors);
             var result = JsonConvert.SerializeObject(tc);
@@ -45,7 +45,7 @@ namespace Microsoft.ComponentDetection.Contracts.Tests
         [TestMethod]
         public void TypedComponent_Serialization_Npm()
         {
-            NpmAuthor npmAuthor = new NpmAuthor("someAuthorName", "someAuthorEmail");
+            var npmAuthor = new NpmAuthor("someAuthorName", "someAuthorEmail");
             var npmCompObj = new NpmComponent("SomeNpmComponent", "1.2.3")
             {
                 Author = npmAuthor,

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/GoComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/GoComponentDetectorTests.cs
@@ -107,7 +107,7 @@ github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 
             var detectedComponents = componentRecorder.GetDetectedComponents();
             Assert.AreEqual(6, detectedComponents.Count());
-            List<TypedComponent> typedComponents = detectedComponents.Select(d => d.Component).ToList();
+            var typedComponents = detectedComponents.Select(d => d.Component).ToList();
             Assert.IsTrue(typedComponents.Contains(
                 new GoComponent("github.com/golang/mock", "v1.1.1", "h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=")));
             Assert.IsTrue(typedComponents.Contains(
@@ -193,7 +193,7 @@ require (
         [TestMethod]
         public async Task TestGoModDetectorInvalidFiles_DoesNotFail()
         {
-            string invalidGoMod =
+            var invalidGoMod =
 @"     #/bin/sh
 lorem ipsum
 four score and seven bugs ago

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/GoComponentTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/GoComponentTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         [TestMethod]
         public void ConstructorTest_NameVersion()
         {
-            GoComponent goComponent = new GoComponent(TestName, TestVersion);
+            var goComponent = new GoComponent(TestName, TestVersion);
             Assert.AreEqual(TestName, goComponent.Name);
             Assert.AreEqual(TestVersion, goComponent.Version);
             Assert.AreEqual(string.Empty, goComponent.Hash);
@@ -32,20 +32,20 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         [ExpectedException(typeof(ArgumentNullException))]
         public void ConstructorTest_NameVersion_NullVersion()
         {
-            GoComponent goComponent = new GoComponent(TestName, null);
+            var goComponent = new GoComponent(TestName, null);
         }
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentNullException))]
         public void ConstructorTest_NameVersion_NullName()
         {
-            GoComponent goComponent = new GoComponent(null, TestVersion);
+            var goComponent = new GoComponent(null, TestVersion);
         }
 
         [TestMethod]
         public void ConstructorTest_NameVersionHash()
         {
-            GoComponent goComponent = new GoComponent(TestName, TestVersion, TestHash);
+            var goComponent = new GoComponent(TestName, TestVersion, TestHash);
             Assert.AreEqual(TestName, goComponent.Name);
             Assert.AreEqual(TestVersion, goComponent.Version);
             Assert.AreEqual(TestHash, goComponent.Hash);
@@ -56,29 +56,29 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         [ExpectedException(typeof(ArgumentNullException))]
         public void ConstructorTest_NameVersionHash_NullVersion()
         {
-            GoComponent goComponent = new GoComponent(TestName, null, TestHash);
+            var goComponent = new GoComponent(TestName, null, TestHash);
         }
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentNullException))]
         public void ConstructorTest_NameVersionHash_NullName()
         {
-            GoComponent goComponent = new GoComponent(null, TestVersion, TestHash);
+            var goComponent = new GoComponent(null, TestVersion, TestHash);
         }
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentNullException))]
         public void ConstructorTest_NameVersionHash_NullHash()
         {
-            GoComponent goComponent = new GoComponent(TestName, TestVersion, null);
+            var goComponent = new GoComponent(TestName, TestVersion, null);
         }
 
         [TestMethod]
         public void TestEquals()
         {
-            GoComponent goComponent1 = new GoComponent(TestName, TestVersion, TestHash);
-            GoComponent goComponent2 = new GoComponent(TestName, TestVersion, TestHash);
-            GoComponent goComponent3 = new GoComponent(TestName, TestVersion, Guid.NewGuid().ToString());
+            var goComponent1 = new GoComponent(TestName, TestVersion, TestHash);
+            var goComponent2 = new GoComponent(TestName, TestVersion, TestHash);
+            var goComponent3 = new GoComponent(TestName, TestVersion, Guid.NewGuid().ToString());
             Assert.IsTrue(goComponent1.Equals(goComponent2));
             Assert.IsTrue(((object)goComponent1).Equals(goComponent2));
 
@@ -89,8 +89,8 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         [TestMethod]
         public void TestGetHashCode()
         {
-            GoComponent goComponent1 = new GoComponent(TestName, TestVersion, TestHash);
-            GoComponent goComponent2 = new GoComponent(TestName, TestVersion, TestHash);
+            var goComponent1 = new GoComponent(TestName, TestVersion, TestHash);
+            var goComponent2 = new GoComponent(TestName, TestVersion, TestHash);
             Assert.IsTrue(goComponent1.GetHashCode() == goComponent2.GetHashCode());
         }
     }

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/GradleComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/GradleComponentDetectorTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         [TestMethod]
         public async Task TestGradleDetectorWithValidFile_DetectsComponentsSuccessfully()
         {
-            string validFileOne =
+            var validFileOne =
 @"org.springframework:spring-beans:5.0.5.RELEASE
 org.springframework:spring-core:5.0.5.RELEASE
 org.springframework:spring-jcl:5.0.5.RELEASE";
@@ -68,7 +68,7 @@ org.springframework:spring-jcl:5.0.5.RELEASE";
         [TestMethod]
         public async Task TestGradleDetectorWithValidSingleLockfilePerProject_DetectsComponentsSuccessfully()
         {
-            string validFileOne =
+            var validFileOne =
 @"org.springframework:spring-beans:5.0.5.RELEASE=lintClassPath
 org.springframework:spring-core:5.0.5.RELEASE=debugCompile,releaseCompile
 org.springframework:spring-jcl:5.0.5.RELEASE=lintClassPath,debugCompile,releaseCompile";
@@ -100,12 +100,12 @@ org.springframework:spring-jcl:5.0.5.RELEASE=lintClassPath,debugCompile,releaseC
         [TestMethod]
         public async Task TestGradleDetectorWithValidFiles_ReturnsSuccessfully()
         {
-            string validFileOne =
+            var validFileOne =
 @"org.springframework:spring-beans:5.0.5.RELEASE
 org.springframework:spring-core:5.0.5.RELEASE
 org.springframework:spring-jcl:5.0.5.RELEASE";
 
-            string validFileTwo =
+            var validFileTwo =
 @"com.fasterxml.jackson.core:jackson-annotations:2.8.0
 com.fasterxml.jackson.core:jackson-core:2.8.10
 com.fasterxml.jackson.core:jackson-databind:2.8.11.3
@@ -151,10 +151,10 @@ org.springframework:spring-jcl:5.0.5.RELEASE";
         [TestMethod]
         public async Task TestGradleDetector_SameComponentDifferentLocations_DifferentLocationsAreSaved()
         {
-            string validFileOne =
+            var validFileOne =
 @"org.springframework:spring-beans:5.0.5.RELEASE";
 
-            string validFileTwo =
+            var validFileTwo =
 "org.springframework:spring-beans:5.0.5.RELEASE";
 
             var (scanResult, componentRecorder) = await this.detectorTestUtility
@@ -182,14 +182,14 @@ org.springframework:spring-jcl:5.0.5.RELEASE";
         [TestMethod]
         public async Task TestGradleDetectorWithInvalidAndValidFiles_ReturnsSuccessfully()
         {
-            string validFileTwo =
+            var validFileTwo =
 @"com.fasterxml.jackson.core:jackson-annotations:2.8.0
 com.fasterxml.jackson.core:jackson-core:2.8.10
 com.fasterxml.jackson.core:jackson-databind:2.8.11.3
 org.msgpack:msgpack-core:0.8.16
 org.springframework:spring-jcl:5.0.5.RELEASE";
 
-            string invalidFileOne =
+            var invalidFileOne =
 @"     #/bin/sh
 lorem ipsum
 four score and seven bugs ago

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/MavenCommandServiceTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/MavenCommandServiceTests.cs
@@ -98,7 +98,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         public void ParseDependenciesFile_Success()
         {
             const string componentString = "org.apache.maven:maven-compat:jar:3.6.1-SNAPSHOT";
-            string content = $@"com.bcde.test:top-level:jar:1.0.0{Environment.NewLine}\- {componentString}{Environment.NewLine}";
+            var content = $@"com.bcde.test:top-level:jar:1.0.0{Environment.NewLine}\- {componentString}{Environment.NewLine}";
 
             var pomLocation = "Test/location";
             var processRequest = new ProcessRequest

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/MavenStyleDependencyGraphParserTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/MavenStyleDependencyGraphParserTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         {
             var sampleMavenDependencyTree = File.ReadAllLines(this.sampleMavenDependencyTreePath);
 
-            MavenStyleDependencyGraphParser parser = new MavenStyleDependencyGraphParser();
+            var parser = new MavenStyleDependencyGraphParser();
             var parsedGraph = parser.Parse(sampleMavenDependencyTree);
             Assert.AreEqual(parsedGraph.Children.Count, 20);
             Assert.AreEqual(parsedGraph.Value, "org.apache.maven:maven-compat:jar:3.6.1-SNAPSHOT");
@@ -47,7 +47,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         {
             var sampleMavenDependencyTree = File.ReadAllLines(this.sampleMavenDependencyTreePath);
 
-            MavenStyleDependencyGraphParser parser = new MavenStyleDependencyGraphParser();
+            var parser = new MavenStyleDependencyGraphParser();
 
             var componentRecorder = new ComponentRecorder();
             var pomfileLocation = "location";

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/MavenTestUtilities.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/MavenTestUtilities.cs
@@ -4,7 +4,7 @@
     {
         public static string GetMalformedPomFile()
         {
-            string pomFile = @"<?THISISWRONG!?>
+            var pomFile = @"<?THISISWRONG!?>
             ";
 
             return pomFile;
@@ -12,7 +12,7 @@
 
         public static string GetPomFileNoDependencies()
         {
-            string pomFile = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+            var pomFile = @"<?xml version=""1.0"" encoding=""UTF-8""?>
             <project xmlns=""http://maven.apache.org/POM/4.0.0"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xsi:schemaLocation=""http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"">
                 <modelVersion>4.0.0</modelVersion>
                 <properties>
@@ -29,7 +29,7 @@
 
         public static string GetPomFileWithDependencyToResolveAsProperty(string groupId, string artifactId, string version)
         {
-            string pomFile = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+            var pomFile = @"<?xml version=""1.0"" encoding=""UTF-8""?>
             <project xmlns=""http://maven.apache.org/POM/4.0.0"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xsi:schemaLocation=""http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"">
                 <modelVersion>4.0.0</modelVersion>
                 <properties>
@@ -51,7 +51,7 @@
 
         public static string GetPomFileWithDependencyToResolveAsProjectVar(string groupId, string artifactId, string version)
         {
-            string pomFile = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+            var pomFile = @"<?xml version=""1.0"" encoding=""UTF-8""?>
             <project xmlns=""http://maven.apache.org/POM/4.0.0"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xsi:schemaLocation=""http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"">
                 <myproperty.version>{2}</myproperty.version>
                 <dependencies>
@@ -69,7 +69,7 @@
 
         public static string GetPomFileWithDependencyFailToResolve(string groupId, string artifactId, string version)
         {
-            string pomFile = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+            var pomFile = @"<?xml version=""1.0"" encoding=""UTF-8""?>
             <project xmlns=""http://maven.apache.org/POM/4.0.0"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xsi:schemaLocation=""http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"">
                 <modelVersion>4.0.0</modelVersion>
                 <properties>
@@ -92,7 +92,7 @@
 
         public static string GetPomFileWithDependency(string groupId, string artifactId, string version)
         {
-            string pomFile = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+            var pomFile = @"<?xml version=""1.0"" encoding=""UTF-8""?>
             <project xmlns=""http://maven.apache.org/POM/4.0.0"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xsi:schemaLocation=""http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"">
                 <modelVersion>4.0.0</modelVersion>
 
@@ -111,7 +111,7 @@
 
         public static string GetPomFileWithDependencyNoVersion(string groupId, string artifactId)
         {
-            string pomFile = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+            var pomFile = @"<?xml version=""1.0"" encoding=""UTF-8""?>
             <project xmlns=""http://maven.apache.org/POM/4.0.0"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xsi:schemaLocation=""http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"">
                 <modelVersion>4.0.0</modelVersion>
 

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/MvnCliDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/MvnCliDetectorTests.cs
@@ -114,7 +114,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
             const string componentString = "org.apache.maven:maven-compat:jar:3.6.1-SNAPSHOT";
             const string childComponentString = "org.apache.maven:maven-compat-child:jar:3.6.1-SNAPSHOT";
 
-            string content = $@"com.bcde.test:top-level:jar:1.0.0{Environment.NewLine}\- {componentString}{Environment.NewLine} \- {childComponentString}";
+            var content = $@"com.bcde.test:top-level:jar:1.0.0{Environment.NewLine}\- {componentString}{Environment.NewLine} \- {childComponentString}";
 
             this.MvnCliHappyPath(content);
 
@@ -145,7 +145,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
 
             const string leafComponentString = "org.apache.maven:maven-compat-child:jar:3.6.1-SNAPSHOT";
 
-            string content = $@"com.bcde.test:top-level:jar:1.0.0
+            var content = $@"com.bcde.test:top-level:jar:1.0.0
 \- {explicitReferencedComponent}
     \- {intermediateParentComponent}
         \-{leafComponentString}";

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/NpmDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/NpmDetectorTests.cs
@@ -37,8 +37,8 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         [TestMethod]
         public async Task TestNpmDetector_NameAndVersionDetected()
         {
-            string componentName = GetRandomString();
-            string version = NewRandomVersion();
+            var componentName = GetRandomString();
+            var version = NewRandomVersion();
             var (packageJsonName, packageJsonContents, packageJsonPath) =
                 NpmTestUtilities.GetPackageJsonNoDependenciesForNameAndVersion(componentName, version);
             var detector = new NpmComponentDetector();
@@ -58,8 +58,8 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         [TestMethod]
         public async Task TestNpmDetector_AuthorNameAndEmailDetected_AuthorInJsonFormat()
         {
-            string authorName = GetRandomString();
-            string authorEmail = GetRandomString();
+            var authorName = GetRandomString();
+            var authorEmail = GetRandomString();
             var (packageJsonName, packageJsonContents, packageJsonPath) = NpmTestUtilities.GetPackageJsonNoDependenciesForAuthorAndEmailInJsonFormat(authorName, authorEmail);
             var detector = new NpmComponentDetector();
 
@@ -78,7 +78,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         [TestMethod]
         public async Task TestNpmDetector_AuthorNameDetectedWhenEmailIsNotPresent_AuthorInJsonFormat()
         {
-            string authorName = GetRandomString();
+            var authorName = GetRandomString();
             var (packageJsonName, packageJsonContents, packageJsonPath) =
                 NpmTestUtilities.GetPackageJsonNoDependenciesForAuthorAndEmailInJsonFormat(authorName, null);
             var detector = new NpmComponentDetector();
@@ -98,9 +98,9 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         [TestMethod]
         public async Task TestNpmDetector_AuthorNameAndAuthorEmailDetected_WhenAuthorNameAndEmailAndUrlIsPresent_AuthorAsSingleString()
         {
-            string authorName = GetRandomString();
-            string authorEmail = GetRandomString();
-            string authroUrl = GetRandomString();
+            var authorName = GetRandomString();
+            var authorEmail = GetRandomString();
+            var authroUrl = GetRandomString();
             var (packageJsonName, packageJsonContents, packageJsonPath) =
                 NpmTestUtilities.GetPackageJsonNoDependenciesForAuthorAndEmailAsSingleString(authorName, authorEmail, authroUrl);
             var detector = new NpmComponentDetector();
@@ -120,8 +120,8 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         [TestMethod]
         public async Task TestNpmDetector_AuthorNameDetected_WhenEmailNotPresentAndUrlIsPresent_AuthorAsSingleString()
         {
-            string authorName = GetRandomString();
-            string authroUrl = GetRandomString();
+            var authorName = GetRandomString();
+            var authroUrl = GetRandomString();
             var (packageJsonName, packageJsonContents, packageJsonPath) =
                 NpmTestUtilities.GetPackageJsonNoDependenciesForAuthorAndEmailAsSingleString(authorName, null, authroUrl);
             var detector = new NpmComponentDetector();
@@ -141,9 +141,9 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         [TestMethod]
         public async Task TestNpmDetector_AuthorNull_WhenAuthorMalformed_AuthorAsSingleString()
         {
-            string authorName = GetRandomString();
-            string authroUrl = GetRandomString();
-            string authorEmail = GetRandomString();
+            var authorName = GetRandomString();
+            var authroUrl = GetRandomString();
+            var authorEmail = GetRandomString();
             var (packageJsonName, packageJsonContents, packageJsonPath) =
                 NpmTestUtilities.GetPackageJsonNoDependenciesMalformedAuthorAsSingleString(authorName, authorEmail, authroUrl);
             var detector = new NpmComponentDetector();
@@ -162,8 +162,8 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         [TestMethod]
         public async Task TestNpmDetector_AuthorNameDetected_WhenEmailNotPresentAndUrlNotPresent_AuthorAsSingleString()
         {
-            string authorName = GetRandomString();
-            string authroUrl = GetRandomString();
+            var authorName = GetRandomString();
+            var authroUrl = GetRandomString();
             var (packageJsonName, packageJsonContents, packageJsonPath) =
                 NpmTestUtilities.GetPackageJsonNoDependenciesForAuthorAndEmailAsSingleString(authorName);
             var detector = new NpmComponentDetector();
@@ -183,8 +183,8 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         [TestMethod]
         public async Task TestNpmDetector_AuthorNameAndAuthorEmailDetected_WhenUrlNotPresent_AuthorAsSingleString()
         {
-            string authorName = GetRandomString();
-            string authorEmail = GetRandomString();
+            var authorName = GetRandomString();
+            var authorEmail = GetRandomString();
             var (packageJsonName, packageJsonContents, packageJsonPath) =
                 NpmTestUtilities.GetPackageJsonNoDependenciesForAuthorAndEmailAsSingleString(authorName, authorEmail);
             var detector = new NpmComponentDetector();
@@ -205,8 +205,8 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         [TestMethod]
         public async Task TestNpmDetector_NullAuthor_WhenAuthorNameIsNullOrEmpty_AuthorAsJson()
         {
-            string authorName = string.Empty;
-            string authorEmail = GetRandomString();
+            var authorName = string.Empty;
+            var authorEmail = GetRandomString();
             var (packageJsonName, packageJsonContents, packageJsonPath) =
                 NpmTestUtilities.GetPackageJsonNoDependenciesForAuthorAndEmailInJsonFormat(authorName, authorEmail);
             var detector = new NpmComponentDetector();
@@ -226,8 +226,8 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         [TestMethod]
         public async Task TestNpmDetector_NullAuthor_WhenAuthorNameIsNullOrEmpty_AuthorAsSingleString()
         {
-            string authorName = string.Empty;
-            string authorEmail = GetRandomString();
+            var authorName = string.Empty;
+            var authorEmail = GetRandomString();
             var (packageJsonName, packageJsonContents, packageJsonPath) =
                 NpmTestUtilities.GetPackageJsonNoDependenciesForAuthorAndEmailAsSingleString(authorName, authorEmail);
             var detector = new NpmComponentDetector();

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/NpmDetectorWithRootsTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/NpmDetectorWithRootsTests.cs
@@ -42,8 +42,8 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         [TestMethod]
         public async Task TestNpmDetector_PackageLockReturnsValid()
         {
-            string componentName0 = Guid.NewGuid().ToString("N");
-            string version0 = NewRandomVersion();
+            var componentName0 = Guid.NewGuid().ToString("N");
+            var version0 = NewRandomVersion();
 
             var (packageLockName, packageLockContents, packageLockPath) = NpmTestUtilities.GetWellFormedPackageLock2(this.packageLockJsonFileName, componentName0, version0);
             var (packageJsonName, packageJsonContents, packageJsonPath) = NpmTestUtilities.GetPackageJsonOneRoot(componentName0, version0);
@@ -74,8 +74,8 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         [TestMethod]
         public async Task TestNpmDetector_MismatchedFilesReturnsEmpty()
         {
-            string componentName0 = Guid.NewGuid().ToString("N");
-            string version0 = NewRandomVersion();
+            var componentName0 = Guid.NewGuid().ToString("N");
+            var version0 = NewRandomVersion();
 
             var (packageLockName, packageLockContents, packageLockPath) = NpmTestUtilities.GetWellFormedPackageLock2(this.packageLockJsonFileName);
             var (packageJsonName, packageJsonContents, packageJsonPath) = NpmTestUtilities.GetPackageJsonOneRoot(componentName0, version0);
@@ -117,16 +117,16 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         [TestMethod]
         public async Task TestNpmDetector_PackageLockMultiRoot()
         {
-            string componentName0 = Guid.NewGuid().ToString("N");
-            string version0 = NewRandomVersion();
-            string componentName1 = Guid.NewGuid().ToString("N");
-            string componentName2 = Guid.NewGuid().ToString("N");
-            string version2 = NewRandomVersion();
-            string componentName3 = Guid.NewGuid().ToString("N");
+            var componentName0 = Guid.NewGuid().ToString("N");
+            var version0 = NewRandomVersion();
+            var componentName1 = Guid.NewGuid().ToString("N");
+            var componentName2 = Guid.NewGuid().ToString("N");
+            var version2 = NewRandomVersion();
+            var componentName3 = Guid.NewGuid().ToString("N");
 
             var (packageLockName, packageLockContents, packageLockPath) = NpmTestUtilities.GetWellFormedPackageLock2(this.packageLockJsonFileName, componentName0, version0, componentName2, version2, packageName1: componentName1, packageName3: componentName3);
 
-            string packagejson = @"{{
+            var packagejson = @"{{
                 ""name"": ""test"",
                 ""version"": ""0.0.0"",
                 ""dependencies"": {{
@@ -181,14 +181,14 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         [TestMethod]
         public async Task TestNpmDetector_VerifyMultiRoot_DependencyGraph()
         {
-            string componentName0 = Guid.NewGuid().ToString("N");
-            string version0 = NewRandomVersion();
-            string componentName2 = Guid.NewGuid().ToString("N");
-            string version2 = NewRandomVersion();
+            var componentName0 = Guid.NewGuid().ToString("N");
+            var version0 = NewRandomVersion();
+            var componentName2 = Guid.NewGuid().ToString("N");
+            var version2 = NewRandomVersion();
 
             var (packageLockName, packageLockContents, packageLockPath) = NpmTestUtilities.GetWellFormedPackageLock2(this.packageLockJsonFileName, componentName0, version0, componentName2, version2);
 
-            string packagejson = @"{{
+            var packagejson = @"{{
                 ""name"": ""test"",
                 ""version"": ""0.0.0"",
                 ""dependencies"": {{
@@ -228,12 +228,12 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         [TestMethod]
         public async Task TestNpmDetector_EmptyVersionSkipped()
         {
-            string componentName0 = Guid.NewGuid().ToString("N");
-            string version0 = NewRandomVersion();
-            string componentName2 = Guid.NewGuid().ToString("N");
-            string version2 = NewRandomVersion();
+            var componentName0 = Guid.NewGuid().ToString("N");
+            var version0 = NewRandomVersion();
+            var componentName2 = Guid.NewGuid().ToString("N");
+            var version2 = NewRandomVersion();
 
-            string packageLockJson = @"{{
+            var packageLockJson = @"{{
                 ""name"": ""test"",
                 ""version"": """",
                 ""dependencies"": {{
@@ -258,7 +258,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
 
             var packageLockTemplate = string.Format(packageLockJson, componentName0, version0, componentName2, version2, componentName2, version2, componentName0, version0);
 
-            string packagejson = @"{{
+            var packagejson = @"{{
                 ""name"": ""test"",
                 ""version"": ""0.0.0"",
                 ""dependencies"": {{
@@ -287,12 +287,12 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         [TestMethod]
         public async Task TestNpmDetector_InvalidNameSkipped()
         {
-            string componentName0 = Guid.NewGuid().ToString("N");
-            string version0 = NewRandomVersion();
-            string componentName2 = Guid.NewGuid().ToString("N");
-            string version2 = NewRandomVersion();
+            var componentName0 = Guid.NewGuid().ToString("N");
+            var version0 = NewRandomVersion();
+            var componentName2 = Guid.NewGuid().ToString("N");
+            var version2 = NewRandomVersion();
 
-            string packageLockJson = @"{{
+            var packageLockJson = @"{{
                 ""name"": """",
                 ""version"": ""1.0.0"",
                 ""dependencies"": {{
@@ -317,7 +317,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
 
             var packageLockTemplate = string.Format(packageLockJson, componentName0, version0, componentName2, version2, componentName2, version2, componentName0, version0);
 
-            string packagejson = @"{{
+            var packagejson = @"{{
                 ""name"": ""test"",
                 ""version"": ""0.0.0"",
                 ""dependencies"": {{
@@ -346,18 +346,18 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         [TestMethod]
         public async Task TestNpmDetector_LernaDirectory()
         {
-            string lockFileLocation = Path.Combine(Path.GetTempPath(), Path.Combine("belowLerna", this.packageLockJsonFileName));
-            string packageJsonFileLocation = Path.Combine(Path.GetTempPath(), Path.Combine("belowLerna", this.packageJsonFileName));
-            string lernaFileLocation = Path.Combine(Path.GetTempPath(), "lerna.json");
+            var lockFileLocation = Path.Combine(Path.GetTempPath(), Path.Combine("belowLerna", this.packageLockJsonFileName));
+            var packageJsonFileLocation = Path.Combine(Path.GetTempPath(), Path.Combine("belowLerna", this.packageJsonFileName));
+            var lernaFileLocation = Path.Combine(Path.GetTempPath(), "lerna.json");
 
-            string componentName0 = Guid.NewGuid().ToString("N");
-            string version0 = NewRandomVersion();
-            string componentName1 = Guid.NewGuid().ToString("N");
-            string version1 = NewRandomVersion();
-            string componentName2 = Guid.NewGuid().ToString("N");
-            string version2 = NewRandomVersion();
+            var componentName0 = Guid.NewGuid().ToString("N");
+            var version0 = NewRandomVersion();
+            var componentName1 = Guid.NewGuid().ToString("N");
+            var version1 = NewRandomVersion();
+            var componentName2 = Guid.NewGuid().ToString("N");
+            var version2 = NewRandomVersion();
 
-            string packageLockJson = @"{{
+            var packageLockJson = @"{{
                 ""name"": """",
                 ""version"": """",
                 ""dependencies"": {{
@@ -382,7 +382,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
 
             var packageLockTemplate = string.Format(packageLockJson, componentName0, version0, componentName2, version2, componentName2, version2, componentName0, version0);
 
-            string packagejson = @"{{
+            var packagejson = @"{{
                 ""name"": ""test"",
                 ""version"": ""0.0.0"",
                 ""dependencies"": {{
@@ -412,14 +412,14 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         [TestMethod]
         public async Task TestNpmDetector_CircularRequirementsResolve()
         {
-            string packageJsonComponentPath = Path.Combine(Path.GetTempPath(), this.packageLockJsonFileName);
+            var packageJsonComponentPath = Path.Combine(Path.GetTempPath(), this.packageLockJsonFileName);
 
-            string componentName0 = Guid.NewGuid().ToString("N");
-            string version0 = NewRandomVersion();
-            string componentName2 = Guid.NewGuid().ToString("N");
-            string version2 = NewRandomVersion();
+            var componentName0 = Guid.NewGuid().ToString("N");
+            var version0 = NewRandomVersion();
+            var componentName2 = Guid.NewGuid().ToString("N");
+            var version2 = NewRandomVersion();
 
-            string packageLockJson = @"{{
+            var packageLockJson = @"{{
                 ""name"": ""test"",
                 ""version"": ""0.0.0"",
                 ""dependencies"": {{
@@ -444,7 +444,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
 
             var packageLockTemplate = string.Format(packageLockJson, componentName0, version0, componentName2, version2, componentName2, version2, componentName0, version0);
 
-            string packagejson = @"{{
+            var packagejson = @"{{
                 ""name"": ""test"",
                 ""version"": ""0.0.0"",
                 ""dependencies"": {{
@@ -483,11 +483,11 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         [TestMethod]
         public async Task TestNpmDetector_ShrinkwrapLockReturnsValid()
         {
-            string lockFileName = "npm-shrinkwrap.json";
-            string packageJsonComponentPath = Path.Combine(Path.GetTempPath(), this.packageJsonFileName);
+            var lockFileName = "npm-shrinkwrap.json";
+            var packageJsonComponentPath = Path.Combine(Path.GetTempPath(), this.packageJsonFileName);
 
-            string componentName0 = Guid.NewGuid().ToString("N");
-            string version0 = NewRandomVersion();
+            var componentName0 = Guid.NewGuid().ToString("N");
+            var version0 = NewRandomVersion();
 
             var (packageLockName, packageLockContents, packageLockPath) = NpmTestUtilities.GetWellFormedPackageLock2(lockFileName, componentName0, version0);
             var (packageJsonName, packageJsonContents, packageJsonPath) = NpmTestUtilities.GetPackageJsonOneRoot(componentName0, version0);
@@ -518,20 +518,20 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         [TestMethod]
         public async Task TestNpmDetector_IgnoresPackageLocksInSubFolders()
         {
-            string pathRoot = Path.GetTempPath();
+            var pathRoot = Path.GetTempPath();
 
-            string packageLockUnderNodeModules = Path.Combine(pathRoot, Path.Combine("node_modules", this.packageLockJsonFileName));
-            string packageJsonUnderNodeModules = Path.Combine(pathRoot, Path.Combine("node_modules", this.packageJsonFileName));
+            var packageLockUnderNodeModules = Path.Combine(pathRoot, Path.Combine("node_modules", this.packageLockJsonFileName));
+            var packageJsonUnderNodeModules = Path.Combine(pathRoot, Path.Combine("node_modules", this.packageJsonFileName));
 
-            string componentName0 = Guid.NewGuid().ToString("N");
-            string version0 = NewRandomVersion();
-            string componentName2 = Guid.NewGuid().ToString("N");
-            string version2 = NewRandomVersion();
+            var componentName0 = Guid.NewGuid().ToString("N");
+            var version0 = NewRandomVersion();
+            var componentName2 = Guid.NewGuid().ToString("N");
+            var version2 = NewRandomVersion();
 
             var (packageLockName, packageLockContents, packageLockPath) = NpmTestUtilities.GetWellFormedPackageLock2(this.packageLockJsonFileName, componentName0, version0);
             var (packageLockName2, packageLockContents2, packageLockPath2) = NpmTestUtilities.GetWellFormedPackageLock2(this.packageLockJsonFileName, componentName2, version2, packageName0: "test2");
 
-            string packagejson = @"{{
+            var packagejson = @"{{
                 ""name"": ""{2}"",
                 ""version"": ""0.0.0"",
                 ""dependencies"": {{
@@ -573,13 +573,13 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         [TestMethod]
         public async Task TestNpmDetector_DependencyGraphIsCreated()
         {
-            string packageJsonComponentPath = Path.Combine(Path.GetTempPath(), this.packageLockJsonFileName);
+            var packageJsonComponentPath = Path.Combine(Path.GetTempPath(), this.packageLockJsonFileName);
 
             var componentA = (Name: "componentA", Version: "1.0.0");
             var componentB = (Name: "componentB", Version: "1.0.0");
             var componentC = (Name: "componentC", Version: "1.0.0");
 
-            string packageLockJson = @"{{
+            var packageLockJson = @"{{
                 ""name"": ""test"",
                 ""version"": ""0.0.0"",
                 ""dependencies"": {{
@@ -613,7 +613,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
                 componentB.Name, componentB.Version,
                 componentC.Name, componentC.Version);
 
-            string packagejson = @"{{
+            var packagejson = @"{{
                 ""name"": ""test"",
                 ""version"": ""0.0.0"",
                 ""dependencies"": {{

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/NpmTestUtilities.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/NpmTestUtilities.cs
@@ -17,7 +17,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
     {
         public static string GetPackageJsonNoDependencies()
         {
-            string packagejson = @"{{
+            var packagejson = @"{{
                 ""name"": ""test"",
                 ""version"": ""0.0.0""
             }}";
@@ -27,7 +27,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
 
         public static IComponentStream GetPackageJsonOneRootComponentStream(string componentName0, string version0)
         {
-            string packagejson = @"{{
+            var packagejson = @"{{
                 ""name"": ""test"",
                 ""version"": ""0.0.0"",
                 ""dependencies"": {{
@@ -79,7 +79,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
 
         public static (string, string, string) GetPackageJsonOneRoot(string componentName0, string version0)
         {
-            string packagejson = @"{{
+            var packagejson = @"{{
                 ""name"": ""test"",
                 ""version"": ""0.0.0"",
                 ""dependencies"": {{
@@ -94,7 +94,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
 
         public static (string, string, string) GetPackageJsonNoDependenciesForNameAndVersion(string packageName, string packageVersion)
         {
-            string packagejson = @"{{
+            var packagejson = @"{{
                 ""name"": ""{0}"",
                 ""version"": ""{1}""
             }}";
@@ -134,7 +134,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         public static (string, string, string) GetPackageJsonNoDependenciesForAuthorAndEmailAsSingleString(
             string authorName, string authorEmail = null, string authorUrl = null)
         {
-            string packagejson = @"{{{{
+            var packagejson = @"{{{{
                     ""name"": ""test"",
                     ""version"": ""0.0.0"",
                     ""author"": {0}
@@ -162,7 +162,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         public static (string, string, string) GetPackageJsonNoDependenciesMalformedAuthorAsSingleString(
             string authorName, string authorEmail = null, string authorUrl = null)
         {
-            string packagejson = @"{{{{
+            var packagejson = @"{{{{
                     ""name"": ""test"",
                     ""version"": ""0.0.0"",
                     ""author"": {0}
@@ -192,7 +192,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
 
         public static (string, string, string) GetWellFormedPackageLock2(string lockFileName, string rootName0 = null, string rootVersion0 = null, string rootName2 = null, string rootVersion2 = null, string packageName0 = "test", string packageName1 = null, string packageName3 = null)
         {
-            string packageLockJson = @"{{
+            var packageLockJson = @"{{
                 ""name"": ""{10}"",
                 ""version"": ""0.0.0"",
                 ""dependencies"": {{
@@ -225,14 +225,14 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
                     }}
                 }}
             }}";
-            string componentName0 = rootName0 ?? Guid.NewGuid().ToString("N");
-            string version0 = rootVersion0 ?? NewRandomVersion();
-            string componentName1 = packageName1 ?? Guid.NewGuid().ToString("N");
-            string version1 = NewRandomVersion();
-            string componentName2 = rootName2 ?? Guid.NewGuid().ToString("N");
-            string version2 = rootVersion2 ?? NewRandomVersion();
-            string componentName3 = packageName3 ?? Guid.NewGuid().ToString("N");
-            string version3 = NewRandomVersion();
+            var componentName0 = rootName0 ?? Guid.NewGuid().ToString("N");
+            var version0 = rootVersion0 ?? NewRandomVersion();
+            var componentName1 = packageName1 ?? Guid.NewGuid().ToString("N");
+            var version1 = NewRandomVersion();
+            var componentName2 = rootName2 ?? Guid.NewGuid().ToString("N");
+            var version2 = rootVersion2 ?? NewRandomVersion();
+            var componentName3 = packageName3 ?? Guid.NewGuid().ToString("N");
+            var version3 = NewRandomVersion();
             var packageLockTemplate = string.Format(packageLockJson, componentName0, version0, componentName1, version1, componentName2, version2, componentName2, version2, componentName3, version3, packageName0);
 
             return (lockFileName, packageLockTemplate, Path.Combine(Path.GetTempPath(), lockFileName));

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/NpmUtilitiesTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/NpmUtilitiesTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         [TestMethod]
         public void TestGetTypedComponent()
         {
-            string json = @"{
+            var json = @"{
                 ""async"": {
                     ""version"": ""2.3.0"",
                     ""resolved"": ""https://mseng.pkgs.visualstudio.com/_packaging/VsoMicrosoftExternals/npm/registry/async/-/async-2.3.0.tgz"",
@@ -36,14 +36,14 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
                 },
             }";
 
-            JObject j = JObject.Parse(json);
+            var j = JObject.Parse(json);
 
             var componentFromJProperty = NpmComponentUtilities.GetTypedComponent(j.Children<JProperty>().Single(), "registry.npmjs.org", this.loggerMock.Object);
 
             Assert.IsNotNull(componentFromJProperty);
             Assert.AreEqual(componentFromJProperty.Type, ComponentType.Npm);
 
-            NpmComponent npmComponent = (NpmComponent)componentFromJProperty;
+            var npmComponent = (NpmComponent)componentFromJProperty;
             Assert.AreEqual(npmComponent.Name, "async");
             Assert.AreEqual(npmComponent.Version, "2.3.0");
         }
@@ -51,7 +51,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         [TestMethod]
         public void TestGetTypedComponent_FailsOnMalformed()
         {
-            string json = @"{
+            var json = @"{
                 ""async"": {
                     ""version"": ""NOTAVERSION"",
                     ""resolved"": ""https://mseng.pkgs.visualstudio.com/_packaging/VsoMicrosoftExternals/npm/registry/async/-/async-2.3.0.tgz"",
@@ -59,7 +59,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
                 },
             }";
 
-            JObject j = JObject.Parse(json);
+            var j = JObject.Parse(json);
 
             var componentFromJProperty = NpmComponentUtilities.GetTypedComponent(j.Children<JProperty>().Single(), "registry.npmjs.org", this.loggerMock.Object);
 
@@ -69,7 +69,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         [TestMethod]
         public void TestGetTypedComponent_FailsOnInvalidPackageName()
         {
-            string jsonInvalidCharacter = @"{
+            var jsonInvalidCharacter = @"{
                 ""async<"": {
                     ""version"": ""1.0.0"",
                     ""resolved"": ""https://mseng.pkgs.visualstudio.com/_packaging/VsoMicrosoftExternals/npm/registry/async/-/async-2.3.0.tgz"",
@@ -77,11 +77,11 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
                 },
             }";
 
-            JObject j = JObject.Parse(jsonInvalidCharacter);
+            var j = JObject.Parse(jsonInvalidCharacter);
             var componentFromJProperty = NpmComponentUtilities.GetTypedComponent(j.Children<JProperty>().Single(), "registry.npmjs.org", this.loggerMock.Object);
             Assert.IsNull(componentFromJProperty);
 
-            string jsonUrlName = @"{
+            var jsonUrlName = @"{
                 ""http://thisis/my/packagename"": {
                     ""version"": ""1.0.0"",
                     ""resolved"": ""https://mseng.pkgs.visualstudio.com/_packaging/VsoMicrosoftExternals/npm/registry/async/-/async-2.3.0.tgz"",
@@ -93,7 +93,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
             componentFromJProperty = NpmComponentUtilities.GetTypedComponent(j.Children<JProperty>().Single(), "registry.npmjs.org", this.loggerMock.Object);
             Assert.IsNull(componentFromJProperty);
 
-            string jsonInvalidInitialCharacter1 = @"{
+            var jsonInvalidInitialCharacter1 = @"{
                 ""_async"": {
                     ""version"": ""1.0.0"",
                     ""resolved"": ""https://mseng.pkgs.visualstudio.com/_packaging/VsoMicrosoftExternals/npm/registry/async/-/async-2.3.0.tgz"",
@@ -105,7 +105,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
             componentFromJProperty = NpmComponentUtilities.GetTypedComponent(j.Children<JProperty>().Single(), "registry.npmjs.org", this.loggerMock.Object);
             Assert.IsNull(componentFromJProperty);
 
-            string jsonInvalidInitialCharacter2 = @"{
+            var jsonInvalidInitialCharacter2 = @"{
                 "".async"": {
                     ""version"": ""1.0.0"",
                     ""resolved"": ""https://mseng.pkgs.visualstudio.com/_packaging/VsoMicrosoftExternals/npm/registry/async/-/async-2.3.0.tgz"",
@@ -118,7 +118,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
             Assert.IsNull(componentFromJProperty);
 
             var longPackageName = new string('a', 214);
-            string jsonLongName = $@"{{
+            var jsonLongName = $@"{{
                 ""{longPackageName}"": {{
                     ""version"": ""1.0.0"",
                     ""resolved"": ""https://mseng.pkgs.visualstudio.com/_packaging/VsoMicrosoftExternals/npm/registry/async/-/async-2.3.0.tgz"",
@@ -134,7 +134,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         [TestMethod]
         public void TestTryParseNpmVersion()
         {
-            var parsed = NpmComponentUtilities.TryParseNpmVersion("registry.npmjs.org", "archiver", "https://registry.npmjs.org/archiver-2.1.1.tgz", out SemanticVersion parsedVersion);
+            var parsed = NpmComponentUtilities.TryParseNpmVersion("registry.npmjs.org", "archiver", "https://registry.npmjs.org/archiver-2.1.1.tgz", out var parsedVersion);
             Assert.IsTrue(parsed);
             Assert.AreEqual(parsedVersion.ToString(), "2.1.1");
 
@@ -145,7 +145,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         [TestMethod]
         public void TestTraverseAndGetRequirementsAndDependencies()
         {
-            string json = @"{
+            var json = @"{
                 ""archiver"": {
                     ""version"": ""2.3.0"",
                     ""resolved"": ""https://mseng.pkgs.visualstudio.com/_packaging/VsoMicrosoftExternals/npm/registry/async/-/async-2.3.0.tgz"",
@@ -165,7 +165,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
             var dependencyLookup = jsonChildren.ToDictionary(dependency => dependency.Name);
 
             var typedComponent = NpmComponentUtilities.GetTypedComponent(currentDependency, "registry.npmjs.org", this.loggerMock.Object);
-            ComponentRecorder componentRecorder = new ComponentRecorder();
+            var componentRecorder = new ComponentRecorder();
 
             var singleFileComponentRecorder1 = componentRecorder.CreateSingleFileComponentRecorder("/this/is/a/test/path/");
             var singleFileComponentRecorder2 = componentRecorder.CreateSingleFileComponentRecorder("/this/is/a/different/path/");
@@ -183,7 +183,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
             Assert.IsTrue(graph2.GetExplicitReferencedDependencyIds(typedComponent.Id).Contains(typedComponent.Id));
             Assert.IsFalse(componentRecorder.GetEffectiveDevDependencyValue(typedComponent.Id).GetValueOrDefault(true));
 
-            string json1 = @"{
+            var json1 = @"{
                 ""test"": {
                     ""version"": ""2.0.0"",
                     ""resolved"": ""https://mseng.pkgs.visualstudio.com/_packaging/VsoMicrosoftExternals/npm/registry/async/-/async-2.3.0.tgz"",
@@ -220,7 +220,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
             var expectedDetectedComponent = new DetectedComponent(new NpmComponent("test", "1.0.0"));
             var expectedDetectedDevComponent = new DetectedComponent(new NpmComponent("test2", "1.0.0"));
 
-            ComponentRecorder componentRecorder = new ComponentRecorder();
+            var componentRecorder = new ComponentRecorder();
 
             var addedComponent1 = NpmComponentUtilities.AddOrUpdateDetectedComponent(
                 componentRecorder.CreateSingleFileComponentRecorder("path1"),

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/NuGetNuspecUtilitiesTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/NuGetNuspecUtilitiesTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         {
             using var stream = new MemoryStream();
 
-            for (int i = 0; i < NuGetNuspecUtilities.MinimumLengthForZipArchive - 1; i++)
+            for (var i = 0; i < NuGetNuspecUtilities.MinimumLengthForZipArchive - 1; i++)
             {
                 stream.WriteByte(0);
             }
@@ -50,7 +50,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         {
             using var stream = new MemoryStream();
 
-            using (ZipArchive archive = new ZipArchive(stream, ZipArchiveMode.Create, true))
+            using (var archive = new ZipArchive(stream, ZipArchiveMode.Create, true))
             {
                 archive.CreateEntry("test.txt");
             }
@@ -73,7 +73,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
 
             using var stream = new MemoryStream();
 
-            using (ZipArchive archive = new ZipArchive(stream, ZipArchiveMode.Create, true))
+            using (var archive = new ZipArchive(stream, ZipArchiveMode.Create, true))
             {
                 var entry = archive.CreateEntry("test.nuspec");
 
@@ -88,7 +88,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
 
             Assert.AreEqual(randomBytes.Length, bytes.Length);
 
-            for (int i = 0; i < randomBytes.Length; i++)
+            for (var i = 0; i < randomBytes.Length; i++)
             {
                 Assert.AreEqual(randomBytes[i], bytes[i]);
             }

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/NuGetProjectModelProjectCentricComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/NuGetProjectModelProjectCentricComponentDetectorTests.cs
@@ -50,7 +50,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         [TestMethod]
         public async Task ScanDirectoryAsync_Base_2_2_Verification()
         {
-            string osAgnostic = this.Convert22SampleToOSAgnostic(TestResources.project_assets_2_2);
+            var osAgnostic = this.Convert22SampleToOSAgnostic(TestResources.project_assets_2_2);
             var (scanResult, componentRecorder) = await this.detectorTestUtility
                                                     .WithFile(this.projectAssetsJsonFileName, osAgnostic)
                                                     .ExecuteDetector();
@@ -73,7 +73,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         [TestMethod]
         public async Task ScanDirectoryAsync_Base_2_2_additional_Verification()
         {
-            string osAgnostic = this.Convert22SampleToOSAgnostic(TestResources.project_assets_2_2_additional);
+            var osAgnostic = this.Convert22SampleToOSAgnostic(TestResources.project_assets_2_2_additional);
             var (scanResult, componentRecorder) = await this.detectorTestUtility
                                                     .WithFile(this.projectAssetsJsonFileName, osAgnostic)
                                                     .ExecuteDetector();
@@ -99,7 +99,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         [TestMethod]
         public async Task ScanDirectoryAsync_ExcludedFrameworkComponent_2_2_Verification()
         {
-            string osAgnostic = this.Convert22SampleToOSAgnostic(TestResources.project_assets_2_2);
+            var osAgnostic = this.Convert22SampleToOSAgnostic(TestResources.project_assets_2_2);
             var (scanResult, componentRecorder) = await this.detectorTestUtility
                                                     .WithFile(this.projectAssetsJsonFileName, osAgnostic)
                                                     .ExecuteDetector();
@@ -114,7 +114,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         [TestMethod]
         public async Task ScanDirectoryAsync_DependencyGraph_2_2_additional_Verification()
         {
-            string osAgnostic = this.Convert22SampleToOSAgnostic(TestResources.project_assets_2_2_additional);
+            var osAgnostic = this.Convert22SampleToOSAgnostic(TestResources.project_assets_2_2_additional);
             var (scanResult, componentRecorder) = await this.detectorTestUtility
                                                     .WithFile(this.projectAssetsJsonFileName, osAgnostic)
                                                     .ExecuteDetector();
@@ -186,7 +186,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
             foreach (var componentId in graph.GetComponents())
             {
                 var component = detectedComponents.First(x => x.Component.Id == componentId);
-                bool expectedExplicitRefValue = expectedExplicitRefs.Contains(((NuGetComponent)component.Component).Name);
+                var expectedExplicitRefValue = expectedExplicitRefs.Contains(((NuGetComponent)component.Component).Name);
                 Assert.AreEqual(expectedExplicitRefValue, graph.IsComponentExplicitlyReferenced(componentId));
             }
         }
@@ -194,7 +194,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         [TestMethod]
         public async Task ScanDirectoryAsync_Base_3_1_Verification()
         {
-            string osAgnostic = this.Convert31SampleToOSAgnostic(TestResources.project_assets_3_1);
+            var osAgnostic = this.Convert31SampleToOSAgnostic(TestResources.project_assets_3_1);
             var (scanResult, componentRecorder) = await this.detectorTestUtility
                                                     .WithFile(this.projectAssetsJsonFileName, osAgnostic)
                                                     .ExecuteDetector();
@@ -216,7 +216,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         [TestMethod]
         public async Task ScanDirectoryAsync_ExcludedFrameworkComponent_3_1_Verification()
         {
-            string osAgnostic = this.Convert31SampleToOSAgnostic(TestResources.project_assets_3_1);
+            var osAgnostic = this.Convert31SampleToOSAgnostic(TestResources.project_assets_3_1);
             var (scanResult, componentRecorder) = await this.detectorTestUtility
                                                     .WithFile(this.projectAssetsJsonFileName, osAgnostic)
                                                     .ExecuteDetector();
@@ -232,7 +232,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         [TestMethod]
         public async Task ScanDirectoryAsync_DependencyGraph_3_1_Verification()
         {
-            string osAgnostic = this.Convert31SampleToOSAgnostic(TestResources.project_assets_3_1);
+            var osAgnostic = this.Convert31SampleToOSAgnostic(TestResources.project_assets_3_1);
             var (scanResult, componentRecorder) = await this.detectorTestUtility
                                                     .WithFile(this.projectAssetsJsonFileName, osAgnostic)
                                                     .ExecuteDetector();
@@ -270,7 +270,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
             foreach (var componentId in graph.GetComponents())
             {
                 var component = detectedComponents.First(x => x.Component.Id == componentId);
-                bool expectedExplicitRefValue = expectedExplicitRefs.Contains(((NuGetComponent)component.Component).Name);
+                var expectedExplicitRefValue = expectedExplicitRefs.Contains(((NuGetComponent)component.Component).Name);
                 Assert.AreEqual(expectedExplicitRefValue, graph.IsComponentExplicitlyReferenced(componentId));
             }
         }
@@ -278,7 +278,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         [TestMethod]
         public async Task ScanDirectory_NoPackageSpec()
         {
-            string osAgnostic =
+            var osAgnostic =
 @"{
   ""version"": 3,
   ""targets"": {

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/NugetTestUtilities.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/NugetTestUtilities.cs
@@ -16,9 +16,9 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
     {
         public static string GetRandomValidNuSpecComponent()
         {
-            string componentName = GetRandomString();
-            string componentSpecFileName = $"{componentName}.nuspec";
-            string componentSpecPath = Path.Combine(Path.GetTempPath(), componentSpecFileName);
+            var componentName = GetRandomString();
+            var componentSpecFileName = $"{componentName}.nuspec";
+            var componentSpecPath = Path.Combine(Path.GetTempPath(), componentSpecFileName);
             var template = GetTemplatedNuspec(componentName, NewRandomVersion(), new string[] { GetRandomString(), GetRandomString() });
 
             return template;
@@ -26,9 +26,9 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
 
         public static IComponentStream GetRandomValidNuSpecComponentStream()
         {
-            string componentName = GetRandomString();
-            string componentSpecFileName = $"{componentName}.nuspec";
-            string componentSpecPath = Path.Combine(Path.GetTempPath(), componentSpecFileName);
+            var componentName = GetRandomString();
+            var componentSpecFileName = $"{componentName}.nuspec";
+            var componentSpecPath = Path.Combine(Path.GetTempPath(), componentSpecFileName);
             var template = GetTemplatedNuspec(componentName, NewRandomVersion(), new string[] { GetRandomString(), GetRandomString() });
 
             var mock = new Mock<IComponentStream>();
@@ -53,7 +53,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
 
         public static string GetRandomValidNuspec()
         {
-            string componentName = GetRandomString();
+            var componentName = GetRandomString();
             var template = GetTemplatedNuspec(componentName, NewRandomVersion(), new string[] { GetRandomString(), GetRandomString() });
             return template;
         }
@@ -67,7 +67,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         {
             var stream = new MemoryStream();
 
-            using (ZipArchive archive = new ZipArchive(stream, ZipArchiveMode.Create, true))
+            using (var archive = new ZipArchive(stream, ZipArchiveMode.Create, true))
             {
                 var entry = archive.CreateEntry($"{filename}.nuspec");
 
@@ -83,7 +83,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
 
         public static string GetRandomMalformedNuPkgComponent()
         {
-            string componentName = GetRandomString();
+            var componentName = GetRandomString();
             var template = GetTemplatedNuspec(componentName, NewRandomVersion(), new string[] { GetRandomString(), GetRandomString() });
             template = template.Replace("<id>", "<?malformed>");
             return template;
@@ -91,7 +91,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
 
         private static string GetTemplatedNuspec(string id, string version, string[] authors)
         {
-            string nuspec = @"<?xml version=""1.0"" encoding=""utf-8""?>
+            var nuspec = @"<?xml version=""1.0"" encoding=""utf-8""?>
                             <package xmlns=""http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"">
                                 <metadata>
                                     <!-- Required elements-->
@@ -111,7 +111,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
 
         private static string GetTemplatedNuGetConfig(string repositoryPath)
         {
-            string nugetConfig =
+            var nugetConfig =
                 @"<?xml version=""1.0"" encoding=""utf-8""?>
                 <configuration>
                     <config>
@@ -123,7 +123,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
 
         private static string GetTemplatedProjectAsset(IDictionary<string, IEnumerable<KeyValuePair<string, string>>> packages)
         {
-            string individualPackageJson =
+            var individualPackageJson =
                 @"""{packageName}"": {
                       ""type"": ""package"",
                       ""dependencies"": {
@@ -140,7 +140,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
             }
 
             var allPackageJson = string.Join(",", packageJsons);
-            string pojectAssetsJson =
+            var pojectAssetsJson =
                 @"{
                       ""version"": 2,
                       ""targets"": {

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/PipDependencySpecifierTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/PipDependencySpecifierTests.cs
@@ -10,7 +10,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         [TestMethod]
         public void TestPipDependencySpecifierConstruction()
         {
-            List<(string, PipDependencySpecification)> specs = new List<(string, PipDependencySpecification)>
+            var specs = new List<(string, PipDependencySpecification)>
             {
                 ("TestPackage==1.0", new PipDependencySpecification { Name = "TestPackage", DependencySpecifiers = new List<string> { "==1.0" } }),
                 ("TestPackage>=1.0,!=1.1", new PipDependencySpecification { Name = "TestPackage", DependencySpecifiers = new List<string> { ">=1.0", "!=1.1" } }),
@@ -24,7 +24,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
 
                 Assert.AreEqual(referenceDependencySpecification.Name, dependencySpecifier.Name);
 
-                for (int i = 0; i < referenceDependencySpecification.DependencySpecifiers.Count; i++)
+                for (var i = 0; i < referenceDependencySpecification.DependencySpecifiers.Count; i++)
                 {
                     Assert.AreEqual(referenceDependencySpecification.DependencySpecifiers[i], dependencySpecifier.DependencySpecifiers[i]);
                 }

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/PipResolverTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/PipResolverTests.cs
@@ -211,9 +211,9 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
                 return false;
             }
 
-            bool valid = true;
+            var valid = true;
 
-            for (int i = 0; i < a.Children.Count; i++)
+            for (var i = 0; i < a.Children.Count; i++)
             {
                 valid = this.CompareGraphs(a.Children[i], b.Children[i]);
             }

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/PythonCommandServiceTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/PythonCommandServiceTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         {
             this.commandLineInvokationService.Setup(x => x.CanCommandBeLocated("python", It.IsAny<IEnumerable<string>>(), "--version")).ReturnsAsync(true);
 
-            PythonCommandService service = new PythonCommandService { CommandLineInvocationService = this.commandLineInvokationService.Object };
+            var service = new PythonCommandService { CommandLineInvocationService = this.commandLineInvokationService.Object };
 
             Assert.IsTrue(await service.PythonExists());
         }
@@ -40,7 +40,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         {
             this.commandLineInvokationService.Setup(x => x.CanCommandBeLocated("python", It.IsAny<IEnumerable<string>>(), "--version")).ReturnsAsync(false);
 
-            PythonCommandService service = new PythonCommandService { CommandLineInvocationService = this.commandLineInvokationService.Object };
+            var service = new PythonCommandService { CommandLineInvocationService = this.commandLineInvokationService.Object };
 
             Assert.IsFalse(await service.PythonExists());
         }
@@ -50,7 +50,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         {
             this.commandLineInvokationService.Setup(x => x.CanCommandBeLocated("test", It.IsAny<IEnumerable<string>>(), "--version")).ReturnsAsync(true);
 
-            PythonCommandService service = new PythonCommandService { CommandLineInvocationService = this.commandLineInvokationService.Object };
+            var service = new PythonCommandService { CommandLineInvocationService = this.commandLineInvokationService.Object };
 
             Assert.IsTrue(await service.PythonExists("test"));
         }
@@ -60,7 +60,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         {
             this.commandLineInvokationService.Setup(x => x.CanCommandBeLocated("test", It.IsAny<IEnumerable<string>>(), "--version")).ReturnsAsync(false);
 
-            PythonCommandService service = new PythonCommandService { CommandLineInvocationService = this.commandLineInvokationService.Object };
+            var service = new PythonCommandService { CommandLineInvocationService = this.commandLineInvokationService.Object };
 
             Assert.IsFalse(await service.PythonExists("test"));
         }
@@ -75,7 +75,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
             this.commandLineInvokationService.Setup(x => x.ExecuteCommand("python", It.IsAny<IEnumerable<string>>(), It.Is<string>(c => c.Contains(fakePathAsPassedToPython))))
                                         .ReturnsAsync(new CommandLineExecutionResult { ExitCode = 0, StdOut = "[]", StdErr = string.Empty });
 
-            PythonCommandService service = new PythonCommandService { CommandLineInvocationService = this.commandLineInvokationService.Object };
+            var service = new PythonCommandService { CommandLineInvocationService = this.commandLineInvokationService.Object };
 
             var result = await service.ParseFile(fakePath);
 
@@ -92,14 +92,14 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
             this.commandLineInvokationService.Setup(x => x.ExecuteCommand("python", It.IsAny<IEnumerable<string>>(), It.Is<string>(c => c.Contains(fakePathAsPassedToPython))))
                                         .ReturnsAsync(new CommandLineExecutionResult { ExitCode = 0, StdOut = "['knack==0.4.1', 'setuptools>=1.0,!=1.1', 'vsts-cli-common==0.1.3', 'vsts-cli-admin==0.1.3', 'vsts-cli-build==0.1.3', 'vsts-cli-code==0.1.3', 'vsts-cli-team==0.1.3', 'vsts-cli-package==0.1.3', 'vsts-cli-work==0.1.3']", StdErr = string.Empty });
 
-            PythonCommandService service = new PythonCommandService { CommandLineInvocationService = this.commandLineInvokationService.Object };
+            var service = new PythonCommandService { CommandLineInvocationService = this.commandLineInvokationService.Object };
 
             var result = await service.ParseFile(fakePath);
             var expected = new string[] { "knack==0.4.1", "setuptools>=1.0,!=1.1", "vsts-cli-common==0.1.3", "vsts-cli-admin==0.1.3", "vsts-cli-build==0.1.3", "vsts-cli-code==0.1.3", "vsts-cli-team==0.1.3", "vsts-cli-package==0.1.3", "vsts-cli-work==0.1.3" }.Select<string, (string, GitComponent)>(dep => (dep, null)).ToArray();
 
             Assert.AreEqual(9, result.Count);
 
-            for (int i = 0; i < 9; i++)
+            for (var i = 0; i < 9; i++)
             {
                 Assert.AreEqual(expected[i], result[i]);
             }
@@ -111,11 +111,11 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
             var testPath = Path.Join(Directory.GetCurrentDirectory(), string.Join(Guid.NewGuid().ToString(), ".txt"));
 
             this.commandLineInvokationService.Setup(x => x.CanCommandBeLocated("python", It.IsAny<IEnumerable<string>>(), "--version")).ReturnsAsync(true);
-            PythonCommandService service = new PythonCommandService { CommandLineInvocationService = this.commandLineInvokationService.Object };
+            var service = new PythonCommandService { CommandLineInvocationService = this.commandLineInvokationService.Object };
 
             try
             {
-                using (StreamWriter writer = File.CreateText(testPath))
+                using (var writer = File.CreateText(testPath))
                 {
                     writer.WriteLine("knack==0.4.1");
                     writer.WriteLine("vsts-cli-common==0.1.3    \\      ");
@@ -128,7 +128,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
 
                 Assert.AreEqual(expected.Length, result.Count);
 
-                for (int i = 0; i < expected.Length; i++)
+                for (var i = 0; i < expected.Length; i++)
                 {
                     Assert.AreEqual(expected[i], result[i]);
                 }
@@ -148,11 +148,11 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
             var testPath = Path.Join(Directory.GetCurrentDirectory(), string.Join(Guid.NewGuid().ToString(), ".txt"));
 
             this.commandLineInvokationService.Setup(x => x.CanCommandBeLocated("python", It.IsAny<IEnumerable<string>>(), "--version")).ReturnsAsync(true);
-            PythonCommandService service = new PythonCommandService { CommandLineInvocationService = this.commandLineInvokationService.Object };
+            var service = new PythonCommandService { CommandLineInvocationService = this.commandLineInvokationService.Object };
 
             try
             {
-                using (StreamWriter writer = File.CreateText(testPath))
+                using (var writer = File.CreateText(testPath))
                 {
                     writer.WriteLine("#this is a comment");
                     writer.WriteLine("knack==0.4.1 #this is another comment");
@@ -330,9 +330,9 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
             var testPath = Path.Join(Directory.GetCurrentDirectory(), string.Join(Guid.NewGuid().ToString(), ".txt"));
 
             this.commandLineInvokationService.Setup(x => x.CanCommandBeLocated("python", It.IsAny<IEnumerable<string>>(), "--version")).ReturnsAsync(true);
-            PythonCommandService service = new PythonCommandService { CommandLineInvocationService = this.commandLineInvokationService.Object };
+            var service = new PythonCommandService { CommandLineInvocationService = this.commandLineInvokationService.Object };
 
-            using (StreamWriter writer = File.CreateText(testPath))
+            using (var writer = File.CreateText(testPath))
             {
                 writer.WriteLine(fileToParse);
                 writer.Flush();

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/PythonVersionTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/PythonVersionTests.cs
@@ -66,7 +66,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
                 "1.1",
             }.Select(x => new PythonVersion(x)).ToList();
 
-            for (int i = 1; i < versions.Count; i++)
+            for (var i = 1; i < versions.Count; i++)
             {
                 Assert.IsTrue(versions[i - 1] < versions[i]);
             }

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/RustCrateDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/RustCrateDetectorTests.cs
@@ -106,7 +106,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         public async Task TestSupportsCargoV1AndV2DefinitionPairs()
         {
             var componentRecorder = new ComponentRecorder();
-            ScanRequest request = new ScanRequest(new DirectoryInfo(Path.GetTempPath()), null, null, new Dictionary<string, string>(), null, componentRecorder);
+            var request = new ScanRequest(new DirectoryInfo(Path.GetTempPath()), null, null, new Dictionary<string, string>(), null, componentRecorder);
 
             var (result1, _) = await this.detectorTestUtility
                                                     /* v1 files */
@@ -269,7 +269,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
             Assert.AreEqual(ProcessingResultCode.Success, result.ResultCode);
             Assert.AreEqual(7, componentRecorder.GetDetectedComponents().Count());
 
-            List<string> packageVersions = new List<string>()
+            var packageVersions = new List<string>()
             {
                 "my_dependency 1.0.0",
                 "other_dependency 0.4.0",
@@ -356,7 +356,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         [TestMethod]
         public async Task TestRustV2Detector_DuplicatePackage()
         {
-            string testCargoLock = @"
+            var testCargoLock = @"
 [[package]]
 name = ""my_dependency""
 version = ""1.0.0""
@@ -526,7 +526,7 @@ source = ""registry+https://github.com/rust-lang/crates.io-index""
             Assert.AreEqual(ProcessingResultCode.Success, result.ResultCode);
             Assert.AreEqual(7, componentRecorder.GetDetectedComponents().Count());
 
-            List<string> packageVersions = new List<string>()
+            var packageVersions = new List<string>()
             {
                 "dev_dependency_dependency 0.2.23",
                 "one_more_dev_dep 1.0.0",
@@ -599,7 +599,7 @@ source = ""registry+https://github.com/rust-lang/crates.io-index""
             Assert.AreEqual(ProcessingResultCode.Success, result.ResultCode);
             Assert.AreEqual(7, componentRecorder.GetDetectedComponents().Count());
 
-            List<string> packageVersions = new List<string>()
+            var packageVersions = new List<string>()
             {
                 "dev_dependency_dependency 0.2.23",
                 "one_more_dev_dep 1.0.0",

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/RustDependencySpecifierTest.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/RustDependencySpecifierTest.cs
@@ -43,7 +43,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         {
             foreach (var testCase in testCases)
             {
-                DependencySpecification di = new DependencySpecification();
+                var di = new DependencySpecification();
                 if (testCase.specifierName != null)
                 {
                     di.Add(testCase.specifierName, testCase.specifierRange);

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/Utilities/ComponentRecorderTestUtilities.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/Utilities/ComponentRecorderTestUtilities.cs
@@ -15,7 +15,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests.Utilities
 
             // This magic grouping is a flattening of "occurrences" of components across single file recorders. This allows aggregate operations
             //  per component id, which is logical for most tests.
-            List<IGrouping<string, (string Location, IDependencyGraph Graph, string ComponentId)>> graphsAndLocationsByComponentId = GroupByComponentId(graphs);
+            var graphsAndLocationsByComponentId = GroupByComponentId(graphs);
 
             foreach (var item in graphsAndLocationsByComponentId)
             {
@@ -30,7 +30,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests.Utilities
 
             // This magic grouping is a flattening of "occurrences" of components across single file recorders. This allows aggregate operations
             //  per component id, which is logical for most tests.
-            List<IGrouping<string, (string Location, IDependencyGraph Graph, string ComponentId)>> graphsAndLocationsByComponentId = GroupByComponentId(graphs);
+            var graphsAndLocationsByComponentId = GroupByComponentId(graphs);
 
             forOneComponent(TupleToObject(graphsAndLocationsByComponentId.First(x => x.Key == componentId)));
         }
@@ -62,7 +62,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests.Utilities
             string componentIdToValidate,
             params Func<TTypedComponent, bool>[] locatingPredicatesForParentExplicitReference)
         {
-            bool isDependency = false;
+            var isDependency = false;
             recorder.ForOneComponent(componentIdToValidate, grouping =>
             {
                 isDependency = true;
@@ -84,8 +84,8 @@ namespace Microsoft.ComponentDetection.Detectors.Tests.Utilities
         {
             recorder.ForOneComponent(componentIdToValidate, grouping =>
             {
-                HashSet<string> explicitReferrers = new HashSet<string>(grouping.ParentComponentIdsThatAreExplicitReferences);
-                int assertionIndex = 0;
+                var explicitReferrers = new HashSet<string>(grouping.ParentComponentIdsThatAreExplicitReferences);
+                var assertionIndex = 0;
                 foreach (var predicate in locatingPredicatesForParentExplicitReference)
                 {
                     var dependencyModel = recorder.GetDetectedComponents().Select(x => x.Component).OfType<TTypedComponent>()

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/YarnBlockFileTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/YarnBlockFileTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         [TestMethod]
         public async Task BlockFileParserWithClosedStream_Fails()
         {
-            using MemoryStream stream = new MemoryStream();
+            using var stream = new MemoryStream();
 
             stream.Close();
 
@@ -50,7 +50,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         [TestMethod]
         public async Task BlockFileParserV1WithVersionString_ProducesEnumerableOfZero()
         {
-            string yarnLockFileVersionString = "#yarn lockfile v1";
+            var yarnLockFileVersionString = "#yarn lockfile v1";
 
             using var stream = new MemoryStream();
 
@@ -70,7 +70,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         [TestMethod]
         public async Task BlockFileParserV1WithSingleBlock_Parses()
         {
-            string yarnLockFileVersionString = "#yarn lockfile v1";
+            var yarnLockFileVersionString = "#yarn lockfile v1";
 
             using var stream = new MemoryStream();
 
@@ -101,7 +101,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         [TestMethod]
         public async Task BlockFileParserV1WithSeveralBlocks_Parses()
         {
-            string yarnLockFileVersionString = "#yarn lockfile v1";
+            var yarnLockFileVersionString = "#yarn lockfile v1";
 
             using var stream = new MemoryStream();
 
@@ -145,7 +145,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         [TestMethod]
         public async Task BlockFileParserV2WithMetadataBlock_Parses()
         {
-            string yarnLockFileVersionString = "__metadata:";
+            var yarnLockFileVersionString = "__metadata:";
 
             using var stream = new MemoryStream();
 
@@ -172,7 +172,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         [TestMethod]
         public async Task BlockFileParserV2WithSingleBlock_Parses()
         {
-            string yarnLockFileVersionString = "__metadata:";
+            var yarnLockFileVersionString = "__metadata:";
 
             using var stream = new MemoryStream();
 
@@ -210,7 +210,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         [TestMethod]
         public async Task BlockFileParserV2WithSingleBlock_ParsesWithQuotes()
         {
-            string yarnLockFileVersionString = "__metadata:";
+            var yarnLockFileVersionString = "__metadata:";
 
             using var stream = new MemoryStream();
 
@@ -248,7 +248,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         [TestMethod]
         public async Task BlockFileParserV2WithMultipleBlocks_Parses()
         {
-            string yarnLockFileVersionString = "__metadata:";
+            var yarnLockFileVersionString = "__metadata:";
 
             using var stream = new MemoryStream();
 

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/YarnParserTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/YarnParserTests.cs
@@ -103,7 +103,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
 
             foreach (var entry in file.Entries)
             {
-                YarnBlock block = blocks.Single(x => x.Values["resolved"] == entry.Resolved);
+                var block = blocks.Single(x => x.Values["resolved"] == entry.Resolved);
 
                 this.AssertBlockMatchesEntry(block, entry);
             }

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/YarnTestUtilities.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/YarnTestUtilities.cs
@@ -10,7 +10,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
     {
         public static string GetWellFormedEmptyYarnV1LockFile()
         {
-            StringBuilder builder = new StringBuilder();
+            var builder = new StringBuilder();
 
             builder.AppendLine("# THIS IS A YARNFILE");
             builder.AppendLine("# yarn lockfile v1");
@@ -21,7 +21,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
 
         public static string GetWellFormedEmptyYarnV2LockFile()
         {
-            StringBuilder builder = new StringBuilder();
+            var builder = new StringBuilder();
 
             builder.AppendLine("# THIS IS A YARNFILE");
             builder.AppendLine();

--- a/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/BcdeScanExecutionServiceTests.cs
+++ b/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/BcdeScanExecutionServiceTests.cs
@@ -223,7 +223,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Tests.Services
         [TestMethod]
         public void DetectComponents_Graph_Happy_Path()
         {
-            string mockGraphLocation = "/some/dependency/graph";
+            var mockGraphLocation = "/some/dependency/graph";
 
             var args = new BcdeArguments
             {
@@ -236,7 +236,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Tests.Services
             singleFileComponentRecorder.RegisterUsage(this.detectedComponents[0], isExplicitReferencedDependency: true, isDevelopmentDependency: true);
             singleFileComponentRecorder.RegisterUsage(this.detectedComponents[1], isDevelopmentDependency: false, parentComponentId: this.detectedComponents[0].Component.Id);
 
-            Mock<IDependencyGraph> mockDependencyGraphA = new Mock<IDependencyGraph>();
+            var mockDependencyGraphA = new Mock<IDependencyGraph>();
             mockDependencyGraphA.Setup(x => x.GetComponents()).Returns(new[] {
                 this.detectedComponents[0].Component.Id, this.detectedComponents[1].Component.Id });
             mockDependencyGraphA.Setup(x => x.GetDependenciesForComponent(this.detectedComponents[0].Component.Id))
@@ -275,7 +275,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Tests.Services
         [TestMethod]
         public void DetectComponents_Graph_AccumulatesGraphsOnSameLocation()
         {
-            string mockGraphLocation = "/some/dependency/graph";
+            var mockGraphLocation = "/some/dependency/graph";
 
             var args = new BcdeArguments
             {
@@ -285,7 +285,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Tests.Services
 
             var componentRecorder = new ComponentRecorder();
 
-            Mock<IDependencyGraph> mockDependencyGraphA = new Mock<IDependencyGraph>();
+            var mockDependencyGraphA = new Mock<IDependencyGraph>();
             mockDependencyGraphA.Setup(x => x.GetComponents()).Returns(new[] {
                 this.detectedComponents[0].Component.Id, this.detectedComponents[1].Component.Id });
             mockDependencyGraphA.Setup(x => x.GetDependenciesForComponent(this.detectedComponents[0].Component.Id))
@@ -297,7 +297,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Tests.Services
             singleFileComponentRecorderA.RegisterUsage(this.detectedComponents[0], isExplicitReferencedDependency: true);
             singleFileComponentRecorderA.RegisterUsage(this.detectedComponents[1], parentComponentId: this.detectedComponents[0].Component.Id);
 
-            Mock<IDependencyGraph> mockDependencyGraphB = new Mock<IDependencyGraph>();
+            var mockDependencyGraphB = new Mock<IDependencyGraph>();
             mockDependencyGraphB.Setup(x => x.GetComponents()).Returns(new[] {
                 this.detectedComponents[0].Component.Id, this.detectedComponents[1].Component.Id });
             mockDependencyGraphB.Setup(x => x.GetDependenciesForComponent(this.detectedComponents[1].Component.Id))

--- a/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/DetectorProcessingServiceTests.cs
+++ b/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/DetectorProcessingServiceTests.cs
@@ -176,7 +176,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Tests.Services
         [TestMethod]
         public void ProcessDetectorsAsync_NullDetectedComponentsReturnIsCoalesced()
         {
-            Mock<IComponentDetector> mockComponentDetector = new Mock<IComponentDetector>();
+            var mockComponentDetector = new Mock<IComponentDetector>();
             mockComponentDetector.Setup(d => d.Id).Returns("test");
 
             mockComponentDetector.Setup(x => x.ExecuteDetectorAsync(It.IsAny<ScanRequest>()))
@@ -209,7 +209,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Tests.Services
             foreach (var discoveredComponent in this.GetDiscoveredComponentsFromDetectorProcessingResult(results))
             {
                 var componentId = discoveredComponent.Component.Id;
-                bool isMatched = false;
+                var isMatched = false;
                 foreach (var graph in results.ComponentRecorders.Select(componentRecorder => componentRecorder.Item2.GetDependencyGraphsByLocation()).SelectMany(x => x.Values))
                 {
                     isMatched |= graph.GetComponents().Contains(componentId);
@@ -395,7 +395,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Tests.Services
 
             // This unit test previously depended on defaultArgs.   But the author assumed that \Source\ was in the default source path, which may not be true on all developers machines.
             // control this more explicitly.
-            BcdeArguments args = new BcdeArguments { SourceDirectory = new DirectoryInfo(this.isWin ? @"C:\Some\Source\Directory" : "/c/Some/Source/Directory"), DetectorArgs = Enumerable.Empty<string>() };
+            var args = new BcdeArguments { SourceDirectory = new DirectoryInfo(this.isWin ? @"C:\Some\Source\Directory" : "/c/Some/Source/Directory"), DetectorArgs = Enumerable.Empty<string>() };
 
             var dn = args.SourceDirectory.Name.AsSpan();
             var dp = args.SourceDirectory.Parent.FullName.AsSpan();
@@ -483,7 +483,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Tests.Services
         [TestMethod]
         public void ProcessDetectorsAsync_CapturesTelemetry()
         {
-            BcdeArguments args = defaultArgs;
+            var args = defaultArgs;
             this.detectorsToUse = new[] {
                 this.firstFileComponentDetectorMock.Object, this.secondFileComponentDetectorMock.Object };
 

--- a/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/DetectorRestrictionServiceTests.cs
+++ b/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/DetectorRestrictionServiceTests.cs
@@ -58,7 +58,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Tests.Services
         [TestMethod]
         public void WithRestrictions_BaseCaseReturnsAll()
         {
-            DetectorRestrictions r = new DetectorRestrictions();
+            var r = new DetectorRestrictions();
             var restrictedDetectors = this.serviceUnderTest.ApplyRestrictions(r, this.detectors);
             restrictedDetectors
                 .Should().Contain(this.detectors);
@@ -67,7 +67,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Tests.Services
         [TestMethod]
         public void WithRestrictions_RemovesDefaultOff()
         {
-            DetectorRestrictions r = new DetectorRestrictions();
+            var r = new DetectorRestrictions();
             var detectorMock = this.GenerateDetector("defaultOffDetector");
             var defaultOffDetectorMock = detectorMock.As<IDefaultOffComponentDetector>();
             this.detectors = this.detectors.Union(new[] { defaultOffDetectorMock.Object as IComponentDetector }).ToArray();
@@ -79,7 +79,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Tests.Services
         [TestMethod]
         public void WithRestrictions_AllowsDefaultOffWithDetectorRestriction()
         {
-            DetectorRestrictions r = new DetectorRestrictions();
+            var r = new DetectorRestrictions();
             var detectorMock = this.GenerateDetector("defaultOffDetector");
             var defaultOffDetectorMock = detectorMock.As<IDefaultOffComponentDetector>();
             this.detectors = this.detectors.Union(new[] { defaultOffDetectorMock.Object as IComponentDetector }).ToArray();

--- a/test/Microsoft.ComponentDetection.Orchestrator.Tests/TelemetryHelper.cs
+++ b/test/Microsoft.ComponentDetection.Orchestrator.Tests/TelemetryHelper.cs
@@ -13,8 +13,8 @@ namespace Microsoft.ComponentDetection.Orchestrator.Tests
         public static IEnumerable<T> ExecuteWhileCapturingTelemetry<T>(Action codeToExecute)
             where T : class, IDetectionTelemetryRecord
         {
-            Mock<ITelemetryService> telemetryServiceMock = new Mock<ITelemetryService>();
-            ConcurrentBag<T> records = new ConcurrentBag<T>();
+            var telemetryServiceMock = new Mock<ITelemetryService>();
+            var records = new ConcurrentBag<T>();
             telemetryServiceMock.Setup(x => x.PostRecord(It.IsAny<IDetectionTelemetryRecord>()))
                 .Callback<IDetectionTelemetryRecord>(record =>
                 {


### PR DESCRIPTION
Automatic refactor applied by IDE to use `var` in place of explicit types where the type is otherwise defined. For example:

```C#
var sb = new StringBuilder();
```

instead of

```C#
StringBuilder sb = new StringBuilder
```

This matches the `.editorconfig` enforced style guidelines.