### PR TITLE
added verification for dockerfile and spdx detector, minor bug fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -709,8 +709,6 @@ dotnet_diagnostic.CA1829.severity = suggestion
 # CA2234: Pass system uri objects instead of strings
 dotnet_diagnostic.CA2234.severity = suggestion
 
-# rbhansali
-
 # SA1101: Prefix local calls with this
 dotnet_diagnostic.SA1101.severity = suggestion
 

--- a/.github/workflows/snapshot-publish.yml
+++ b/.github/workflows/snapshot-publish.yml
@@ -41,6 +41,7 @@ jobs:
         working-directory: src/Microsoft.ComponentDetection
         run: dotnet run scan --Verbosity Verbose --SourceDirectory ${{ github.workspace }}/test/Microsoft.ComponentDetection.VerificationTests/resources --Output ${{ github.workspace }}/output
                                                  --DockerImagesToScan "docker.io/library/debian@sha256:9b0e3056b8cd8630271825665a0613cc27829d6a24906dc0122b3b4834312f7d,mcr.microsoft.com/cbl-mariner/base/core@sha256:c1bc83a3d385eccbb2f7f7da43a726c697e22a996f693a407c35ac7b4387cd59,docker.io/library/alpine@sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870"
+                                                 --DetectorArgs DockerReference=EnableIfDefaultOff,SPDX22SBOM=EnableIfDefaultOff
 
       - name: Upload output folder
         uses: actions/upload-artifact@v3

--- a/.github/workflows/snapshot-verify.yml
+++ b/.github/workflows/snapshot-verify.yml
@@ -78,6 +78,7 @@ jobs:
         working-directory: src/Microsoft.ComponentDetection
         run: dotnet run scan --Verbosity Verbose --SourceDirectory ${{ github.workspace }}/test/Microsoft.ComponentDetection.VerificationTests/resources --Output ${{ github.workspace }}/output
                                                  --DockerImagesToScan "docker.io/library/debian@sha256:9b0e3056b8cd8630271825665a0613cc27829d6a24906dc0122b3b4834312f7d,mcr.microsoft.com/cbl-mariner/base/core@sha256:c1bc83a3d385eccbb2f7f7da43a726c697e22a996f693a407c35ac7b4387cd59,docker.io/library/alpine@sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870"
+                                                 --DetectorArgs DockerReference=EnableIfDefaultOff,SPDX22SBOM=EnableIfDefaultOff
 
       - name: Run Verification Tests
         working-directory: test/Microsoft.ComponentDetection.VerificationTests

--- a/src/Microsoft.ComponentDetection.Contracts/BcdeModels/TypedComponentConverter.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/BcdeModels/TypedComponentConverter.cs
@@ -25,6 +25,7 @@ namespace Microsoft.ComponentDetection.Contracts.BcdeModels
             { ComponentType.Conda, typeof(CondaComponent) },
             { ComponentType.DockerReference, typeof(DockerReferenceComponent) },
             { ComponentType.Vcpkg, typeof(VcpkgComponent) },
+            { ComponentType.Spdx, typeof(SpdxComponent) },
         };
 
         public override bool CanWrite

--- a/src/Microsoft.ComponentDetection.Contracts/DockerReference.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/DockerReference.cs
@@ -32,7 +32,7 @@ namespace Microsoft.ComponentDetection.Contracts
             }
             else if (string.IsNullOrEmpty(tag))
             {
-                if (string.IsNullOrEmpty(digest))
+                if (!string.IsNullOrEmpty(digest))
                 {
                     return new CanonicalReference
                     {

--- a/src/Microsoft.ComponentDetection.Contracts/TypedComponent/SpdxComponent.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/TypedComponent/SpdxComponent.cs
@@ -21,17 +21,17 @@ namespace Microsoft.ComponentDetection.Contracts.TypedComponent
 
         public override ComponentType Type => ComponentType.Spdx;
 
-        public string RootElementId { get; }
+        public string RootElementId { get; set; }
 
-        public string Name { get; }
+        public string Name { get; set; }
 
-        public string SpdxVersion { get; }
+        public string SpdxVersion { get; set; }
 
-        public Uri DocumentNamespace { get; }
+        public Uri DocumentNamespace { get; set; }
 
-        public string Checksum { get; }
+        public string Checksum { get; set; }
 
-        public string Path { get; }
+        public string Path { get; set; }
 
         public override string Id => $"{this.Name}-{this.SpdxVersion}-{this.Checksum}";
     }

--- a/test/Microsoft.ComponentDetection.VerificationTests/resources/VerificationTest.ps1
+++ b/test/Microsoft.ComponentDetection.VerificationTests/resources/VerificationTest.ps1
@@ -37,13 +37,15 @@ function main()
     dotnet restore
     Set-Location ((Get-Item  $repoPath).FullName + "\src\Microsoft.ComponentDetection")
     dotnet run scan --SourceDirectory $verificationTestRepo --Output $output `
-                    --DockerImagesToScan $dockerImagesToScan
+                    --DockerImagesToScan $dockerImagesToScan `
+                    --DetectorArgs DockerReference=EnableIfDefaultOff,SPDX22SBOM=EnableIfDefaultOff
 
     Set-Location $CDRelease
     dotnet restore
     Set-Location ($CDRelease + "\src\Microsoft.ComponentDetection")
     dotnet run scan --SourceDirectory $verificationTestRepo --Output $releaseOutput `
-                    --DockerImagesToScan $dockerImagesToScan    
+                    --DockerImagesToScan $dockerImagesToScan `
+                    --DetectorArgs DockerReference=EnableIfDefaultOff,SPDX22SBOM=EnableIfDefaultOff
 
     $env:GITHUB_OLD_ARTIFACTS_DIR = $releaseOutput
     $env:GITHUB_NEW_ARTIFACTS_DIR = $output

--- a/test/Microsoft.ComponentDetection.VerificationTests/resources/dockerFiles/Dockerfile
+++ b/test/Microsoft.ComponentDetection.VerificationTests/resources/dockerFiles/Dockerfile
@@ -1,0 +1,28 @@
+﻿FROM mcr.microsoft.com/dotnet/sdk:3.1-cbl-mariner1.0 AS build
+WORKDIR /app
+COPY . .
+RUN dotnet publish -c Release -o out \
+    -r linux-x64 \
+    -p:MinVerSkip=true \
+    --self-contained true \
+    -p:PublishReadyToRun=false \
+    -p:IncludeNativeLibrariesForSelfExtract=true \
+    -p:PublishSingleFile=true \
+    -p:PublishTrimmed=true \
+    -p:TrimUnusedDependencies=true \
+    ./src/Microsoft.ComponentDetection
+
+FROM mcr.microsoft.com/dotnet/runtime-deps:3.1-cbl-mariner1.0 AS runtime
+WORKDIR /app
+COPY --from=build /app/out ./
+
+RUN tdnf install -y \
+    golang \
+    moby-engine \
+    gradle \
+    maven \
+    pnpm \
+    poetry \
+    python
+
+ENTRYPOINT ["/app/Microsoft.ComponentDetection"]

--- a/test/Microsoft.ComponentDetection.VerificationTests/resources/dockerFiles/alpine.dockerfile
+++ b/test/Microsoft.ComponentDetection.VerificationTests/resources/dockerFiles/alpine.dockerfile
@@ -1,0 +1,12 @@
+FROM docker.io/library/alpine:latest@sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870
+
+LABEL maintainer="foobar <foobar@microsoft.com"
+
+ARG TZ="US/Seattle"
+
+ENV TZ ${TZ}
+
+RUN apk upgrade \
+    && apk add bash tzdata bind-tools busybox-extras ca-certificates libc6-compat wget curl
+
+CMD ["/bin/bash"]

--- a/test/Microsoft.ComponentDetection.VerificationTests/resources/dockerFiles/atlassian.dockerfile
+++ b/test/Microsoft.ComponentDetection.VerificationTests/resources/dockerFiles/atlassian.dockerfile
@@ -1,0 +1,17 @@
+FROM docker.io/library/atlassian/confluence-server@sha256:1552dbec533e1793d8b3c8459dac43d71faaa0bfe01980961db19c091a850113
+
+LABEL maintainer="foobar <foobar@microsoft.com>"
+
+ARG TZ="US/Seattle"
+
+ENV TZ ${TZ}
+ENV AGENT_PATH /opt/atlassian-agent.jar
+
+COPY atlassian-agent.jar ${AGENT_PATH}
+COPY hijack.sh /hijack.sh
+
+RUN set -x \
+    && export DEBIAN_FRONTEND=noninteractive \
+    && apt update \
+
+CMD ["/hijack.sh"]

--- a/test/Microsoft.ComponentDetection.VerificationTests/resources/dockerFiles/python.dockerfile
+++ b/test/Microsoft.ComponentDetection.VerificationTests/resources/dockerFiles/python.dockerfile
@@ -1,0 +1,18 @@
+FROM docker.io/library/python:3.11.0rc2-bullseye AS base
+FROM base
+
+LABEL maintainer="foorbar <foobar@microsoft.com>"
+
+ARG TZ="US/Seattle"
+
+ENV TZ ${TZ}
+ENV AGENT_PATH /opt/atlassian-agent.jar
+
+COPY atlassian-agent.jar ${AGENT_PATH}
+COPY hijack.sh /hijack.sh
+
+RUN set -x \
+    && export DEBIAN_FRONTEND=noninteractive \
+    && apt update \
+
+CMD ["/hijack.sh"]

--- a/test/Microsoft.ComponentDetection.VerificationTests/resources/dockerFiles/ubuntu.dockerfile
+++ b/test/Microsoft.ComponentDetection.VerificationTests/resources/dockerFiles/ubuntu.dockerfile
@@ -1,0 +1,17 @@
+FROM docker.io/library/ubuntu
+
+LABEL maintainer="foorbar <foobar@microsoft.com>"
+
+ARG TZ="US/Seattle"
+
+ENV TZ ${TZ}
+ENV AGENT_PATH /opt/atlassian-agent.jar
+
+COPY atlassian-agent.jar ${AGENT_PATH}
+COPY hijack.sh /hijack.sh
+
+RUN set -x \
+    && export DEBIAN_FRONTEND=noninteractive \
+    && apt update \
+
+CMD ["/hijack.sh"]


### PR DESCRIPTION
- Enabled verification tests for `DockerReference` and `SPDX22SBOM` detectors
- minor bug fix in `DockerRefernce` detection that detected Repository kind as canonical.
- bug fix in de-serialization of "spdx" component during verification tests. 


Note: verification tests are expected to fail because new detectors are enabled in this PR. 