### PR TITLE
refactor: fix SA1001

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -459,10 +459,6 @@ dotnet_naming_rule.parameters_rule.severity             = warning
 # https://github.com/DotNetAnalyzers/StyleCopAnalyzers
 ##########################################
 
-# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1001.md
-# Commas should not be preceded by whitespace
-dotnet_diagnostic.SA1001.severity = suggestion
-
 # https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1005.md
 # Single line comment should begin with a space
 dotnet_diagnostic.SA1005.severity = suggestion

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/LinuxContainerDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/LinuxContainerDetectorTests.cs
@@ -215,7 +215,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
                 .Throws(new IOException());
             this.mockDockerService.Setup(service => service.InspectImageAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 // Specify BaseImageRef = scratch to verify that cope
-                .ReturnsAsync(new ContainerDetails { Id = 1, ImageId = NodeLatestDigest, Layers = Enumerable.Empty<DockerLayer>() , BaseImageRef = "scratch"});
+                .ReturnsAsync(new ContainerDetails { Id = 1, ImageId = NodeLatestDigest, Layers = Enumerable.Empty<DockerLayer>(), BaseImageRef = "scratch"});
             await this.TestLinuxContainerDetector();
         }
     }


### PR DESCRIPTION
Related to #202

Commas should not be preceded by whitespace
https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1001.md