### PR TITLE
Fix Issue 199

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/npm/NpmComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/npm/NpmComponentDetector.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Composition;
 using System.IO;
@@ -65,7 +65,7 @@ namespace Microsoft.ComponentDetection.Detectors.Npm
             catch (Exception e)
             {
                 // If something went wrong, just ignore the component
-                this.Logger.LogBuildWarning($"Could not parse Jtokens from file {sourceFilePath}.");
+                this.Logger.LogInfo($"Could not parse Jtokens from file {sourceFilePath}.");
                 this.Logger.LogFailedReadingFile(sourceFilePath, e);
                 return;
             }

--- a/src/Microsoft.ComponentDetection.Detectors/npm/NpmComponentDetectorWithRoots.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/npm/NpmComponentDetectorWithRoots.cs
@@ -192,7 +192,7 @@ namespace Microsoft.ComponentDetection.Detectors.Npm
             catch (Exception e)
             {
                 // If something went wrong, just ignore the component
-                this.Logger.LogBuildWarning($"Could not parse Jtokens from {componentStream.Location} file.");
+                this.Logger.LogInfo($"Could not parse Jtokens from {componentStream.Location} file.");
                 this.Logger.LogFailedReadingFile(componentStream.Location, e);
                 return;
             }
@@ -209,7 +209,7 @@ namespace Microsoft.ComponentDetection.Detectors.Npm
             }
             catch (Exception ex)
             {
-                this.Logger.LogBuildWarning($"Could not read {componentStream.Location} file.");
+                this.Logger.LogInfo($"Could not read {componentStream.Location} file.");
                 this.Logger.LogFailedReadingFile(componentStream.Location, ex);
                 return Task.CompletedTask;
             }


### PR DESCRIPTION
Changed Logger.LogBuildWarning to Logger.LogInfo in npm detector files to prevent unnecessary build warnings. Related: #199 