### PR TITLE
ci: remove official_build environment variable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,6 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      OFFICIAL_BUILD: 'True'
       # Set the build number in MinVer.
       MINVERBUILDMETADATA: build.${{github.run_number}}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,6 @@ jobs:
         rid: [win-x64, linux-x64, osx-x64]
 
     env:
-      OFFICIAL_BUILD: 'True'
       # Set the build number in MinVer.
       MINVERBUILDMETADATA: build.${{github.run_number}}
 

--- a/.github/workflows/snapshot-verify.yml
+++ b/.github/workflows/snapshot-verify.yml
@@ -83,7 +83,6 @@ jobs:
         working-directory: test/Microsoft.ComponentDetection.VerificationTests
         run: dotnet test
         env:
-          OFFICIAL_BUILD: 'True'
           GITHUB_OLD_ARTIFACTS_DIR: ${{ github.workspace }}/release-output
           GITHUB_NEW_ARTIFACTS_DIR: ${{ github.workspace }}/output
           ALLOWED_TIME_DRIFT_RATIO: '.75'

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -7,9 +7,6 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    env:
-      OFFICIAL_BUILD: 'True'
-
     steps:
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
This was previously used to enable build warnings and errors. However, we now enable all warnings as errors, so this environment variable is unnecessary.