### PR TITLE
refactor: fix CA1820

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -708,9 +708,6 @@ dotnet_diagnostic.CA1014.severity = none
 # CA1824: Mark assemblies with NeutralResourcesLanguageAttribute
 dotnet_diagnostic.CA1824.severity = none
 
-# CA1820: Test for empty strings using string length
-dotnet_diagnostic.CA1820.severity = suggestion
-
 # CA1508: Avoid dead conditional code
 dotnet_diagnostic.CA1508.severity = suggestion
 
@@ -885,7 +882,7 @@ dotnet_diagnostic.IDE0016.severity = suggestion
 # IDE0039: Use local function
 dotnet_diagnostic.IDE0039.severity = suggestion
 
-# IDE0220: 
+# IDE0220:
 dotnet_diagnostic.IDE0220.severity = suggestion
 
 # IDE0031: Null check can be simplified

--- a/src/Microsoft.ComponentDetection.Detectors/ruby/RubyComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/ruby/RubyComponentDetector.cs
@@ -211,7 +211,7 @@ namespace Microsoft.ComponentDetection.Detectors.Ruby
                     {
                         line = lines[0].TrimEnd();
                         lines.RemoveAt(0);
-                        if (line.Trim().Equals(string.Empty))
+                        if (string.IsNullOrEmpty(line.Trim()))
                         {
                             break;
                         }

--- a/src/Microsoft.ComponentDetection.Detectors/rust/RustCrateDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/rust/RustCrateDetector.cs
@@ -35,7 +35,7 @@ namespace Microsoft.ComponentDetection.Detectors.Rust
             version = versionMatch.Success ? versionMatch.Value : null;
             source = sourceMatch.Success ? sourceMatch.Value : null;
 
-            if (source == string.Empty)
+            if (string.IsNullOrEmpty(source))
             {
                 source = null;
             }

--- a/src/Microsoft.ComponentDetection.Detectors/rust/SemVer/ComparatorSet.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/rust/SemVer/ComparatorSet.cs
@@ -23,7 +23,7 @@ namespace Microsoft.ComponentDetection.Detectors.Rust.SemVer
             this.comparators = new List<Comparator> { };
 
             spec = spec.Trim();
-            if (spec == string.Empty)
+            if (string.IsNullOrEmpty(spec))
             {
                 spec = "*";
             }
@@ -78,16 +78,16 @@ namespace Microsoft.ComponentDetection.Detectors.Rust.SemVer
         public bool IsSatisfied(SemVersion version)
         {
             var satisfied = this.comparators.All(c => c.IsSatisfied(version));
-            if (version.Prerelease != string.Empty)
+            if (!string.IsNullOrEmpty(version.Prerelease))
             {
                 // If the version is a pre-release, then one of the
                 // comparators must have the same version and also include
                 // a pre-release tag.
                 return satisfied && this.comparators.Any(c =>
-                        c.Version.Prerelease != string.Empty &&
-                        c.Version.Major == version.Major &&
-                        c.Version.Minor == version.Minor &&
-                        c.Version.Patch == version.Patch);
+                    !string.IsNullOrEmpty(c.Version.Prerelease) &&
+                    c.Version.Major == version.Major &&
+                    c.Version.Minor == version.Minor &&
+                    c.Version.Patch == version.Patch);
             }
             else
             {

--- a/src/Microsoft.ComponentDetection.Detectors/rust/SemVer/PartialVersion.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/rust/SemVer/PartialVersion.cs
@@ -47,7 +47,7 @@ namespace Microsoft.ComponentDetection.Detectors.Rust.SemVer
         {
             string[] xValues = { "X", "x", "*" };
 
-            if (input.Trim() == string.Empty)
+            if (string.IsNullOrEmpty(input.Trim()))
             {
                 // Empty input means any version
                 return;


### PR DESCRIPTION
[CA1820: Test for empty strings using string length
](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1820)
Related to #202 