### PR TITLE
Update tomlyn to 0.15.1 fixing PoetryDetector

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -39,7 +39,7 @@
         <PackageVersion Include="System.Reactive" Version="5.0.0"/>
         <PackageVersion Include="System.Runtime.Loader" Version="4.3.0"/>
         <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="4.11.1"/>
-        <PackageVersion Include="Tomlyn" Version="0.15.0"/>
+        <PackageVersion Include="Tomlyn" Version="0.15.1"/>
         <PackageVersion Include="yamldotnet" Version="11.2.1"/>
         <PackageVersion Include="Faker.net" Version="2.0.154"/>
         <PackageVersion Include="Valleysoft.DockerfileModel" Version="1.0.0"/>


### PR DESCRIPTION
We have hit issues with the PoetryDetector. 
```
[ERROR] SafelyExecuteAsync logged TomlException: (991,2) : error : Unable to set the property extras on object type Microsoft.ComponentDetection.Detectors.Poetry.Contracts.PoetryLock.
```
I believe this is due to an issue with Tomlyn where defaulting missing tables didn't work for `object` types. This has now been fixed in version [0.15.1](https://github.com/xoofx/Tomlyn/releases/tag/0.15.1).
[Corresponding PR](https://github.com/xoofx/Tomlyn/pull/44)

Could I please request a release of component-detection once this change is in, to fixup my pipelines? 

Question for reviewer:
- Why did the testing in `component-detection` not identify this issue and could you suggest some additional testing to add to verify that PRs haven't broken detectors.
