### PR TITLE
fix: Add MacOS support

### DIFF
--- a/src/Microsoft.ComponentDetection.Common/PathUtilityService.cs
+++ b/src/Microsoft.ComponentDetection.Common/PathUtilityService.cs
@@ -71,6 +71,7 @@ namespace Microsoft.ComponentDetection.Common
 
         private static readonly bool IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
         private static readonly bool IsLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+        private static readonly bool IsMacOS = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
 
         private object isRunningOnWindowsContainerLock = new object();
         private bool? isRunningOnWindowsContainer = null;
@@ -135,9 +136,9 @@ namespace Microsoft.ComponentDetection.Common
             {
                 return this.ResolvePhysicalPathWindows(path);
             }
-            else if (IsLinux)
+            else if (IsLinux || IsMacOS)
             {
-                return this.ResolvePhysicalPathLinux(path);
+                return this.ResolvePhysicalPathLibC(path);
             }
 
             return path;
@@ -193,9 +194,9 @@ namespace Microsoft.ComponentDetection.Common
             return result;
         }
 
-        public string ResolvePhysicalPathLinux(string path)
+        public string ResolvePhysicalPathLibC(string path)
         {
-            if (!IsLinux)
+            if (!IsLinux && !IsMacOS)
             {
                 throw new PlatformNotSupportedException("Attempted to call a function that makes linux-only library calls");
             }


### PR DESCRIPTION
On MacOS file systems with heavily nested symlinks, component detection would stall out. This happened because symlinks to the same location were never detected as such, since the realpath logic only ran on Linux.

We don't have any dependencies on glibc, so calling standard unix libc functions works on both Linux and BSD. This change adds symlink resolution on MacOS.

Fixes #267.