### PR TITLE
fix: downgrade `System.Threading.Tasks.Dataflow` from `4.11.1` to `4.9.0`

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -39,7 +39,7 @@
         <PackageVersion Include="System.Memory" Version="4.5.5"/>
         <PackageVersion Include="System.Reactive" Version="5.0.0"/>
         <PackageVersion Include="System.Runtime.Loader" Version="4.3.0"/>
-        <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="4.11.1"/>
+        <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="4.9.0"/>
         <PackageVersion Include="yamldotnet" Version="11.2.1"/>
         <PackageVersion Include="Faker.net" Version="2.0.154"/>
         <PackageVersion Include="Valleysoft.DockerfileModel" Version="1.0.0"/>


### PR DESCRIPTION
This was originally upgraded in #144 but is causing deadlocks for some users. The long-term fix is outlined in #221, but this workaround is sufficient to temporarily resolve the issue.