### PR TITLE
refactor: fix SA1648

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -631,10 +631,6 @@ dotnet_diagnostic.SA1633.severity = suggestion
 # Constructor summary documentation should begin with standard text
 dotnet_diagnostic.SA1642.severity = suggestion
 
-# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1648.md
-# inheritdoc should be used with inheriting class
-dotnet_diagnostic.SA1648.severity = suggestion
-
 ##########################################
 # Provided by Microsoft.VisualStudio.Threading.Analyzers
 # https://github.com/Microsoft/vs-threading

--- a/src/Microsoft.ComponentDetection.Contracts/FileComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/FileComponentDetector.cs
@@ -68,7 +68,6 @@ namespace Microsoft.ComponentDetection.Contracts
             return await this.ScanDirectoryAsync(request);
         }
 
-        /// <inheritdoc />
         private Task<IndividualDetectorScanResult> ScanDirectoryAsync(ScanRequest request)
         {
             this.CurrentScanRequest = request;

--- a/src/Microsoft.ComponentDetection.Detectors/gradle/GradleComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/gradle/GradleComponentDetector.cs
@@ -23,7 +23,6 @@ namespace Microsoft.ComponentDetection.Detectors.Gradle
 
         public override int Version { get; } = 2;
 
-        /// <inheritdoc />
         private static readonly Regex StartsWithLetterRegex = new Regex("^[A-Za-z]", RegexOptions.Compiled);
 
         protected override Task OnFileFound(ProcessRequest processRequest, IDictionary<string, string> detectorArgs)


### PR DESCRIPTION
Related to #202

inheritdoc should be used with inheriting class
https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1648.md