### PR TITLE
Use extended log file names format to prevent collisions in concurrent builds

### DIFF
--- a/src/Microsoft.ComponentDetection.Common/FileWritingService.cs
+++ b/src/Microsoft.ComponentDetection.Common/FileWritingService.cs
@@ -10,7 +10,7 @@ namespace Microsoft.ComponentDetection.Common
     [Shared]
     public class FileWritingService : IFileWritingService
     {
-        public const string TimestampFormatString = "yyyyMMddHHmmss";
+        public const string TimestampFormatString = "yyyyMMddHHmmssfff";
 
         private object lockObject = new object();
         private string timestamp = DateTime.Now.ToString(TimestampFormatString);


### PR DESCRIPTION
Related to https://github.com/microsoft/component-detection/issues/279