### PR TITLE
refactor: fix SA1629

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -559,10 +559,6 @@ dotnet_diagnostic.SA1616.severity = suggestion
 # Void return value should not be documented
 dotnet_diagnostic.SA1617.severity = suggestion
 
-# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1629.md
-# Documentation text should end with a period
-dotnet_diagnostic.SA1629.severity = suggestion
-
 # https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1633.md
 # The file header is missing or not located at the top of the file.
 dotnet_diagnostic.SA1633.severity = suggestion

--- a/src/Microsoft.ComponentDetection.Contracts/DetectorClass.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/DetectorClass.cs
@@ -24,7 +24,7 @@
         /// <summary>Indicates a detector applies to Pip packages.</summary>
         Pip,
 
-        /// <summary>Indicates a detector applies to Go modules</summary>
+        /// <summary>Indicates a detector applies to Go modules.</summary>
         GoMod,
 
         /// <summary>Indicates a detector applies to CocoaPods packages.</summary>


### PR DESCRIPTION
Related to #202

Documentation text should end with a period
https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1629.md