### PR TITLE
fix release failure.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -911,3 +911,6 @@ dotnet_diagnostic.CA1724.severity = suggestion
 
 # SA1028: Code should not contain trailing whitespace
 dotnet_diagnostic.SA1028.severity = suggestion
+
+# IL3000: always returns an empty string for assemblies embedded in a single-file app.
+dotnet_diagnostic.IL3000.severity = suggestion

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         run: dotnet restore
 
       - name: Build CLI tool
-        run: dotnet publish --configuration Release --output ./bin --self-contained --runtime ${{ matrix.rid }} -p:PublishSingleFile=true -p:DebugType=None -p:PublishTrimmed=true ./src/Microsoft.ComponentDetection
+        run: dotnet publish --configuration Release --output ./bin --self-contained --runtime ${{ matrix.rid }} -p:PublishSingleFile=true -p:DebugType=None -p:PublishTrimmed=false ./src/Microsoft.ComponentDetection
 
       - name: Publish CLI tool
         uses: shogo82148/actions-upload-release-asset@v1.6.2


### PR DESCRIPTION
### Summary
Fix release failure for 2.0.0. 

### Detail:
Release 2.0.0 [failed](https://github.com/microsoft/component-detection/actions/runs/3200952692/jobs/5228440236) with net6 migration. 
- error `IL3000` is avoided by suppressing it `.editorconfig` file.
- error `IL2026` is avoided by disabling [TrimmedPublishing ](https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trim-self-contained) during release. 

### Testing
ran `dotnet publish --configuration Release --output ./bin --self-contained --runtime win-x64 -p:PublishSingleFile=true -p:DebugType=None -p:PublishTrimmed=false ./src/Microsoft.ComponentDetection` in local.
 - command succeeds.
 - validated that published artifacts are not larger than the previous one. 

