### PR TITLE
fix IDE0031, IDE0042, IDE0018, IDE0017, IDE0004, IDE0007, IDE0016

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -873,9 +873,6 @@ dotnet_diagnostic.IDE0024.severity = suggestion
 # IDE0010: Populate switch
 dotnet_diagnostic.IDE0010.severity = suggestion
 
-# IDE0016: Null check can be simplified
-dotnet_diagnostic.IDE0016.severity = suggestion
-
 # IDE0039: Use local function
 dotnet_diagnostic.IDE0039.severity = suggestion
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -855,9 +855,6 @@ dotnet_diagnostic.IDE0066.severity = suggestion
 # IDE0018: Variable declaration can be inlined
 dotnet_diagnostic.IDE0018.severity = suggestion
 
-# IDE0017: Object initialization can be simplified
-dotnet_diagnostic.IDE0017.severity = suggestion
-
 # IDE0074: Use compound assignment
 dotnet_diagnostic.IDE0074.severity = suggestion
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -858,9 +858,6 @@ dotnet_diagnostic.IDE0018.severity = suggestion
 # IDE0017: Object initialization can be simplified
 dotnet_diagnostic.IDE0017.severity = suggestion
 
-# IDE0004: Cast is redundant.
-dotnet_diagnostic.IDE0004.severity = suggestion
-
 # IDE0074: Use compound assignment
 dotnet_diagnostic.IDE0074.severity = suggestion
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -882,9 +882,6 @@ dotnet_diagnostic.IDE0039.severity = suggestion
 # IDE0220:
 dotnet_diagnostic.IDE0220.severity = suggestion
 
-# IDE0031: Null check can be simplified
-dotnet_diagnostic.IDE0031.severity = suggestion
-
 # CA1724: Type names should not match namespaces
 dotnet_diagnostic.CA1724.severity = suggestion
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -876,9 +876,6 @@ dotnet_diagnostic.IDE0010.severity = suggestion
 # IDE0039: Use local function
 dotnet_diagnostic.IDE0039.severity = suggestion
 
-# IDE0220:
-dotnet_diagnostic.IDE0220.severity = suggestion
-
 # CA1724: Type names should not match namespaces
 dotnet_diagnostic.CA1724.severity = suggestion
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -849,9 +849,6 @@ dotnet_diagnostic.IDE0037.severity = suggestion
 # IDE0066: Use 'switch' expression
 dotnet_diagnostic.IDE0066.severity = suggestion
 
-# IDE0018: Variable declaration can be inlined
-dotnet_diagnostic.IDE0018.severity = suggestion
-
 # IDE0074: Use compound assignment
 dotnet_diagnostic.IDE0074.severity = suggestion
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -864,9 +864,6 @@ dotnet_diagnostic.IDE0004.severity = suggestion
 # IDE0074: Use compound assignment
 dotnet_diagnostic.IDE0074.severity = suggestion
 
-# IDE0007: use 'var' instead of explicit type
-dotnet_diagnostic.IDE0007.severity = suggestion
-
 # IDE0024: Use expression body for operators
 dotnet_diagnostic.IDE0024.severity = suggestion
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -843,9 +843,6 @@ dotnet_diagnostic.IDE0120.severity = suggestion
 # IDE0075: Conditional expression can be simplified
 dotnet_diagnostic.IDE0075.severity = suggestion
 
-# IDE0042: Variable declaration can be deconstructed
-dotnet_diagnostic.IDE0042.severity = suggestion
-
 # IDE0037: Member name can be simplified
 dotnet_diagnostic.IDE0037.severity = suggestion
 

--- a/src/Microsoft.ComponentDetection.Detectors/go/GoComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/go/GoComponentDetector.cs
@@ -277,8 +277,10 @@ namespace Microsoft.ComponentDetection.Detectors.Go
         private void RecordBuildDependencies(string goListOutput, ISingleFileComponentRecorder singleFileComponentRecorder)
         {
             var goBuildModules = new List<GoBuildModule>();
-            var reader = new JsonTextReader(new StringReader(goListOutput));
-            reader.SupportMultipleContent = true;
+            var reader = new JsonTextReader(new StringReader(goListOutput))
+            {
+                SupportMultipleContent = true,
+            };
 
             while (reader.Read())
             {

--- a/src/Microsoft.ComponentDetection.Detectors/go/GoComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/go/GoComponentDetector.cs
@@ -243,11 +243,8 @@ namespace Microsoft.ComponentDetection.Detectors.Go
                     continue;
                 }
 
-                GoComponent parentComponent;
-                GoComponent childComponent;
-
-                var isParentParsed = this.TryCreateGoComponentFromRelationshipPart(components[0], out parentComponent);
-                var isChildParsed = this.TryCreateGoComponentFromRelationshipPart(components[1], out childComponent);
+                var isParentParsed = this.TryCreateGoComponentFromRelationshipPart(components[0], out var parentComponent);
+                var isChildParsed = this.TryCreateGoComponentFromRelationshipPart(components[1], out var childComponent);
 
                 if (!isParentParsed)
                 {

--- a/src/Microsoft.ComponentDetection.Detectors/maven/MavenParsingUtilities.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/maven/MavenParsingUtilities.cs
@@ -20,17 +20,17 @@ namespace Microsoft.ComponentDetection.Detectors.Maven
 
         public static (DetectedComponent Component, bool? IsDevelopmentDependency, DependencyScope? dependencyScope) GenerateDetectedComponentAndMetadataFromMavenString(string key)
         {
-            var componentAndMetaData = GetMavenComponentAndIsDevDependencyAndScope(key);
+            var (component, isDevDependency, dependencyScope) = GetMavenComponentAndIsDevDependencyAndScope(key);
 
-            var detectedComponent = new DetectedComponent(componentAndMetaData.component);
+            var detectedComponent = new DetectedComponent(component);
 
-            return (detectedComponent, componentAndMetaData.isDevDependency, componentAndMetaData.dependencyScope);
+            return (detectedComponent, isDevDependency, dependencyScope);
         }
 
         private static (MavenComponent component, bool? isDevDependency, DependencyScope? dependencyScope) GetMavenComponentAndIsDevDependencyAndScope(string componentString)
         {
-            var info = GetMavenComponentStringInfo(componentString);
-            return (new MavenComponent(info.groupId, info.artifactId, info.version), info.isDevelopmentDependency, info.dependencyScope);
+            var (groupId, artifactId, version, isDevelopmentDependency, dependencyScope) = GetMavenComponentStringInfo(componentString);
+            return (new MavenComponent(groupId, artifactId, version), isDevelopmentDependency, dependencyScope);
         }
 
         private static (string groupId, string artifactId, string version, bool? isDevelopmentDependency, DependencyScope dependencyScope)

--- a/src/Microsoft.ComponentDetection.Detectors/maven/MavenStyleDependencyGraphParser.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/maven/MavenStyleDependencyGraphParser.cs
@@ -48,12 +48,12 @@ namespace Microsoft.ComponentDetection.Detectors.Maven
                 var localLine = line.Trim(TrimCharacters);
                 if (!string.IsNullOrWhiteSpace(localLine) && this.topLevelComponent == null)
                 {
-                    var topLevelMavenStringInfo = MavenParsingUtilities.GenerateDetectedComponentAndMetadataFromMavenString(localLine);
-                    this.topLevelComponent = topLevelMavenStringInfo.Component;
+                    var (component, isDevelopmentDependency, dependencyScope) = MavenParsingUtilities.GenerateDetectedComponentAndMetadataFromMavenString(localLine);
+                    this.topLevelComponent = component;
                     singleFileComponentRecorder.RegisterUsage(
-                        topLevelMavenStringInfo.Component,
-                        isDevelopmentDependency: topLevelMavenStringInfo.IsDevelopmentDependency,
-                        dependencyScope: topLevelMavenStringInfo.dependencyScope);
+                        component,
+                        isDevelopmentDependency: isDevelopmentDependency,
+                        dependencyScope: dependencyScope);
                 }
                 else
                 {
@@ -107,8 +107,8 @@ namespace Microsoft.ComponentDetection.Detectors.Maven
                 this.tupleStack.Pop();
             }
 
-            var componentAndDevDependencyTuple = MavenParsingUtilities.GenerateDetectedComponentAndMetadataFromMavenString(versionedComponent);
-            var newTuple = (ParseLevel: position, componentAndDevDependencyTuple.Component);
+            var (component, isDevelopmentDependency, dependencyScope) = MavenParsingUtilities.GenerateDetectedComponentAndMetadataFromMavenString(versionedComponent);
+            var newTuple = (ParseLevel: position, Component: component);
 
             if (this.tupleStack.Count > 0)
             {
@@ -117,8 +117,8 @@ namespace Microsoft.ComponentDetection.Detectors.Maven
                 componentRecorder.RegisterUsage(
                     newTuple.Component,
                     parentComponentId: parent.Component.Id,
-                    isDevelopmentDependency: componentAndDevDependencyTuple.IsDevelopmentDependency,
-                    dependencyScope: componentAndDevDependencyTuple.dependencyScope);
+                    isDevelopmentDependency: isDevelopmentDependency,
+                    dependencyScope: dependencyScope);
             }
             else
             {
@@ -126,8 +126,8 @@ namespace Microsoft.ComponentDetection.Detectors.Maven
                     newTuple.Component,
                     isExplicitReferencedDependency: true,
                     parentComponentId: this.topLevelComponent.Component.Id,
-                    isDevelopmentDependency: componentAndDevDependencyTuple.IsDevelopmentDependency,
-                    dependencyScope: componentAndDevDependencyTuple.dependencyScope);
+                    isDevelopmentDependency: isDevelopmentDependency,
+                    dependencyScope: dependencyScope);
             }
 
             this.tupleStack.Push(newTuple);

--- a/src/Microsoft.ComponentDetection.Detectors/npm/NpmComponentDetectorWithRoots.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/npm/NpmComponentDetectorWithRoots.cs
@@ -296,7 +296,7 @@ namespace Microsoft.ComponentDetection.Detectors.Npm
         {
             if (dependencies != null)
             {
-                foreach (JProperty dependency in dependencies.Cast<JProperty>())
+                foreach (var dependency in dependencies.Cast<JProperty>())
                 {
                     if (dependency != null)
                     {
@@ -311,7 +311,7 @@ namespace Microsoft.ComponentDetection.Detectors.Npm
             var isValid = true;
             if (dependencies != null)
             {
-                foreach (JProperty dependency in dependencies.Cast<JProperty>())
+                foreach (var dependency in dependencies.Cast<JProperty>())
                 {
                     if (dependency == null || dependency.Name == null)
                     {

--- a/src/Microsoft.ComponentDetection.Detectors/npm/NpmComponentDetectorWithRoots.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/npm/NpmComponentDetectorWithRoots.cs
@@ -296,7 +296,7 @@ namespace Microsoft.ComponentDetection.Detectors.Npm
         {
             if (dependencies != null)
             {
-                foreach (JProperty dependency in dependencies)
+                foreach (JProperty dependency in dependencies.Cast<JProperty>())
                 {
                     if (dependency != null)
                     {
@@ -311,7 +311,7 @@ namespace Microsoft.ComponentDetection.Detectors.Npm
             var isValid = true;
             if (dependencies != null)
             {
-                foreach (JProperty dependency in dependencies)
+                foreach (JProperty dependency in dependencies.Cast<JProperty>())
                 {
                     if (dependency == null || dependency.Name == null)
                     {

--- a/src/Microsoft.ComponentDetection.Detectors/nuget/NuGetComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/nuget/NuGetComponentDetector.cs
@@ -146,7 +146,7 @@ namespace Microsoft.ComponentDetection.Detectors.NuGet
             while ((line = reader.ReadLine()) != null)
             {
                 var matches = Regex.Matches(line, @"\s*([a-zA-Z0-9-.]*) \([<>=]*[ ]*([0-9a-zA-Z-.]*)\)", RegexOptions.Singleline);
-                foreach (Match match in matches)
+                foreach (Match match in matches.Cast<Match>())
                 {
                     var name = match.Groups[1].Value;
                     string version = match.Groups[2].Value;

--- a/src/Microsoft.ComponentDetection.Detectors/nuget/NuGetComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/nuget/NuGetComponentDetector.cs
@@ -146,11 +146,11 @@ namespace Microsoft.ComponentDetection.Detectors.NuGet
             while ((line = reader.ReadLine()) != null)
             {
                 var matches = Regex.Matches(line, @"\s*([a-zA-Z0-9-.]*) \([<>=]*[ ]*([0-9a-zA-Z-.]*)\)", RegexOptions.Singleline);
-                foreach (Match match in matches.Cast<Match>())
+                foreach (var match in matches.Cast<Match>())
                 {
                     var name = match.Groups[1].Value;
-                    string version = match.Groups[2].Value;
-                    NuGetComponent component = new NuGetComponent(name, version);
+                    var version = match.Groups[2].Value;
+                    var component = new NuGetComponent(name, version);
                     singleFileComponentRecorder.RegisterUsage(new DetectedComponent(component));
                 }
             }

--- a/src/Microsoft.ComponentDetection.Detectors/nuget/NuGetProjectModelProjectCentricComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/nuget/NuGetProjectModelProjectCentricComponentDetector.cs
@@ -180,7 +180,7 @@ namespace Microsoft.ComponentDetection.Detectors.NuGet
                 {
                     if (librariesWithAbsolutePath.TryGetValue(Path.GetFullPath(projectReference.ProjectPath), out var library))
                     {
-                        toBeFilled.Add((library.Name, library.Version.Version, (VersionRange)null));
+                        toBeFilled.Add((library.Name, library.Version.Version, null));
                     }
                 }
             }

--- a/src/Microsoft.ComponentDetection.Detectors/pip/PythonResolver.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/PythonResolver.cs
@@ -74,7 +74,7 @@ namespace Microsoft.ComponentDetection.Detectors.Pip
                 {
                     // if we have already seen the dependency and the version we have is valid, just add the dependency to the graph
                     if (state.NodeReferences.TryGetValue(dependencyNode.Name, out var node) &&
-                        PythonVersionUtilities.VersionValidForSpec(((PipComponent)node.Value).Version, dependencyNode.DependencySpecifiers))
+                        PythonVersionUtilities.VersionValidForSpec(node.Value.Version, dependencyNode.DependencySpecifiers))
                     {
                         state.NodeReferences[currentNode.Name].Children.Add(node);
                         node.Parents.Add(state.NodeReferences[currentNode.Name]);
@@ -123,10 +123,10 @@ namespace Microsoft.ComponentDetection.Detectors.Pip
             PipGraphNode node,
             PipDependencySpecification newSpec)
         {
-            var pipComponent = (PipComponent)node.Value;
+            var pipComponent = node.Value;
 
             var oldVersions = state.ValidVersionMap[pipComponent.Name].Keys.ToList();
-            var currentSelectedVersion = ((PipComponent)node.Value).Version;
+            var currentSelectedVersion = node.Value.Version;
             var currentReleases = state.ValidVersionMap[pipComponent.Name][currentSelectedVersion];
             foreach (var version in oldVersions)
             {
@@ -151,7 +151,7 @@ namespace Microsoft.ComponentDetection.Detectors.Pip
             var toRemove = new List<PipGraphNode>();
             foreach (var child in node.Children)
             {
-                var pipChild = (PipComponent)child.Value;
+                var pipChild = child.Value;
 
                 if (!dependencies.TryGetValue(pipChild.Name, out var newDependency))
                 {
@@ -178,7 +178,7 @@ namespace Microsoft.ComponentDetection.Detectors.Pip
             PythonResolverState state,
             PipDependencySpecification spec)
         {
-            var candidateVersion = ((PipComponent)state.NodeReferences[spec.Name].Value).Version;
+            var candidateVersion = state.NodeReferences[spec.Name].Value.Version;
 
             var packageToFetch = state.ValidVersionMap[spec.Name][candidateVersion].FirstOrDefault(x => string.Equals("bdist_wheel", x.PackageType, StringComparison.OrdinalIgnoreCase)) ??
                                  state.ValidVersionMap[spec.Name][candidateVersion].FirstOrDefault(x => string.Equals("bdist_egg", x.PackageType, StringComparison.OrdinalIgnoreCase));

--- a/src/Microsoft.ComponentDetection.Detectors/rust/SemVer/Comparator.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/rust/SemVer/Comparator.cs
@@ -103,13 +103,8 @@ namespace Microsoft.ComponentDetection.Detectors.Rust.SemVer
 
         public Comparator(Operator comparatorType, SemVersion comparatorVersion)
         {
-            if (comparatorVersion == null)
-            {
-                throw new NullReferenceException("Null comparator version");
-            }
-
             this.ComparatorType = comparatorType;
-            this.Version = comparatorVersion;
+            this.Version = comparatorVersion ?? throw new NullReferenceException("Null comparator version");
         }
 
         public static Tuple<int, Comparator> TryParse(string input)

--- a/src/Microsoft.ComponentDetection.Detectors/rust/SemVer/Range.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/rust/SemVer/Range.cs
@@ -178,7 +178,7 @@ namespace Microsoft.ComponentDetection.Detectors.Rust.SemVer
         {
             var versions = this.ValidVersions(versionStrings, loose);
             var maxVersion = this.MaxSatisfying(versions);
-            return maxVersion == null ? null : maxVersion.ToString();
+            return maxVersion?.ToString();
         }
 
         /// <summary>

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/MavenStyleDependencyGraphParserTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/MavenStyleDependencyGraphParserTests.cs
@@ -56,8 +56,8 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
 
             var dependencyGraph = componentRecorder.GetDependencyGraphsByLocation()[pomfileLocation];
 
-            var topLevelComponentInfo = MavenParsingUtilities.GenerateDetectedComponentAndMetadataFromMavenString("org.apache.maven:maven-compat:jar:3.6.1-SNAPSHOT");
-            var topLevelComponent = topLevelComponentInfo.Component;
+            var (component, isDevelopmentDependency, dependencyScope) = MavenParsingUtilities.GenerateDetectedComponentAndMetadataFromMavenString("org.apache.maven:maven-compat:jar:3.6.1-SNAPSHOT");
+            var topLevelComponent = component;
             var mavenCoreTuple = MavenParsingUtilities.GenerateDetectedComponentAndMetadataFromMavenString("org.apache.maven:maven-core:jar:3.6.1-SNAPSHOT:compile");
             var mavenCore = mavenCoreTuple.Component;
             var guiceTuple = MavenParsingUtilities.GenerateDetectedComponentAndMetadataFromMavenString("com.google.inject:guice:jar:no_aop:4.2.1:compile");

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/PipComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/PipComponentDetectorTests.cs
@@ -112,7 +112,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
 
             foreach (var item in setupPyRoots)
             {
-                var reference = (PipComponent)item.Value;
+                var reference = item.Value;
 
                 Assert.AreEqual(reference.Version, ((PipComponent)pipComponents.Single(x => ((PipComponent)x.Component).Name == reference.Name).Component).Version);
             }

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/PipResolverTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/PipResolverTests.cs
@@ -197,8 +197,8 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
 
         private bool CompareGraphs(PipGraphNode a, PipGraphNode b)
         {
-            var componentA = (PipComponent)a.Value;
-            var componentB = (PipComponent)b.Value;
+            var componentA = a.Value;
+            var componentB = b.Value;
 
             if (!string.Equals(componentA.Name, componentB.Name, StringComparison.OrdinalIgnoreCase) ||
                 !string.Equals(componentA.Version, componentB.Version, StringComparison.OrdinalIgnoreCase))

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/RustDependencySpecifierTest.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/RustDependencySpecifierTest.cs
@@ -41,16 +41,16 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
 
         public void DoAllTheTests(IEnumerable<(bool shouldMatch, string caseName, string specifierName, string specifierRange)> testCases)
         {
-            foreach (var testCase in testCases)
+            foreach (var (shouldMatch, caseName, specifierName, specifierRange) in testCases)
             {
                 var di = new DependencySpecification();
-                if (testCase.specifierName != null)
+                if (specifierName != null)
                 {
-                    di.Add(testCase.specifierName, testCase.specifierRange);
+                    di.Add(specifierName, specifierRange);
                 }
 
                 di.MatchesPackage(new CargoPackage { name = "some-cargo-package", version = "1.2.3" })
-                    .Should().Be(testCase.shouldMatch, testCase.caseName);
+                    .Should().Be(shouldMatch, caseName);
             }
         }
     }

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/YarnLockDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/YarnLockDetectorTests.cs
@@ -921,9 +921,9 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
                 if (component.Dependencies.Any())
                 {
                     builder.AppendLine($"  dependencies:");
-                    foreach (var dependency in component.Dependencies)
+                    foreach (var (name, requestedVersion) in component.Dependencies)
                     {
-                        builder.AppendLine($"    {dependency.Name} \"{dependency.RequestedVersion}\"");
+                        builder.AppendLine($"    {name} \"{requestedVersion}\"");
                     }
                 }
 
@@ -954,9 +954,9 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
                 if (component.Dependencies.Any())
                 {
                     builder.AppendLine($"  dependencies:");
-                    foreach (var dependency in component.Dependencies)
+                    foreach (var (name, requestedVersion) in component.Dependencies)
                     {
-                        builder.AppendLine($"    {dependency.Name}: {dependency.RequestedVersion}");
+                        builder.AppendLine($"    {name}: {requestedVersion}");
                     }
                 }
 

--- a/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/BcdeScanExecutionServiceTests.cs
+++ b/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/BcdeScanExecutionServiceTests.cs
@@ -492,18 +492,18 @@ namespace Microsoft.ComponentDetection.Orchestrator.Tests.Services
             var componentDWithDevDepTrueCopy = new DetectedComponent(new NpmComponent("testD", "1.0.0"), detector: npmDetector);
 
             // The hint for reading this test is to know that each "column" you see visually is what's being merged, so componentAWithNoDevDep is being merged "down" into componentAWithDevDepTrue.
-#pragma warning disable format
+#pragma warning disable IDE0007 // Use implicit type
             foreach ((DetectedComponent component, bool? isDevDep) component in new[]
             {
-                (componentAWithNoDevDep, (bool?)null), (componentAWithDevDepTrue, true),
+                (componentAWithNoDevDep, null), (componentAWithDevDepTrue, true),
                 (componentBWithNoDevDep, (bool?)null), (componentBWithDevDepFalse, false),
                 (componentCWithDevDepTrue, true), (componentCWithDevDepFalse, false),
                 (componentDWithDevDepTrue, true), (componentDWithDevDepTrueCopy, true),
             })
-#pragma warning restore format
             {
                 firstRecorder.RegisterUsage(component.component, isDevelopmentDependency: component.isDevDep);
             }
+#pragma warning restore IDE0007 // Use implicit type
 
             var results = this.SetupRecorderBasedScanning(args, new List<ComponentRecorder> { componentRecorder });
 

--- a/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/DetectorRestrictionServiceTests.cs
+++ b/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/DetectorRestrictionServiceTests.cs
@@ -64,7 +64,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Tests.Services
             this.detectors = this.detectors.Union(new[] { defaultOffDetectorMock.Object as IComponentDetector }).ToArray();
             var restrictedDetectors = this.serviceUnderTest.ApplyRestrictions(r, this.detectors);
             restrictedDetectors
-                .Should().NotContain(defaultOffDetectorMock.Object as IComponentDetector);
+                .Should().NotContain(defaultOffDetectorMock.Object);
         }
 
         [TestMethod]
@@ -77,7 +77,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Tests.Services
             r.ExplicitlyEnabledDetectorIds = new[] { "defaultOffDetector" };
             var restrictedDetectors = this.serviceUnderTest.ApplyRestrictions(r, this.detectors);
             restrictedDetectors
-                .Should().Contain(defaultOffDetectorMock.Object as IComponentDetector);
+                .Should().Contain(defaultOffDetectorMock.Object);
         }
 
         [TestMethod]

--- a/test/Microsoft.ComponentDetection.VerificationTests/ComponentDetectionIntegrationTests.cs
+++ b/test/Microsoft.ComponentDetection.VerificationTests/ComponentDetectionIntegrationTests.cs
@@ -36,11 +36,11 @@ namespace Microsoft.ComponentDetection.VerificationTests
         public void LogFileHasNoErrors()
         {
             // make sure the new log does not contain any error messages.
-            int errorIndex = this.newLogFileContents.IndexOf("[ERROR]");
+            var errorIndex = this.newLogFileContents.IndexOf("[ERROR]");
             if (errorIndex >= 0)
             {
                 // prints out the line that the error occured.
-                string errorMessage = $"An Error was found: {this.newLogFileContents.Substring(errorIndex, 200)}";
+                var errorMessage = $"An Error was found: {this.newLogFileContents.Substring(errorIndex, 200)}";
                 throw new Exception(errorMessage);
             }
         }
@@ -57,14 +57,14 @@ namespace Microsoft.ComponentDetection.VerificationTests
             var newComponents = this.newScanResult.ComponentsFound.Where(c => !experimentalDetectorsId.Contains(c.DetectorId));
             var oldComponents = this.oldScanResult.ComponentsFound.Where(c => !experimentalDetectorsId.Contains(c.DetectorId));
 
-            Dictionary<string, ScannedComponent> newComponentDictionary = this.GetComponentDictionary(newComponents);
-            Dictionary<string, ScannedComponent> oldComponentDictionary = this.GetComponentDictionary(oldComponents);
+            var newComponentDictionary = this.GetComponentDictionary(newComponents);
+            var oldComponentDictionary = this.GetComponentDictionary(oldComponents);
             using (new AssertionScope())
             {
                 this.CompareDetectedComponents(oldComponents, newComponentDictionary, "new");
                 this.CompareDetectedComponents(newComponents, oldComponentDictionary, "old");
-                DependencyGraphCollection oldGraphs = this.oldScanResult.DependencyGraphs;
-                DependencyGraphCollection newGraphs = this.newScanResult.DependencyGraphs;
+                var oldGraphs = this.oldScanResult.DependencyGraphs;
+                var newGraphs = this.newScanResult.DependencyGraphs;
                 this.CompareGraphs(oldGraphs, newGraphs, "old", "new");
                 this.CompareGraphs(newGraphs, oldGraphs, "new", "old");
             }
@@ -178,7 +178,7 @@ namespace Microsoft.ComponentDetection.VerificationTests
             using (new AssertionScope())
             {
                 this.ProcessDetectorVersions();
-                string regexPattern = @"Detection time: (\w+\.\w+) seconds. |(\w+ *[\w()]+) *\|(\w+\.*\w*) seconds *\|(\d+)";
+                var regexPattern = @"Detection time: (\w+\.\w+) seconds. |(\w+ *[\w()]+) *\|(\w+\.*\w*) seconds *\|(\d+)";
                 var oldMatches = Regex.Matches(this.oldLogFileContents, regexPattern);
                 var newMatches = Regex.Matches(this.newLogFileContents, regexPattern);
 
@@ -186,7 +186,7 @@ namespace Microsoft.ComponentDetection.VerificationTests
 
                 var detectorTimes = new Dictionary<string, float>();
                 var detectorCounts = new Dictionary<string, int>();
-                foreach (Match match in oldMatches.Cast<Match>())
+                foreach (var match in oldMatches.Cast<Match>())
                 {
                     if (!match.Groups[2].Success)
                     {
@@ -194,29 +194,29 @@ namespace Microsoft.ComponentDetection.VerificationTests
                     }
                     else
                     {
-                        string detectorId = match.Groups[2].Value;
+                        var detectorId = match.Groups[2].Value;
                         detectorTimes.Add(detectorId, float.Parse(match.Groups[3].Value));
                         detectorCounts.Add(detectorId, int.Parse(match.Groups[4].Value));
                     }
                 }
 
                 // fail at the end to gather all failures instead of just the first.
-                foreach (Match match in newMatches.Cast<Match>())
+                foreach (var match in newMatches.Cast<Match>())
                 {
                     // for each detector and overall, make sure the time doesn't increase by more than 10%
                     // for each detector make sure component counts do not change. if they increase, make sure the version of the detector was bumped.
                     if (!match.Groups[2].Success)
                     {
                         detectorTimes.TryGetValue("TotalTime", out var oldTime);
-                        float newTime = float.Parse(match.Groups[1].Value);
+                        var newTime = float.Parse(match.Groups[1].Value);
 
-                        float maxTimeThreshold = (float)(oldTime + Math.Max(5, oldTime * this.allowedTimeDriftRatio));
+                        var maxTimeThreshold = (float)(oldTime + Math.Max(5, oldTime * this.allowedTimeDriftRatio));
                         newTime.Should().BeLessOrEqualTo(maxTimeThreshold, $"Total Time take increased by a large amount. Please verify before continuing. old time: {oldTime}, new time: {newTime}");
                     }
                     else
                     {
-                        string detectorId = match.Groups[2].Value;
-                        int newCount = int.Parse(match.Groups[4].Value);
+                        var detectorId = match.Groups[2].Value;
+                        var newCount = int.Parse(match.Groups[4].Value);
                         if (detectorCounts.TryGetValue(detectorId, out var oldCount))
                         {
                             newCount.Should().BeGreaterOrEqualTo(oldCount, $"{oldCount - newCount} Components were lost for detector {detectorId}. Verify this is expected behavior. \n Old Count: {oldCount}, PPE Count: {newCount}");

--- a/test/Microsoft.ComponentDetection.VerificationTests/ComponentDetectionIntegrationTests.cs
+++ b/test/Microsoft.ComponentDetection.VerificationTests/ComponentDetectionIntegrationTests.cs
@@ -186,7 +186,7 @@ namespace Microsoft.ComponentDetection.VerificationTests
 
                 var detectorTimes = new Dictionary<string, float>();
                 var detectorCounts = new Dictionary<string, int>();
-                foreach (Match match in oldMatches)
+                foreach (Match match in oldMatches.Cast<Match>())
                 {
                     if (!match.Groups[2].Success)
                     {
@@ -201,7 +201,7 @@ namespace Microsoft.ComponentDetection.VerificationTests
                 }
 
                 // fail at the end to gather all failures instead of just the first.
-                foreach (Match match in newMatches)
+                foreach (Match match in newMatches.Cast<Match>())
                 {
                     // for each detector and overall, make sure the time doesn't increase by more than 10%
                     // for each detector make sure component counts do not change. if they increase, make sure the version of the detector was bumped.


### PR DESCRIPTION
fixed following analyzer warning
- fix IDE0031: Null check can be simplified
- IDE0042: Variable declaration can be deconstructed
- IDE0018: Variable declaration can be inlined
- IDE0017: Object initialization can be simplified
- IDE0004: Cast is redundant.
- IDE0007: use 'var' instead of explicit type
- IDE0016: Null check can be simplified
