### PR TITLE
allow manual trigger of snapshot-publish workflow

### DIFF
--- a/.github/workflows/snapshot-publish.yml
+++ b/.github/workflows/snapshot-publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch
 
 jobs:
   build:

--- a/.github/workflows/snapshot-publish.yml
+++ b/.github/workflows/snapshot-publish.yml
@@ -1,10 +1,10 @@
 name: Publish snapshot of test scan
 
 on:
-  push:
-    branches:
-      - main
-  workflow_dispatch
+  - push:
+      branches:
+        - main
+  - workflow_dispatch
 
 jobs:
   build:


### PR DESCRIPTION
### Summary
allow manual triggering of snapshot-publish workflow

### Details:
intermittent failures in snapshot-publish (example) can cause incomplete manifest in the published artifact. This incomplete artifact is then used for all the future PRs, causing failures (example).

Manually allowing triggering this workflow can be helpful in overwriting previously generated incomplete artifacts. 
