### PR TITLE
Add new exclusions to .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -789,3 +789,18 @@ dotnet_diagnostic.CA1724.severity = suggestion
 
 # IL3000: always returns an empty string for assemblies embedded in a single-file app.
 dotnet_diagnostic.IL3000.severity = suggestion
+
+# IDE0053: Use expression body for lambdas
+dotnet_diagnostic.IDE0053.severity = suggestion
+
+# IDE0200: Lambda expression can be removed
+dotnet_diagnostic.IDE0200.severity = suggestion
+
+# CA1311: Use ToLowerInvariant/ToUpperInvariant
+dotnet_diagnostic.CA1311.severity = suggestion
+
+# CA1852: Type can be sealed
+dotnet_diagnostic.CA1852.severity = suggestion
+
+# CA1854: Prefer the IDictionary.TryGetValue(TKey, out TValue) method
+dotnet_diagnostic.CA1854.severity = suggestion


### PR DESCRIPTION
Add the IDE0053, IDE0200, CA1311, CA1852, and CA1854 exlcusions to .editorconfig to avoid build breaks.
They will be addressed as part of #202 