### PR TITLE
Refactor: Fix warning SA1114

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -467,10 +467,6 @@ dotnet_diagnostic.SA1101.severity = suggestion
 # Block statements should not contain embedded comments
 dotnet_diagnostic.SA1108.severity = suggestion
 
-# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1114.md
-# Parameter list should follow declaration
-dotnet_diagnostic.SA1114.severity = suggestion
-
 # https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1142.md
 # Refer to tuple fields by name
 dotnet_diagnostic.SA1142.severity = suggestion

--- a/src/Microsoft.ComponentDetection.Detectors/rust/RustCrateUtilities.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/rust/RustCrateUtilities.cs
@@ -15,10 +15,8 @@ namespace Microsoft.ComponentDetection.Detectors.Rust
 {
     public class RustCrateUtilities
     {
-        private static readonly Regex DependencyFormatRegex = new Regex(
-        ////  PkgName Version    Source
-            @"([^ ]+) ([^ ]+) \(([^()]*)\)",
-            RegexOptions.Compiled);
+        private const string Pattern = @"([^ ]+) ([^ ]+) \(([^()]*)\)"; // PkgName Version Source
+        private static readonly Regex DependencyFormatRegex = new Regex(Pattern, RegexOptions.Compiled);
 
         public const string CargoTomlSearchPattern = "Cargo.toml";
         public const string CargoLockSearchPattern = "Cargo.lock";


### PR DESCRIPTION
Remove fix occurrences warning SA1114

Parameter list should follow declaration.
https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1114.md

Related to #202