### PR TITLE
fix: rollback dotnet.glob from 2.1.4 to 2.1.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,7 +17,7 @@
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.3.0"/>
         <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1"/>
         <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.3.44"/>
-        <PackageVersion Include="DotNet.Glob" Version="2.1.4"/>
+        <PackageVersion Include="DotNet.Glob" Version="2.1.1"/>
         <PackageVersion Include="MinVer" Version="4.1.0"/>
         <PackageVersion Include="Moq" Version="4.18.2"/>
         <PackageVersion Include="morelinq" Version="3.3.2"/>


### PR DESCRIPTION
I believe we were incorrectly using the `**` pattern. Rolling back `dotnet.glob` as a quick fix until we can investigate more.

Sources:
- https://github.com/microsoft/component-detection/releases/tag/v1.2.1
- https://github.com/microsoft/component-detection/pull/138
- https://github.com/dazinator/DotNet.Glob/issues/65
- https://github.com/dazinator/DotNet.Glob/commit/f1ee0efcc82c375e8124f08053190509eeb3de45