### PR TITLE
Disable warnings as errors setting

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <AnalysisLevel>latest</AnalysisLevel>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
   </PropertyGroup>
 


### PR DESCRIPTION
## Problem
When working directly in this repository the Warnings are not breaking the builds as the setting would expect. When other repositories consume this repo as a submodule, this setting breaks them big time for submodule code.

## Solution
Short term: Disable treat warnings as errors setting
Long term: Understand why it isn't breaking builds in this repo