### PR TITLE
ci: remove `TargetLatestRuntimePatch` property

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,6 @@
     <AnalysisLevel>latest</AnalysisLevel>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
   </PropertyGroup>
 
   <PropertyGroup Label="Package">


### PR DESCRIPTION
The `TargetLatestRuntimePatch` property forces the `runtimeconfig.json`[^1] of our executables to specify the latest version of the runtime that the SDK we used to build knows about, instead of targeting `6.0.xxx`. Forcing this higher version makes any executables we produce less portable.

[^1]: https://learn.microsoft.com/en-us/dotnet/core/runtime-config/