### PR TITLE
test: exclude `Microsoft.NET.Test.Sdk` from `Microsoft.ComponentDetection.TestsUtilities` project

### DIFF
--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -2,12 +2,7 @@
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"/>
 
-  <PropertyGroup Label="Build">
-    <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
-  </PropertyGroup>
-
   <ItemGroup Label="Package References">
-    <PackageReference Include="Microsoft.NET.Test.Sdk"/>
     <PackageReference Include="MSTest.TestAdapter"/>
     <PackageReference Include="MSTest.TestFramework"/>
     <PackageReference Include="Moq"/>

--- a/test/Microsoft.ComponentDetection.Common.Tests/Microsoft.ComponentDetection.Common.Tests.csproj
+++ b/test/Microsoft.ComponentDetection.Common.Tests/Microsoft.ComponentDetection.Common.Tests.csproj
@@ -1,7 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <ItemGroup>
+    <ItemGroup Label="Project References">
         <ProjectReference Include="..\Microsoft.ComponentDetection.TestsUtilities\Microsoft.ComponentDetection.TestsUtilities.csproj"/>
+    </ItemGroup>
+
+    <ItemGroup Label="Package References">
+      <PackageReference Include="Microsoft.NET.Test.Sdk"/>
     </ItemGroup>
 
 </Project>

--- a/test/Microsoft.ComponentDetection.Contracts.Tests/Microsoft.ComponentDetection.Contracts.Tests.csproj
+++ b/test/Microsoft.ComponentDetection.Contracts.Tests/Microsoft.ComponentDetection.Contracts.Tests.csproj
@@ -4,7 +4,8 @@
         <ProjectReference Include="..\..\src\Microsoft.ComponentDetection.Contracts\Microsoft.ComponentDetection.Contracts.csproj"/>
     </ItemGroup>
 
-    <ItemGroup>
+    <ItemGroup Label="Package References">
+        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="System.Reactive"/>
         <PackageReference Include="packageurl-dotnet"/>
     </ItemGroup>

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/Microsoft.ComponentDetection.Detectors.Tests.csproj
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/Microsoft.ComponentDetection.Detectors.Tests.csproj
@@ -4,7 +4,8 @@
         <ProjectReference Include="..\Microsoft.ComponentDetection.TestsUtilities\Microsoft.ComponentDetection.TestsUtilities.csproj" />
     </ItemGroup>
 
-    <ItemGroup>
+    <ItemGroup Label="Package References">
+        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="NuGet.Versioning" />
         <PackageReference Include="System.Reactive" />
         <PackageReference Include="packageurl-dotnet" />

--- a/test/Microsoft.ComponentDetection.Orchestrator.Tests/Microsoft.ComponentDetection.Orchestrator.Tests.csproj
+++ b/test/Microsoft.ComponentDetection.Orchestrator.Tests/Microsoft.ComponentDetection.Orchestrator.Tests.csproj
@@ -5,4 +5,8 @@
         <ProjectReference Include="..\Microsoft.ComponentDetection.TestsUtilities\Microsoft.ComponentDetection.TestsUtilities.csproj"/>
     </ItemGroup>
 
+    <ItemGroup Label="Package References">
+        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+    </ItemGroup>
+
 </Project>

--- a/test/Microsoft.ComponentDetection.TestsUtilities/Microsoft.ComponentDetection.TestsUtilities.csproj
+++ b/test/Microsoft.ComponentDetection.TestsUtilities/Microsoft.ComponentDetection.TestsUtilities.csproj
@@ -1,10 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+    <PropertyGroup Label="Build">
+      <IsPackable>true</IsPackable>
+    </PropertyGroup>
+
     <ItemGroup Label="Project References">
         <ProjectReference Include="..\..\src\Microsoft.ComponentDetection.Detectors\Microsoft.ComponentDetection.Detectors.csproj"/>
         <PackageReference Include="System.Reactive"/>
     </ItemGroup>
-    <PropertyGroup>
-        <IsPackable>true</IsPackable>
-    </PropertyGroup>
+
 </Project>


### PR DESCRIPTION
The `Microsoft.NET.Test.Sdk` automatically creates an entrypoint for test projects and enables them to run. The `Microsoft.ComponentDetection.TestsUtilities` project is a shared library that is used in other test projects, and is not a runnable project itself.

This change moves `Microsoft.NET.Test.Sdk` from `test/Directory.Build.props`, which is inherited by all projects in the `test` directory, to each individual test project that needs it.