### PR TITLE
Add param to skip searching /Plugins for extra detectors

### DIFF
--- a/src/Microsoft.ComponentDetection.Orchestrator/ArgumentSets/BaseArguments.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/ArgumentSets/BaseArguments.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -21,6 +21,9 @@ namespace Microsoft.ComponentDetection.Orchestrator.ArgumentSets
         public IEnumerable<DirectoryInfo> AdditionalPluginDirectories { get; set; }
 
         public IEnumerable<string> AdditionalPluginDirectoriesSerialized => this.AdditionalPluginDirectories?.Select(x => x.ToString()) ?? new List<string>();
+
+        [Option("SkipPluginsDirectory", Required = false, Default = false, HelpText = "Skip searching of /Plugins directory for additional component detectors.")]
+        public bool SkipPluginsDirectory { get; set; }
 
         [Option("CorrelationId", Required = false, HelpText = "Identifier used to correlate all telemetry for a given execution. If not provided, a new GUID will be generated.")]
         public Guid CorrelationId { get; set; }

--- a/src/Microsoft.ComponentDetection.Orchestrator/ArgumentSets/IScanArguments.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/ArgumentSets/IScanArguments.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.ComponentDetection.Common;
@@ -10,6 +10,8 @@ namespace Microsoft.ComponentDetection.Orchestrator.ArgumentSets
         IEnumerable<DirectoryInfo> AdditionalPluginDirectories { get; set; }
 
         IEnumerable<string> AdditionalDITargets { get; set; }
+
+        bool SkipPluginsDirectory { get; set; }
 
         Guid CorrelationId { get; set; }
 

--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/BcdeScanExecutionService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/BcdeScanExecutionService.cs
@@ -30,7 +30,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Services
         public async Task<ScanResult> ExecuteScanAsync(IDetectionArguments detectionArguments)
         {
             this.Logger.LogCreateLoggingGroup();
-            var initialDetectors = this.DetectorRegistryService.GetDetectors(detectionArguments.AdditionalPluginDirectories, detectionArguments.AdditionalDITargets).ToImmutableList();
+            var initialDetectors = this.DetectorRegistryService.GetDetectors(detectionArguments.AdditionalPluginDirectories, detectionArguments.AdditionalDITargets, detectionArguments.SkipPluginsDirectory).ToImmutableList();
 
             if (!initialDetectors.Any())
             {

--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/DetectorListingCommandService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/DetectorListingCommandService.cs
@@ -1,4 +1,4 @@
-﻿using System.Composition;
+using System.Composition;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.ComponentDetection.Contracts;
@@ -29,7 +29,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Services
 
         private async Task<ProcessingResultCode> ListDetectorsAsync(IScanArguments listArguments)
         {
-            var detectors = this.DetectorRegistryService.GetDetectors(listArguments.AdditionalPluginDirectories, listArguments.AdditionalDITargets);
+            var detectors = this.DetectorRegistryService.GetDetectors(listArguments.AdditionalPluginDirectories, listArguments.AdditionalDITargets, listArguments.SkipPluginsDirectory);
             if (detectors.Any())
             {
                 foreach (var detector in detectors)

--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/DetectorRegistryService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/DetectorRegistryService.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Composition;
 using System.Composition.Hosting;
 using System.IO;
@@ -22,12 +22,17 @@ namespace Microsoft.ComponentDetection.Orchestrator.Services
 
         private IEnumerable<IComponentDetector> ComponentDetectors { get; set; }
 
-        public IEnumerable<IComponentDetector> GetDetectors(IEnumerable<DirectoryInfo> additionalSearchDirectories, IEnumerable<string> extraDetectorAssemblies)
+        public IEnumerable<IComponentDetector> GetDetectors(IEnumerable<DirectoryInfo> additionalSearchDirectories, IEnumerable<string> extraDetectorAssemblies, bool skipPluginsDirectory = false)
         {
-            var executableLocation = Assembly.GetEntryAssembly().Location;
-            var searchPath = Path.Combine(Path.GetDirectoryName(executableLocation), "Plugins");
+            var directoriesToSearch = new List<DirectoryInfo>();
 
-            var directoriesToSearch = new List<DirectoryInfo> { new DirectoryInfo(searchPath) };
+            // Checking Plugins directory is not required when skip argument is provided
+            if (!skipPluginsDirectory)
+            {
+                var executableLocation = Assembly.GetEntryAssembly().Location;
+                var searchPath = Path.Combine(Path.GetDirectoryName(executableLocation), "Plugins");
+                directoriesToSearch.Add(new DirectoryInfo(searchPath));
+            }
 
             if (additionalSearchDirectories != null)
             {
@@ -38,7 +43,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Services
 
             if (!this.ComponentDetectors.Any())
             {
-                this.Logger.LogError($"No component detectors were found in {searchPath} or other provided search paths.");
+                this.Logger.LogError($"No component detectors were found in {directoriesToSearch.FirstOrDefault()} or other provided search paths.");
             }
 
             return this.ComponentDetectors;

--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/IDetectorRegistryService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/IDetectorRegistryService.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using Microsoft.ComponentDetection.Contracts;
@@ -7,7 +7,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Services
 {
     public interface IDetectorRegistryService
     {
-        IEnumerable<IComponentDetector> GetDetectors(IEnumerable<DirectoryInfo> additionalSearchDirectories, IEnumerable<string> extraDetectorAssemblies);
+        IEnumerable<IComponentDetector> GetDetectors(IEnumerable<DirectoryInfo> additionalSearchDirectories, IEnumerable<string> extraDetectorAssemblies, bool skipPluginsDirectory = false);
 
         IEnumerable<IComponentDetector> GetDetectors(Assembly assemblyToSearch, IEnumerable<string> extraDetectorAssemblies);
     }

--- a/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/BcdeScanExecutionServiceTests.cs
+++ b/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/BcdeScanExecutionServiceTests.cs
@@ -630,7 +630,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Tests.Services
                 this.componentDetector2Mock.Object, this.componentDetector3Mock.Object,
             };
 
-            this.detectorRegistryServiceMock.Setup(x => x.GetDetectors(Enumerable.Empty<DirectoryInfo>(), It.IsAny<IEnumerable<string>>()))
+            this.detectorRegistryServiceMock.Setup(x => x.GetDetectors(Enumerable.Empty<DirectoryInfo>(), It.IsAny<IEnumerable<string>>(), It.IsAny<bool>()))
                 .Returns(registeredDetectors);
             this.detectorRestrictionServiceMock.Setup(
                 x => x.ApplyRestrictions(
@@ -688,7 +688,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Tests.Services
                 this.componentDetector2Mock.Object, this.componentDetector3Mock.Object,
             };
 
-            this.detectorRegistryServiceMock.Setup(x => x.GetDetectors(Enumerable.Empty<DirectoryInfo>(), It.IsAny<IEnumerable<string>>()))
+            this.detectorRegistryServiceMock.Setup(x => x.GetDetectors(Enumerable.Empty<DirectoryInfo>(), It.IsAny<IEnumerable<string>>(), It.IsAny<bool>()))
                 .Returns(registeredDetectors);
             this.detectorRestrictionServiceMock.Setup(
                 x => x.ApplyRestrictions(

--- a/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/DetectorListingCommandServiceTests.cs
+++ b/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/DetectorListingCommandServiceTests.cs
@@ -57,7 +57,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Tests.Services
                 this.versionedComponentDetector1Mock.Object,
             };
 
-            this.detectorRegistryServiceMock.Setup(x => x.GetDetectors(It.IsAny<IEnumerable<DirectoryInfo>>(), It.IsAny<IEnumerable<string>>()))
+            this.detectorRegistryServiceMock.Setup(x => x.GetDetectors(It.IsAny<IEnumerable<DirectoryInfo>>(), It.IsAny<IEnumerable<string>>(), It.IsAny<bool>()))
                 .Returns(registeredDetectors);
         }
 


### PR DESCRIPTION
On most runs of component detection, the /Plugins folder is searched for additional detector assemblies, but the folder does not exist, showing a [WARN] message like
```
[WARN] Provided search path D:\a\_tasks\SomeFolder\1.1.48\detection\Plugins does not exist.
```

This adds a default parameter to allow skipping the check for additional detectors in /Plugins without modifying logic of additional directory search parameters.