### PR TITLE
Fixed release failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         run: dotnet restore
 
       - name: Build CLI tool
-        run: dotnet publish --configuration Release --output ./bin --self-contained --runtime ${{ matrix.rid }} -p:PublishSingleFile=true -p:DebugType=None -p:PublishTrimmed=false ./src/Microsoft.ComponentDetection
+        run: dotnet publish --configuration Release --output ./bin --self-contained --runtime ${{ matrix.rid }} -p:PublishSingleFile=true -p:IncludeAllContentForSelfExtract=true -p:DebugType=None -p:PublishTrimmed=false ./src/Microsoft.ComponentDetection
 
       - name: Publish CLI tool
         uses: shogo82148/actions-upload-release-asset@v1.6.2


### PR DESCRIPTION
### Summary 
Previous release  (2.0.1) failed during publishing step ([failure](https://github.com/microsoft/component-detection/actions/runs/3206317150/jobs/5240012749)). This is a fix for it. 

Rootcause: 
after .net6 migration the default publishing step was generating multiple asset files in the `./bin` folder. This was causing failure in `Publish CLI tool` step, since its only expecting single file under `./bin`. 


due to .net6 migration , it was required that we add `-p:IncludeAllContentForSelfExtract=true ([source](https://learn.microsoft.com/en-us/answers/questions/296816/self-contained-single-file-does-not-produce-a-sing.html)).


### Testing:
- locally ran `dotnet publish --configuration Release --output ./bin --self-contained --runtime win-x64 -p:PublishSingleFile=true -p:IncludeAllContentForSelfExtract=true -p:DebugType=None -p:PublishTrimmed=false ./src/Microsoft.ComponentDetection`  command to validate that only single file is generated.
- validated that generted `.exe` file is able to run properly and scan components on windows platform. 