### PR TITLE
refactor: enable `TreatWarningsAsErrors`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -448,3 +448,239 @@ dotnet_naming_rule.parameters_rule.severity             = warning
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 ##########################################
+
+##########################################
+# Custom rules
+##########################################
+[*.cs]
+# See https://github.com/microsoft/component-detection/issues/202
+##########################################
+# Provided by StyleCop.Analyzers
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers
+##########################################
+
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1001.md
+# Commas should not be preceded by whitespace
+dotnet_diagnostic.SA1001.severity = suggestion
+
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1005.md
+# Single line comment should begin with a space
+dotnet_diagnostic.SA1005.severity = suggestion
+
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1101.md
+# Prefix local calls with this
+dotnet_diagnostic.SA1101.severity = suggestion
+
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1105.md
+# Single line comment should begin with a space
+dotnet_diagnostic.SA1105.severity = suggestion
+
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1008.md
+# Opening parenthesis should not be followed by a space.
+dotnet_diagnostic.SA1008.severity = suggestion
+
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1009.md
+# Closing parenthesis should not be followed by a space
+dotnet_diagnostic.SA1009.severity = suggestion
+
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1011.md
+# Closing square bracket should be followed by a space
+dotnet_diagnostic.SA1011.severity = suggestion
+
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1012.md
+# Opening brace should be preceded by a space
+dotnet_diagnostic.SA1012.severity = suggestion
+
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1013.md
+# Closing brace should be preceded by a space
+dotnet_diagnostic.SA1013.severity = suggestion
+
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1013.md
+# Opening brace should be preceded by a space
+dotnet_diagnostic.SA1013.severity = suggestion
+
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1026.md
+# The keyword 'new' should not be followed by a space or a blank line
+dotnet_diagnostic.SA1026.severity = suggestion
+
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1108.md
+# Block statements should not contain embedded comments
+dotnet_diagnostic.SA1108.severity = suggestion
+
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1114.md
+# Parameter list should follow declaration
+dotnet_diagnostic.SA1114.severity = suggestion
+
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1117.md
+# The parameters should all be placed on the same line or each parameter should be placed on its own line
+dotnet_diagnostic.SA1117.severity = suggestion
+
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1118.md
+# The parameter spans multiple lines
+dotnet_diagnostic.SA1118.severity = suggestion
+
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1135.md
+# Using directive for namespace '...' should be qualified
+dotnet_diagnostic.SA1135.severity = suggestion
+
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1137.md
+# Elements should have the same indentation
+dotnet_diagnostic.SA1137.severity = suggestion
+
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1142.md
+# Refer to tuple fields by name
+dotnet_diagnostic.SA1142.severity = suggestion
+
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1200.md
+# Using directive should appear within a namespace declaration
+dotnet_diagnostic.SA1200.severity = suggestion
+
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1201.md
+# A field should not follow a property
+dotnet_diagnostic.SA1201.severity = suggestion
+
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1202.md
+# Constant fields should appear before non-constant fields
+dotnet_diagnostic.SA1202.severity = suggestion
+
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1203.md
+# 'public' members should come before 'private' members
+dotnet_diagnostic.SA1203.severity = suggestion
+
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1204.md
+# Static members should appear before non-static members
+dotnet_diagnostic.SA1204.severity = suggestion
+
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1208.md
+# Using directive for '...' should appear before directive for '...'
+dotnet_diagnostic.SA1208.severity = suggestion
+
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1210.md
+#  Using directives should be ordered alphabetically by the namespaces
+dotnet_diagnostic.SA1210.severity = suggestion
+
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1214.md
+# Readonly fields should appear before non-readonly fields
+dotnet_diagnostic.SA1214.severity = suggestion
+
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1216.md
+# Using static directives should be placed at the correct location
+dotnet_diagnostic.SA1216.severity = suggestion
+
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1316.md
+# Tuple element names should use correct casing
+dotnet_diagnostic.SA1316.severity = suggestion
+
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1401.md
+# Field should be private
+dotnet_diagnostic.SA1401.severity = suggestion
+
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1413.md
+# Use trailing comma in multi-line initializers
+dotnet_diagnostic.SA1413.severity = suggestion
+
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1414.md
+# Tuple types in signatures should have element names
+dotnet_diagnostic.SA1414.severity = suggestion
+
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1500.md
+# Braces for multi-line statements should not share line
+dotnet_diagnostic.SA1500.severity = suggestion
+
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1515.md
+# Single-line comment should be preceded by blank line
+dotnet_diagnostic.SA1515.severity = suggestion
+
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1518.md
+# File is required to end with a single newline character
+dotnet_diagnostic.SA1518.severity = suggestion
+
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1600.md
+# Elements should be documented
+dotnet_diagnostic.SA1600.severity = suggestion
+
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1602.md
+# Enumeration items should be documented
+dotnet_diagnostic.SA1602.severity = suggestion
+
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1604.md
+# Element documentation should have summary
+dotnet_diagnostic.SA1604.severity = suggestion
+
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1611.md
+# The documentation for parameter '...' is missing
+dotnet_diagnostic.SA1611.severity = suggestion
+
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1614.md
+# Element parameter documentation should have text
+dotnet_diagnostic.SA1614.severity = suggestion
+
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1615.md
+# Element return value should be documented
+dotnet_diagnostic.SA1615.severity = suggestion
+
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1616.md
+# Element return value documentation should have text
+dotnet_diagnostic.SA1616.severity = suggestion
+
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1617.md
+# Void return value should not be documented
+dotnet_diagnostic.SA1617.severity = suggestion
+
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1629.md
+# Documentation text should end with a period
+dotnet_diagnostic.SA1629.severity = suggestion
+
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1633.md
+# The file header is missing or not located at the top of the file.
+dotnet_diagnostic.SA1633.severity = suggestion
+
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1642.md
+# Constructor summary documentation should begin with standard text
+dotnet_diagnostic.SA1642.severity = suggestion
+
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1648.md
+# inheritdoc should be used with inheriting class
+dotnet_diagnostic.SA1648.severity = suggestion
+
+##########################################
+# Provided by Microsoft.VisualStudio.Threading.Analyzers
+# https://github.com/Microsoft/vs-threading
+##########################################
+
+# https://github.com/microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD002.md
+# Synchronously waiting on tasks or awaiters may cause deadlocks. Use await or JoinableTaskFactory.Run instead.
+dotnet_diagnostic.VSTHRD002.severity = suggestion
+
+# https://github.com/microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD103.md
+# Result synchronously blocks. Use await instead.
+dotnet_diagnostic.VSTHRD103.severity = suggestion
+
+# https://github.com/microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD101.md
+# Avoid using async lambda for a void returning delegate type, because any exceptions not handled by the delegate will crash the process
+dotnet_diagnostic.VSTHRD101.severity = suggestion
+
+# https://github.com/microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD104.md
+# Expose an async version of this method that does not synchronously block. Then simplify this method to call that async method within a JoinableTaskFactory.Run delegate.
+dotnet_diagnostic.VSTHRD104.severity = suggestion
+
+# https://github.com/microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD111.md
+# Add .ConfigureAwait(bool) to your await expression
+dotnet_diagnostic.VSTHRD111.severity = suggestion
+
+# https://github.com/microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD200.md
+# Use "Async" suffix in names of methods that return an awaitable type
+dotnet_diagnostic.VSTHRD200.severity = suggestion
+
+##########################################
+# Provided by Roslyn
+# https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/
+##########################################
+
+# https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs0618
+# '...' is obsolete
+dotnet_diagnostic.CS0618.severity = suggestion
+
+# https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs1591
+# Missing XML comment for publicly visible type or member '...'
+dotnet_diagnostic.CS1591.severity = suggestion

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,9 +7,8 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <AnalysisLevel>latest</AnalysisLevel>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
-    <NoWarn>$(NoWarn);CS1591;NU1608,NU5119;SA1600</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Label="Package">


### PR DESCRIPTION
This change:
- Enables `TreatWarningsAsErrors`
- Disables any analyzers that would currently break the build

I've created an overarching issue to track re-enabling each of these analyzers: #202 