### PR TITLE
Address CA1831 after path substring changes

### DIFF
--- a/src/Microsoft.ComponentDetection.Common/PathUtilityService.cs
+++ b/src/Microsoft.ComponentDetection.Common/PathUtilityService.cs
@@ -78,11 +78,11 @@ namespace Microsoft.ComponentDetection.Common
 
         public static bool MatchesPattern(string searchPattern, ref FileSystemEntry fse)
         {
-            if (searchPattern.StartsWith("*") && fse.FileName.EndsWith(searchPattern[1..], StringComparison.OrdinalIgnoreCase))
+            if (searchPattern.StartsWith("*") && fse.FileName.EndsWith(searchPattern.AsSpan()[1..], StringComparison.OrdinalIgnoreCase))
             {
                 return true;
             }
-            else if (searchPattern.EndsWith("*") && fse.FileName.StartsWith(searchPattern[..^1], StringComparison.OrdinalIgnoreCase))
+            else if (searchPattern.EndsWith("*") && fse.FileName.StartsWith(searchPattern.AsSpan()[..^1], StringComparison.OrdinalIgnoreCase))
             {
                 return true;
             }


### PR DESCRIPTION
After #330 CA1831 was being flagged in PathUtilityService (on some build machines) due to the new use of [..1] indexers. This PR adds the .AsSpan call to avoid making data copies.

`Microsoft.ComponentDetection.Common\PathUtilityService.cs(85,77): error CA1831: Use 'AsSpan' instead of the 'System.Range'-based indexer on 'string' to avoid creating unnecessary data copies`
