### PR TITLE
refactor: fix SA1210

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -495,10 +495,6 @@ dotnet_diagnostic.SA1202.severity = suggestion
 # 'public' members should come before 'private' members
 dotnet_diagnostic.SA1203.severity = suggestion
 
-# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1210.md
-#  Using directives should be ordered alphabetically by the namespaces
-dotnet_diagnostic.SA1210.severity = suggestion
-
 # https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1214.md
 # Readonly fields should appear before non-readonly fields
 dotnet_diagnostic.SA1214.severity = suggestion

--- a/src/Microsoft.ComponentDetection.Common/EnvironmentVariableService.cs
+++ b/src/Microsoft.ComponentDetection.Common/EnvironmentVariableService.cs
@@ -1,6 +1,6 @@
 using System;
-using System.Linq;
 using System.Composition;
+using System.Linq;
 using Microsoft.ComponentDetection.Contracts;
 
 namespace Microsoft.ComponentDetection.Common

--- a/src/Microsoft.ComponentDetection.Detectors/dockerfile/DockerfileComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/dockerfile/DockerfileComponentDetector.cs
@@ -5,11 +5,11 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using Valleysoft.DockerfileModel;
 using Microsoft.ComponentDetection.Common;
 using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Contracts.Internal;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
+using Valleysoft.DockerfileModel;
 
 namespace Microsoft.ComponentDetection.Detectors.Dockerfile
 {

--- a/src/Microsoft.ComponentDetection.Detectors/ivy/IvyDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/ivy/IvyDetector.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Composition;
 using System.IO;
@@ -7,9 +7,9 @@ using System.Reactive.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.ComponentDetection.Contracts;
+using Microsoft.ComponentDetection.Contracts.BcdeModels;
 using Microsoft.ComponentDetection.Contracts.Internal;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
-using Microsoft.ComponentDetection.Contracts.BcdeModels;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.ComponentDetection.Detectors.Ivy

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/GoComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/GoComponentDetectorTests.cs
@@ -8,9 +8,9 @@ using Microsoft.ComponentDetection.Common.DependencyGraph;
 using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.ComponentDetection.Detectors.Go;
+using Microsoft.ComponentDetection.TestsUtilities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
-using Microsoft.ComponentDetection.TestsUtilities;
 
 namespace Microsoft.ComponentDetection.Detectors.Tests
 {

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/GradleComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/GradleComponentDetectorTests.cs
@@ -6,8 +6,8 @@ using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.ComponentDetection.Detectors.Gradle;
 using Microsoft.ComponentDetection.Detectors.Tests.Utilities;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.ComponentDetection.TestsUtilities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.ComponentDetection.Detectors.Tests
 {

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/MvnCliDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/MvnCliDetectorTests.cs
@@ -9,9 +9,9 @@ using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.ComponentDetection.Detectors.Maven;
 using Microsoft.ComponentDetection.Detectors.Tests.Utilities;
+using Microsoft.ComponentDetection.TestsUtilities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
-using Microsoft.ComponentDetection.TestsUtilities;
 
 namespace Microsoft.ComponentDetection.Detectors.Tests
 {

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/NpmDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/NpmDetectorTests.cs
@@ -6,10 +6,9 @@ using Microsoft.ComponentDetection.Common.DependencyGraph;
 using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.ComponentDetection.Detectors.Npm;
+using Microsoft.ComponentDetection.TestsUtilities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
-using Microsoft.ComponentDetection.TestsUtilities;
-
 using static Microsoft.ComponentDetection.Detectors.Tests.Utilities.TestUtilityExtensions;
 
 namespace Microsoft.ComponentDetection.Detectors.Tests

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/NpmDetectorWithRootsTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/NpmDetectorWithRootsTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -9,10 +9,9 @@ using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.ComponentDetection.Detectors.Npm;
 using Microsoft.ComponentDetection.Detectors.Tests.Utilities;
+using Microsoft.ComponentDetection.TestsUtilities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
-using Microsoft.ComponentDetection.TestsUtilities;
-
 using static Microsoft.ComponentDetection.Detectors.Tests.Utilities.TestUtilityExtensions;
 
 namespace Microsoft.ComponentDetection.Detectors.Tests

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/NpmTestUtilities.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/NpmTestUtilities.cs
@@ -6,9 +6,8 @@ using System.Reactive.Linq;
 using Microsoft.ComponentDetection.Common.DependencyGraph;
 using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Contracts.Internal;
-using Moq;
 using Microsoft.ComponentDetection.TestsUtilities;
-
+using Moq;
 using static Microsoft.ComponentDetection.Detectors.Tests.Utilities.TestUtilityExtensions;
 
 namespace Microsoft.ComponentDetection.Detectors.Tests

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/NuGetComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/NuGetComponentDetectorTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -7,11 +7,11 @@ using System.Threading.Tasks;
 using Microsoft.ComponentDetection.Common.DependencyGraph;
 using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Contracts.Internal;
+using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.ComponentDetection.Detectors.NuGet;
+using Microsoft.ComponentDetection.TestsUtilities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
-using Microsoft.ComponentDetection.TestsUtilities;
-using Microsoft.ComponentDetection.Contracts.TypedComponent;
 
 namespace Microsoft.ComponentDetection.Detectors.Tests
 {

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/NuGetProjectModelProjectCentricComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/NuGetProjectModelProjectCentricComponentDetectorTests.cs
@@ -9,9 +9,9 @@ using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.ComponentDetection.Detectors.NuGet;
 using Microsoft.ComponentDetection.Detectors.Tests.Mocks;
 using Microsoft.ComponentDetection.Detectors.Tests.Utilities;
+using Microsoft.ComponentDetection.TestsUtilities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
-using Microsoft.ComponentDetection.TestsUtilities;
 using Newtonsoft.Json;
 
 namespace Microsoft.ComponentDetection.Detectors.Tests

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/NugetTestUtilities.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/NugetTestUtilities.cs
@@ -5,9 +5,8 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.ComponentDetection.Contracts;
-using Moq;
 using Microsoft.ComponentDetection.TestsUtilities;
-
+using Moq;
 using static Microsoft.ComponentDetection.Detectors.Tests.Utilities.TestUtilityExtensions;
 
 namespace Microsoft.ComponentDetection.Detectors.Tests

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/PipComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/PipComponentDetectorTests.cs
@@ -8,9 +8,9 @@ using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.ComponentDetection.Detectors.Pip;
 using Microsoft.ComponentDetection.Detectors.Tests.Utilities;
+using Microsoft.ComponentDetection.TestsUtilities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
-using Microsoft.ComponentDetection.TestsUtilities;
 using Newtonsoft.Json;
 
 namespace Microsoft.ComponentDetection.Detectors.Tests

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/PnpmDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/PnpmDetectorTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -8,8 +8,8 @@ using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.ComponentDetection.Detectors.Pnpm;
 using Microsoft.ComponentDetection.Detectors.Tests.Utilities;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.ComponentDetection.TestsUtilities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.ComponentDetection.Detectors.Tests
 {

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/PnpmParsingUtilitiesTest.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/PnpmParsingUtilitiesTest.cs
@@ -4,9 +4,9 @@ using FluentAssertions;
 using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.ComponentDetection.Detectors.Pnpm;
+using Microsoft.ComponentDetection.TestsUtilities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
-using Microsoft.ComponentDetection.TestsUtilities;
 
 namespace Microsoft.ComponentDetection.Detectors.Tests
 {

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/PodDetectorTest.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/PodDetectorTest.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -7,8 +7,8 @@ using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.ComponentDetection.Detectors.CocoaPods;
 using Microsoft.ComponentDetection.Detectors.Tests.Utilities;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.ComponentDetection.TestsUtilities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.ComponentDetection.Detectors.Tests
 {

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/PoetryComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/PoetryComponentDetectorTests.cs
@@ -5,8 +5,8 @@ using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.ComponentDetection.Detectors.Poetry;
 using Microsoft.ComponentDetection.Detectors.Tests.Utilities;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.ComponentDetection.TestsUtilities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.ComponentDetection.Detectors.Tests
 {

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/RubyDetectorTest.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/RubyDetectorTest.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -8,9 +8,9 @@ using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.ComponentDetection.Detectors.Ruby;
 using Microsoft.ComponentDetection.Detectors.Tests.Utilities;
+using Microsoft.ComponentDetection.TestsUtilities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
-using Microsoft.ComponentDetection.TestsUtilities;
 
 namespace Microsoft.ComponentDetection.Detectors.Tests
 {

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/RustCrateDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/RustCrateDetectorTests.cs
@@ -9,8 +9,8 @@ using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.ComponentDetection.Detectors.Rust;
 using Microsoft.ComponentDetection.Detectors.Tests.Utilities;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.ComponentDetection.TestsUtilities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.ComponentDetection.Detectors.Tests
 {

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/YarnLockDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/YarnLockDetectorTests.cs
@@ -13,11 +13,10 @@ using Microsoft.ComponentDetection.Contracts.Internal;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.ComponentDetection.Detectors.Tests.Utilities;
 using Microsoft.ComponentDetection.Detectors.Yarn;
+using Microsoft.ComponentDetection.TestsUtilities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
-using Microsoft.ComponentDetection.TestsUtilities;
 using Newtonsoft.Json;
-
 using static Microsoft.ComponentDetection.Detectors.Tests.Utilities.TestUtilityExtensions;
 
 namespace Microsoft.ComponentDetection.Detectors.Tests

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/YarnTestUtilities.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/YarnTestUtilities.cs
@@ -1,8 +1,8 @@
 ﻿using System.IO;
 using System.Text;
 using Microsoft.ComponentDetection.Contracts;
-using Moq;
 using Microsoft.ComponentDetection.TestsUtilities;
+using Moq;
 
 namespace Microsoft.ComponentDetection.Detectors.Tests
 {


### PR DESCRIPTION
Related to #202

Using directives should be ordered alphabetically by the namespaces https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1210.md