### PR TITLE
Fix for Bug 196

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/dockerfile/DockerfileComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/dockerfile/DockerfileComponentDetector.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Composition;
 using System.IO;
@@ -36,19 +36,26 @@ namespace Microsoft.ComponentDetection.Detectors.Dockerfile
 
         protected override async Task OnFileFound(ProcessRequest processRequest, IDictionary<string, string> detectorArgs)
         {
-            var singleFileComponentRecorder = processRequest.SingleFileComponentRecorder;
-            var file = processRequest.ComponentStream;
-            var filePath = file.Location;
-            this.Logger.LogInfo($"Discovered dockerfile: {file.Location}");
-
-            string contents;
-            using (var reader = new StreamReader(file.Stream))
+            try
             {
-                contents = await reader.ReadToEndAsync();
-            }
+                var singleFileComponentRecorder = processRequest.SingleFileComponentRecorder;
+                var file = processRequest.ComponentStream;
+                var filePath = file.Location;
+                this.Logger.LogInfo($"Discovered dockerfile: {file.Location}");
 
-            var stageNameMap = new Dictionary<string, string>();
-            var dockerFileComponent = this.ParseDockerFile(contents, file.Location, singleFileComponentRecorder, stageNameMap);
+                string contents;
+                using (var reader = new StreamReader(file.Stream))
+                {
+                    contents = await reader.ReadToEndAsync();
+                }
+
+                var stageNameMap = new Dictionary<string, string>();
+                var dockerFileComponent = this.ParseDockerFile(contents, file.Location, singleFileComponentRecorder, stageNameMap);
+            } catch (Exception e)
+            {
+                this.Logger.LogError($"The file is not a Dockerfile it just has 'Docker' in the name. \n Error Message: <{e.Message}>");
+                this.Logger.LogException(e, isError: true, printException: true);
+            }
         }
 
         private Task ParseDockerFile(string fileContents, string fileLocation, ISingleFileComponentRecorder singleFileComponentRecorder, Dictionary<string, string> stageNameMap)

--- a/src/Microsoft.ComponentDetection.Detectors/dockerfile/DockerfileComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/dockerfile/DockerfileComponentDetector.cs
@@ -54,7 +54,7 @@ namespace Microsoft.ComponentDetection.Detectors.Dockerfile
             } catch (Exception e)
             {
                 this.Logger.LogError($"The file is not a Dockerfile it just has 'Docker' in the name. \n Error Message: <{e.Message}>");
-                this.Logger.LogException(e, isError: true, printException: true);
+                this.Logger.LogException(e);
             }
         }
 

--- a/src/Microsoft.ComponentDetection.Detectors/dockerfile/DockerfileComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/dockerfile/DockerfileComponentDetector.cs
@@ -36,26 +36,26 @@ namespace Microsoft.ComponentDetection.Detectors.Dockerfile
 
         protected override async Task OnFileFound(ProcessRequest processRequest, IDictionary<string, string> detectorArgs)
         {
-            var singleFileComponentRecorder = processRequest.SingleFileComponentRecorder;
-            file = processRequest.ComponentStream;
-            var filePath = file.Location;
-                try
-                {
-                    this.Logger.LogInfo($"Discovered dockerfile: {file.Location}");
+            try
+            {
+                var singleFileComponentRecorder = processRequest.SingleFileComponentRecorder;
+                var file = processRequest.ComponentStream;
+                var filePath = file.Location;
+                this.Logger.LogInfo($"Discovered dockerfile: {file.Location}");
 
-                    string contents;
-                    using (var reader = new StreamReader(file.Stream))
-                    {
-                        contents = await reader.ReadToEndAsync();
-                    }
-
-                    var stageNameMap = new Dictionary<string, string>();
-                    var dockerFileComponent = this.ParseDockerFile(contents, file.Location, singleFileComponentRecorder, stageNameMap);
-                } catch (Exception e)
+                string contents;
+                using (var reader = new StreamReader(file.Stream))
                 {
-                    this.Logger.LogError($"The file doesn't appear to be a Dockerfile: '{file.location}'");
-                    this.Logger.LogException(e, false);
+                    contents = await reader.ReadToEndAsync();
                 }
+
+                var stageNameMap = new Dictionary<string, string>();
+                var dockerFileComponent = this.ParseDockerFile(contents, file.Location, singleFileComponentRecorder, stageNameMap);
+            } catch (Exception e)
+            {
+                this.Logger.LogError($"The file doesn't appear to be a Dockerfile: '{file.location}'");
+                this.Logger.LogException(e, false);
+            }
         }
 
         private Task ParseDockerFile(string fileContents, string fileLocation, ISingleFileComponentRecorder singleFileComponentRecorder, Dictionary<string, string> stageNameMap)

--- a/src/Microsoft.ComponentDetection.Detectors/dockerfile/DockerfileComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/dockerfile/DockerfileComponentDetector.cs
@@ -36,26 +36,26 @@ namespace Microsoft.ComponentDetection.Detectors.Dockerfile
 
         protected override async Task OnFileFound(ProcessRequest processRequest, IDictionary<string, string> detectorArgs)
         {
-        var singleFileComponentRecorder = processRequest.SingleFileComponentRecorder;
-        file = processRequest.ComponentStream;
-        var filePath = file.Location;
-            try
-            {
-                this.Logger.LogInfo($"Discovered dockerfile: {file.Location}");
-
-                string contents;
-                using (var reader = new StreamReader(file.Stream))
+            var singleFileComponentRecorder = processRequest.SingleFileComponentRecorder;
+            file = processRequest.ComponentStream;
+            var filePath = file.Location;
+                try
                 {
-                    contents = await reader.ReadToEndAsync();
-                }
+                    this.Logger.LogInfo($"Discovered dockerfile: {file.Location}");
 
-                var stageNameMap = new Dictionary<string, string>();
-                var dockerFileComponent = this.ParseDockerFile(contents, file.Location, singleFileComponentRecorder, stageNameMap);
-            } catch (Exception e)
-            {
-                this.Logger.LogError($"The file doesn't appear to be a Dockerfile: '{filePath}'");
-                this.Logger.LogException(e, false);
-            }
+                    string contents;
+                    using (var reader = new StreamReader(file.Stream))
+                    {
+                        contents = await reader.ReadToEndAsync();
+                    }
+
+                    var stageNameMap = new Dictionary<string, string>();
+                    var dockerFileComponent = this.ParseDockerFile(contents, file.Location, singleFileComponentRecorder, stageNameMap);
+                } catch (Exception e)
+                {
+                    this.Logger.LogError($"The file doesn't appear to be a Dockerfile: '{file.location}'");
+                    this.Logger.LogException(e, false);
+                }
         }
 
         private Task ParseDockerFile(string fileContents, string fileLocation, ISingleFileComponentRecorder singleFileComponentRecorder, Dictionary<string, string> stageNameMap)

--- a/src/Microsoft.ComponentDetection.Detectors/dockerfile/DockerfileComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/dockerfile/DockerfileComponentDetector.cs
@@ -53,7 +53,7 @@ namespace Microsoft.ComponentDetection.Detectors.Dockerfile
                 var dockerFileComponent = this.ParseDockerFile(contents, file.Location, singleFileComponentRecorder, stageNameMap);
             } catch (Exception e)
             {
-                this.Logger.LogError($"The file doesn't appear to be a Dockerfile: '{file.Location}'");
+                this.Logger.LogError($"The file doesn't appear to be a Dockerfile: '{filePath}'");
                 this.Logger.LogException(e, false);
             }
         }

--- a/src/Microsoft.ComponentDetection.Detectors/dockerfile/DockerfileComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/dockerfile/DockerfileComponentDetector.cs
@@ -36,26 +36,26 @@ namespace Microsoft.ComponentDetection.Detectors.Dockerfile
 
         protected override async Task OnFileFound(ProcessRequest processRequest, IDictionary<string, string> detectorArgs)
         {
-            try
-            {
-                var singleFileComponentRecorder = processRequest.SingleFileComponentRecorder;
-                var file = processRequest.ComponentStream;
-                var filePath = file.Location;
-                this.Logger.LogInfo($"Discovered dockerfile: {file.Location}");
-
-                string contents;
-                using (var reader = new StreamReader(file.Stream))
+            var singleFileComponentRecorder = processRequest.SingleFileComponentRecorder;
+            var file = processRequest.ComponentStream;
+            var filePath = file.Location;
+                try
                 {
-                    contents = await reader.ReadToEndAsync();
-                }
+                    this.Logger.LogInfo($"Discovered dockerfile: {file.Location}");
 
-                var stageNameMap = new Dictionary<string, string>();
-                var dockerFileComponent = this.ParseDockerFile(contents, file.Location, singleFileComponentRecorder, stageNameMap);
-            } catch (Exception e)
-            {
-                this.Logger.LogError($"The file doesn't appear to be a Dockerfile: '{file.location}'");
-                this.Logger.LogException(e, false);
-            }
+                    string contents;
+                    using (var reader = new StreamReader(file.Stream))
+                    {
+                        contents = await reader.ReadToEndAsync();
+                    }
+
+                    var stageNameMap = new Dictionary<string, string>();
+                    var dockerFileComponent = this.ParseDockerFile(contents, file.Location, singleFileComponentRecorder, stageNameMap);
+                } catch (Exception e)
+                {
+                    this.Logger.LogError($"The file doesn't appear to be a Dockerfile: '{file.location}'");
+                    this.Logger.LogException(e, false);
+                }
         }
 
         private Task ParseDockerFile(string fileContents, string fileLocation, ISingleFileComponentRecorder singleFileComponentRecorder, Dictionary<string, string> stageNameMap)

--- a/src/Microsoft.ComponentDetection.Detectors/dockerfile/DockerfileComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/dockerfile/DockerfileComponentDetector.cs
@@ -53,7 +53,7 @@ namespace Microsoft.ComponentDetection.Detectors.Dockerfile
                     var dockerFileComponent = this.ParseDockerFile(contents, file.Location, singleFileComponentRecorder, stageNameMap);
                 } catch (Exception e)
                 {
-                    this.Logger.LogError($"The file doesn't appear to be a Dockerfile: '{file.location}'");
+                    this.Logger.LogError($"The file doesn't appear to be a Dockerfile: '{file.Location}'");
                     this.Logger.LogException(e, false);
                 }
         }

--- a/src/Microsoft.ComponentDetection.Detectors/dockerfile/DockerfileComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/dockerfile/DockerfileComponentDetector.cs
@@ -39,23 +39,23 @@ namespace Microsoft.ComponentDetection.Detectors.Dockerfile
             var singleFileComponentRecorder = processRequest.SingleFileComponentRecorder;
             var file = processRequest.ComponentStream;
             var filePath = file.Location;
-                try
-                {
-                    this.Logger.LogInfo($"Discovered dockerfile: {file.Location}");
+            try
+            {
+                this.Logger.LogInfo($"Discovered dockerfile: {file.Location}");
 
-                    string contents;
-                    using (var reader = new StreamReader(file.Stream))
-                    {
-                        contents = await reader.ReadToEndAsync();
-                    }
-
-                    var stageNameMap = new Dictionary<string, string>();
-                    var dockerFileComponent = this.ParseDockerFile(contents, file.Location, singleFileComponentRecorder, stageNameMap);
-                } catch (Exception e)
+                string contents;
+                using (var reader = new StreamReader(file.Stream))
                 {
-                    this.Logger.LogError($"The file doesn't appear to be a Dockerfile: '{file.Location}'");
-                    this.Logger.LogException(e, false);
+                    contents = await reader.ReadToEndAsync();
                 }
+
+                var stageNameMap = new Dictionary<string, string>();
+                var dockerFileComponent = this.ParseDockerFile(contents, file.Location, singleFileComponentRecorder, stageNameMap);
+            } catch (Exception e)
+            {
+                this.Logger.LogError($"The file doesn't appear to be a Dockerfile: '{file.Location}'");
+                this.Logger.LogException(e, false);
+            }
         }
 
         private Task ParseDockerFile(string fileContents, string fileLocation, ISingleFileComponentRecorder singleFileComponentRecorder, Dictionary<string, string> stageNameMap)

--- a/src/Microsoft.ComponentDetection.Detectors/dockerfile/DockerfileComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/dockerfile/DockerfileComponentDetector.cs
@@ -36,11 +36,11 @@ namespace Microsoft.ComponentDetection.Detectors.Dockerfile
 
         protected override async Task OnFileFound(ProcessRequest processRequest, IDictionary<string, string> detectorArgs)
         {
+        var singleFileComponentRecorder = processRequest.SingleFileComponentRecorder;
+        file = processRequest.ComponentStream;
+        var filePath = file.Location;
             try
             {
-                var singleFileComponentRecorder = processRequest.SingleFileComponentRecorder;
-                var file = processRequest.ComponentStream;
-                var filePath = file.Location;
                 this.Logger.LogInfo($"Discovered dockerfile: {file.Location}");
 
                 string contents;

--- a/src/Microsoft.ComponentDetection.Detectors/dockerfile/DockerfileComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/dockerfile/DockerfileComponentDetector.cs
@@ -54,7 +54,7 @@ namespace Microsoft.ComponentDetection.Detectors.Dockerfile
             } catch (Exception e)
             {
                 this.Logger.LogError($"The file doesn't appear to be a Dockerfile: '{file.Location}'");
-                this.Logger.LogException(e);
+                this.Logger.LogException(e, false);
             }
         }
 

--- a/src/Microsoft.ComponentDetection.Detectors/dockerfile/DockerfileComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/dockerfile/DockerfileComponentDetector.cs
@@ -53,7 +53,7 @@ namespace Microsoft.ComponentDetection.Detectors.Dockerfile
                 var dockerFileComponent = this.ParseDockerFile(contents, file.Location, singleFileComponentRecorder, stageNameMap);
             } catch (Exception e)
             {
-                this.Logger.LogError($"The file is not a Dockerfile it just has 'Docker' in the name. \n Error Message: <{e.Message}>");
+                this.Logger.LogError($"The file doesn't appear to be a Dockerfile: '{file.Location}'");
                 this.Logger.LogException(e);
             }
         }


### PR DESCRIPTION
Related: #196 

Added a try-catch statement in the OnFileFound method for the Docker component because component detection was attempting to scan files that are named like a Dockerfile but aren't really a Dockerfile which was causing an error. 