### PR TITLE
Added NoWarn for NU1505

### DIFF
--- a/src/Microsoft.ComponentDetection/Microsoft.ComponentDetection.csproj
+++ b/src/Microsoft.ComponentDetection/Microsoft.ComponentDetection.csproj
@@ -1,9 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
         <RootProjectDirectory>$(MSBuildThisFileDirectory)..\..\</RootProjectDirectory>
+        <NoWarn>NU1505</NoWarn>
     </PropertyGroup>
 
     <ItemGroup Label="Package References">


### PR DESCRIPTION
Added <NoWarn>NU1505</NoWarn> under the Microsoft.ComponentDetection.csproj file to prevent this warning from happening. The warning is happening unexpectedly: https://github.com/dotnet/sdk/issues/24747 
This should fix issue #257 