### PR TITLE
refactor: fix SA1135

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -471,10 +471,6 @@ dotnet_diagnostic.SA1108.severity = suggestion
 # Parameter list should follow declaration
 dotnet_diagnostic.SA1114.severity = suggestion
 
-# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1135.md
-# Using directive for namespace '...' should be qualified
-dotnet_diagnostic.SA1135.severity = suggestion
-
 # https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1142.md
 # Refer to tuple fields by name
 dotnet_diagnostic.SA1142.severity = suggestion

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/nuget/NuGetPackagesConfigDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/nuget/NuGetPackagesConfigDetectorTests.cs
@@ -1,12 +1,12 @@
 ﻿namespace Microsoft.ComponentDetection.Detectors.Tests.NuGet
 {
     using System.Threading.Tasks;
-    using Contracts;
-    using Contracts.TypedComponent;
-    using Detectors.NuGet;
+    using Microsoft.ComponentDetection.Contracts;
+    using Microsoft.ComponentDetection.Contracts.TypedComponent;
+    using Microsoft.ComponentDetection.Detectors.NuGet;
     using FluentAssertions;
-    using TestsUtilities;
-    using VisualStudio.TestTools.UnitTesting;
+    using Microsoft.ComponentDetection.TestsUtilities;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     [TestClass]
     public class NuGetPackagesConfigDetectorTests


### PR DESCRIPTION
Related to #202

Using directive for namespace '...' should be qualified https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1135.md