### PR TITLE
refactor: fix SA1208

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -499,10 +499,6 @@ dotnet_diagnostic.SA1203.severity = suggestion
 # Static members should appear before non-static members
 dotnet_diagnostic.SA1204.severity = suggestion
 
-# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1208.md
-# Using directive for '...' should appear before directive for '...'
-dotnet_diagnostic.SA1208.severity = suggestion
-
 # https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1210.md
 #  Using directives should be ordered alphabetically by the namespaces
 dotnet_diagnostic.SA1210.severity = suggestion

--- a/src/Microsoft.ComponentDetection.Common/DockerReference/DockerReferenceUtility.cs
+++ b/src/Microsoft.ComponentDetection.Common/DockerReference/DockerReferenceUtility.cs
@@ -1,5 +1,4 @@
 using Microsoft.ComponentDetection.Contracts;
-using System.Text.RegularExpressions;
 
 // transcribed from https://github.com/containers/image/blob/c1a5f92d0ebbf9e0bf187b3353dd400472b388eb/docker/reference/reference.go
 

--- a/src/Microsoft.ComponentDetection.Contracts/TypedComponent/PodComponent.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/TypedComponent/PodComponent.cs
@@ -1,5 +1,5 @@
-﻿using PackageUrl;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using PackageUrl;
 
 namespace Microsoft.ComponentDetection.Contracts.TypedComponent
 {

--- a/src/Microsoft.ComponentDetection.Detectors/maven/IMavenCommandService.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/maven/IMavenCommandService.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.ComponentDetection.Contracts.Internal;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
+using Microsoft.ComponentDetection.Contracts.Internal;
 
 namespace Microsoft.ComponentDetection.Detectors.Maven
 {

--- a/src/Microsoft.ComponentDetection.Detectors/maven/MavenCommandService.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/maven/MavenCommandService.cs
@@ -1,9 +1,9 @@
-﻿using Microsoft.ComponentDetection.Contracts;
-using Microsoft.ComponentDetection.Contracts.Internal;
-using System;
+﻿using System;
 using System.Composition;
 using System.IO;
 using System.Threading.Tasks;
+using Microsoft.ComponentDetection.Contracts;
+using Microsoft.ComponentDetection.Contracts.Internal;
 
 namespace Microsoft.ComponentDetection.Detectors.Maven
 {

--- a/src/Microsoft.ComponentDetection.Detectors/maven/MavenStyleDependencyGraphParserService.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/maven/MavenStyleDependencyGraphParserService.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.ComponentDetection.Contracts;
-using System.Composition;
+﻿using System.Composition;
+using Microsoft.ComponentDetection.Contracts;
 
 namespace Microsoft.ComponentDetection.Detectors.Maven
 {

--- a/src/Microsoft.ComponentDetection.Detectors/npm/NpmComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/npm/NpmComponentDetector.cs
@@ -2,13 +2,13 @@
 using System.Collections.Generic;
 using System.Composition;
 using System.IO;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Contracts.Internal;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Newtonsoft.Json.Linq;
 using NuGet.Versioning;
-using System.Text.RegularExpressions;
 
 namespace Microsoft.ComponentDetection.Detectors.Npm
 {

--- a/src/Microsoft.ComponentDetection.Detectors/pip/PythonCommandService.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/PythonCommandService.cs
@@ -1,12 +1,12 @@
-﻿using Microsoft.ComponentDetection.Contracts.TypedComponent;
-using Microsoft.ComponentDetection.Contracts;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Composition;
+using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using System.IO;
+using Microsoft.ComponentDetection.Contracts;
+using Microsoft.ComponentDetection.Contracts.TypedComponent;
 
 namespace Microsoft.ComponentDetection.Detectors.Pip
 {

--- a/src/Microsoft.ComponentDetection.Detectors/pip/PythonResolver.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/PythonResolver.cs
@@ -1,10 +1,10 @@
-﻿using Microsoft.ComponentDetection.Contracts;
-using Microsoft.ComponentDetection.Contracts.TypedComponent;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Composition;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.ComponentDetection.Contracts;
+using Microsoft.ComponentDetection.Contracts.TypedComponent;
 
 namespace Microsoft.ComponentDetection.Detectors.Pip
 {

--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/DetectorProcessingService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/DetectorProcessingService.cs
@@ -1,11 +1,3 @@
-using DotNet.Globbing;
-using Microsoft.ComponentDetection.Common;
-using Microsoft.ComponentDetection.Common.DependencyGraph;
-using Microsoft.ComponentDetection.Common.Telemetry.Records;
-using Microsoft.ComponentDetection.Contracts;
-using Microsoft.ComponentDetection.Contracts.BcdeModels;
-using Microsoft.ComponentDetection.Orchestrator.ArgumentSets;
-using Newtonsoft.Json;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -15,7 +7,14 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-
+using DotNet.Globbing;
+using Microsoft.ComponentDetection.Common;
+using Microsoft.ComponentDetection.Common.DependencyGraph;
+using Microsoft.ComponentDetection.Common.Telemetry.Records;
+using Microsoft.ComponentDetection.Contracts;
+using Microsoft.ComponentDetection.Contracts.BcdeModels;
+using Microsoft.ComponentDetection.Orchestrator.ArgumentSets;
+using Newtonsoft.Json;
 using static System.Environment;
 
 namespace Microsoft.ComponentDetection.Orchestrator.Services

--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/GraphTranslation/DefaultGraphTranslationService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/GraphTranslation/DefaultGraphTranslationService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Composition;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.ComponentDetection.Common;
 using Microsoft.ComponentDetection.Common.DependencyGraph;
 using Microsoft.ComponentDetection.Common.Telemetry.Records;
@@ -10,7 +11,6 @@ using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Contracts.BcdeModels;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.ComponentDetection.Orchestrator.ArgumentSets;
-using System.Threading.Tasks;
 
 namespace Microsoft.ComponentDetection.Orchestrator.Services.GraphTranslation
 {

--- a/test/Microsoft.ComponentDetection.Common.Tests/EnvironmentVariableServiceTests.cs
+++ b/test/Microsoft.ComponentDetection.Common.Tests/EnvironmentVariableServiceTests.cs
@@ -1,6 +1,5 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-
-using System;
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.ComponentDetection.Common.Tests
 {

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/MavenCommandServiceTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/MavenCommandServiceTests.cs
@@ -1,15 +1,15 @@
-﻿using FluentAssertions;
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
 using Microsoft.ComponentDetection.Common;
 using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Contracts.Internal;
 using Microsoft.ComponentDetection.Detectors.Maven;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Microsoft.ComponentDetection.Detectors.Tests
 {

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/MavenParsingUtilitiesTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/MavenParsingUtilitiesTests.cs
@@ -1,8 +1,8 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using static Microsoft.ComponentDetection.Detectors.Maven.MavenParsingUtilities;
-using Microsoft.ComponentDetection.Contracts.TypedComponent;
+﻿using System;
 using Microsoft.ComponentDetection.Contracts.BcdeModels;
+using Microsoft.ComponentDetection.Contracts.TypedComponent;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using static Microsoft.ComponentDetection.Detectors.Maven.MavenParsingUtilities;
 
 namespace Microsoft.ComponentDetection.Detectors.Tests
 {

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/SPDX22ComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/SPDX22ComponentDetectorTests.cs
@@ -1,7 +1,3 @@
-using Microsoft.ComponentDetection.Common.DependencyGraph;
-using Microsoft.ComponentDetection.Contracts;
-using Microsoft.ComponentDetection.TestsUtilities;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -9,8 +5,12 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.ComponentDetection.Common.DependencyGraph;
+using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.ComponentDetection.Detectors.Spdx;
+using Microsoft.ComponentDetection.TestsUtilities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.ComponentDetection.Detectors.Tests
 {

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/VcpkgComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/VcpkgComponentDetectorTests.cs
@@ -1,13 +1,13 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.ComponentDetection.Common.DependencyGraph;
 using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.ComponentDetection.Detectors.Vcpkg;
 using Microsoft.ComponentDetection.TestsUtilities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace Microsoft.ComponentDetection.Detectors.Tests
 {

--- a/test/Microsoft.ComponentDetection.TestsUtilities/DetectorTestUtility.cs
+++ b/test/Microsoft.ComponentDetection.TestsUtilities/DetectorTestUtility.cs
@@ -1,5 +1,4 @@
-﻿using Moq;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reactive.Linq;
@@ -8,6 +7,7 @@ using Microsoft.ComponentDetection.Common;
 using Microsoft.ComponentDetection.Common.DependencyGraph;
 using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Contracts.Internal;
+using Moq;
 
 namespace Microsoft.ComponentDetection.TestsUtilities
 {


### PR DESCRIPTION
Related to #202

Using directive for '...' should appear before directive for '...'
https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1208.md