### PR TITLE
Fix Analyzer warnings: CA1707, CA1300, CA1040

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -708,9 +708,6 @@ dotnet_diagnostic.CA1847.severity = suggestion
 # CA1835: Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
 dotnet_diagnostic.CA1835.severity = suggestion
 
-# CA1040: Avoid empty interfaces
-dotnet_diagnostic.CA1040.severity = suggestion
-
 # CA1036: Override methods on comparable types
 dotnet_diagnostic.CA1036.severity = suggestion
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -708,9 +708,6 @@ dotnet_diagnostic.CA1847.severity = suggestion
 # CA1835: Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
 dotnet_diagnostic.CA1835.severity = suggestion
 
-# CA1707: Identifiers should not contain underscores
-dotnet_diagnostic.CA1707.severity = suggestion
-
 # CA1040: Avoid empty interfaces
 dotnet_diagnostic.CA1040.severity = suggestion
 

--- a/src/Microsoft.ComponentDetection.Detectors/IComponentGovernanceOwnedDetectors.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/IComponentGovernanceOwnedDetectors.cs
@@ -3,6 +3,7 @@
     /// <summary>
     /// This type is used to find this assembly.
     /// </summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1040:Avoid empty interfaces", Justification = "This type is used to find this assembly.")]
     public interface IComponentGovernanceOwnedDetectors
     {
     }

--- a/src/Microsoft.ComponentDetection.Detectors/poetry/Contracts/PoetrySource.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/poetry/Contracts/PoetrySource.cs
@@ -14,6 +14,7 @@ namespace Microsoft.ComponentDetection.Detectors.Poetry.Contracts
         public string reference { get; set; }
 
         [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:ElementMustBeginWithUpperCaseLetter", Justification = "Deserialization contract. Casing cannot be overwritten.")]
+        [SuppressMessage("Naming", "CA1707:IdentifiersShouldNotContainUnderscores", Justification = "Deserialization contract. Casing cannot be overwritten.")]
         public string resolved_reference { get; set; }
     }
 }

--- a/src/Microsoft.ComponentDetection.Detectors/poetry/Contracts/PoetrySource.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/poetry/Contracts/PoetrySource.cs
@@ -1,20 +1,19 @@
-using System.Diagnostics.CodeAnalysis;
+using System.Runtime.Serialization;
 
 namespace Microsoft.ComponentDetection.Detectors.Poetry.Contracts
 {
     public class PoetrySource
     {
-        [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:ElementMustBeginWithUpperCaseLetter", Justification = "Deserialization contract. Casing cannot be overwritten.")]
-        public string type { get; set; }
+        [DataMember(Name = "type")]
+        public string Type { get; set; }
 
-        [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:ElementMustBeginWithUpperCaseLetter", Justification = "Deserialization contract. Casing cannot be overwritten.")]
-        public string url { get; set; }
+        [DataMember(Name = "url")]
+        public string Url { get; set; }
 
-        [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:ElementMustBeginWithUpperCaseLetter", Justification = "Deserialization contract. Casing cannot be overwritten.")]
-        public string reference { get; set; }
+        [DataMember(Name = "reference")]
+        public string Reference { get; set; }
 
-        [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:ElementMustBeginWithUpperCaseLetter", Justification = "Deserialization contract. Casing cannot be overwritten.")]
-        [SuppressMessage("Naming", "CA1707:IdentifiersShouldNotContainUnderscores", Justification = "Deserialization contract. Casing cannot be overwritten.")]
-        public string resolved_reference { get; set; }
+        [DataMember(Name = "resolved_reference")]
+        public string ResolvedReference { get; set; }
     }
 }

--- a/src/Microsoft.ComponentDetection.Detectors/poetry/PoetryComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/poetry/PoetryComponentDetector.cs
@@ -41,9 +41,9 @@ namespace Microsoft.ComponentDetection.Detectors.Poetry
             {
                 var isDevelopmentDependency = package.Category != "main";
 
-                if (package.Source != null && package.Source.type == "git")
+                if (package.Source != null && package.Source.Type == "git")
                 {
-                    var component = new DetectedComponent(new GitComponent(new Uri(package.Source.url), package.Source.resolved_reference));
+                    var component = new DetectedComponent(new GitComponent(new Uri(package.Source.Url), package.Source.ResolvedReference));
                     singleFileComponentRecorder.RegisterUsage(component, isDevelopmentDependency: isDevelopmentDependency);
                 }
                 else

--- a/src/Microsoft.ComponentDetection.Detectors/rust/Contracts/CargoPackage.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/rust/Contracts/CargoPackage.cs
@@ -1,47 +1,47 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
+using System.Runtime.Serialization;
 
 namespace Microsoft.ComponentDetection.Detectors.Rust.Contracts
 {
     public class CargoPackage
     {
-        [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:ElementMustBeginWithUpperCaseLetter", Justification = "Deserialization contract. Casing cannot be overwritten.")]
-        public string name { get; set; }
+        [DataMember(Name = "name")]
+        public string Name { get; set; }
 
-        [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:ElementMustBeginWithUpperCaseLetter", Justification = "Deserialization contract. Casing cannot be overwritten.")]
-        public string version { get; set; }
+        [DataMember(Name = "version")]
+        public string Version { get; set; }
 
-        [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:ElementMustBeginWithUpperCaseLetter", Justification = "Deserialization contract. Casing cannot be overwritten.")]
-        public string author { get; set; }
+        [DataMember(Name = "author")]
+        public string Author { get; set; }
 
-        [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:ElementMustBeginWithUpperCaseLetter", Justification = "Deserialization contract. Casing cannot be overwritten.")]
-        public string source { get; set; }
+        [DataMember(Name = "source")]
+        public string Source { get; set; }
 
-        [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:ElementMustBeginWithUpperCaseLetter", Justification = "Deserialization contract. Casing cannot be overwritten.")]
-        public string checksum { get; set; }
+        [DataMember(Name = "checksum")]
+        public string Checksum { get; set; }
 
-        [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:ElementMustBeginWithUpperCaseLetter", Justification = "Deserialization contract. Casing cannot be overwritten.")]
-        public string[] dependencies { get; set; }
+        [DataMember(Name = "dependencies")]
+        public string[] Dependencies { get; set; }
 
         // Get hash code and equals are IDE generated
         // Manually added some casing handling
         public override bool Equals(object obj)
         {
             return obj is CargoPackage package &&
-                   string.Equals(this.name, package.name) &&
-                   string.Equals(this.version, package.version, StringComparison.OrdinalIgnoreCase) &&
-                   string.Equals(this.source, package.source) &&
-                   string.Equals(this.checksum, package.checksum);
+                   string.Equals(this.Name, package.Name) &&
+                   string.Equals(this.Version, package.Version, StringComparison.OrdinalIgnoreCase) &&
+                   string.Equals(this.Source, package.Source) &&
+                   string.Equals(this.Checksum, package.Checksum);
         }
 
         public override int GetHashCode()
         {
             return HashCode.Combine(
-                EqualityComparer<string>.Default.GetHashCode(this.name),
-                EqualityComparer<string>.Default.GetHashCode(this.version.ToLowerInvariant()),
-                EqualityComparer<string>.Default.GetHashCode(this.source),
-                EqualityComparer<string>.Default.GetHashCode(this.checksum));
+                EqualityComparer<string>.Default.GetHashCode(this.Name),
+                EqualityComparer<string>.Default.GetHashCode(this.Version.ToLowerInvariant()),
+                EqualityComparer<string>.Default.GetHashCode(this.Source),
+                EqualityComparer<string>.Default.GetHashCode(this.Checksum));
         }
     }
 }

--- a/src/Microsoft.ComponentDetection.Detectors/rust/Contracts/CargoToml.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/rust/Contracts/CargoToml.cs
@@ -1,10 +1,10 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Runtime.Serialization;
 
 namespace Microsoft.ComponentDetection.Detectors.Rust.Contracts
 {
     public class CargoToml
     {
-        [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:ElementMustBeginWithUpperCaseLetter", Justification = "Deserialization contract. Casing cannot be overwritten.")]
-        public CargoPackage package { get; set; }
+        [DataMember(Name = "package")]
+        public CargoPackage Package { get; set; }
     }
 }

--- a/src/Microsoft.ComponentDetection.Detectors/rust/DependencySpecification.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/rust/DependencySpecification.cs
@@ -32,17 +32,17 @@ namespace Microsoft.ComponentDetection.Detectors.Rust
 
         public bool MatchesPackage(CargoPackage package)
         {
-            if (!this.dependencies.ContainsKey(package.name))
+            if (!this.dependencies.ContainsKey(package.Name))
             {
                 return false;
             }
 
-            foreach (var ranges in this.dependencies[package.name])
+            foreach (var ranges in this.dependencies[package.Name])
             {
                 var allSatisfied = true;
                 foreach (var range in ranges)
                 {
-                    if (SemVersion.TryParse(package.version, out var sv))
+                    if (SemVersion.TryParse(package.Version, out var sv))
                     {
                         if (!range.IsSatisfied(sv))
                         {
@@ -51,7 +51,7 @@ namespace Microsoft.ComponentDetection.Detectors.Rust
                     }
                     else
                     {
-                        throw new FormatException($"Could not parse {package.version} into a valid Semver");
+                        throw new FormatException($"Could not parse {package.Version} into a valid Semver");
                     }
                 }
 

--- a/src/Microsoft.ComponentDetection.Detectors/rust/RustCrateDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/rust/RustCrateDetector.cs
@@ -53,7 +53,7 @@ namespace Microsoft.ComponentDetection.Detectors.Rust
             return match.Success;
         }
 
-        private static bool IsLocalPackage(CargoPackage package) => package.source == null;
+        private static bool IsLocalPackage(CargoPackage package) => package.Source == null;
 
         protected override Task OnFileFound(ProcessRequest processRequest, IDictionary<string, string> detectorArgs)
         {
@@ -78,11 +78,11 @@ namespace Microsoft.ComponentDetection.Detectors.Rust
                     foreach (var cargoPackage in cargoLock.Package)
                     {
                         // Get or create the list of packages with this name
-                        if (!packagesByName.TryGetValue(cargoPackage.name, out var packageList))
+                        if (!packagesByName.TryGetValue(cargoPackage.Name, out var packageList))
                         {
                             // First package with this name
                             packageList = new List<(CargoPackage, CargoComponent)>();
-                            packagesByName.Add(cargoPackage.name, packageList);
+                            packagesByName.Add(cargoPackage.Name, packageList);
                         }
                         else if (packageList.Any(p => p.Package.Equals(cargoPackage)))
                         {
@@ -94,7 +94,7 @@ namespace Microsoft.ComponentDetection.Detectors.Rust
                         CargoComponent cargoComponent = null;
                         if (!IsLocalPackage(cargoPackage))
                         {
-                            cargoComponent = new CargoComponent(cargoPackage.name, cargoPackage.version);
+                            cargoComponent = new CargoComponent(cargoPackage.Name, cargoPackage.Version);
                             singleFileComponentRecorder.RegisterUsage(new DetectedComponent(cargoComponent));
                         }
 
@@ -108,14 +108,14 @@ namespace Microsoft.ComponentDetection.Detectors.Rust
                         // Get the parent package and component
                         foreach (var (parentPackage, parentComponent) in packageList)
                         {
-                            if (parentPackage.dependencies == null)
+                            if (parentPackage.Dependencies == null)
                             {
                                 // This package has no dependency edges to contribute.
                                 continue;
                             }
 
                             // Process each dependency
-                            foreach (var dependency in parentPackage.dependencies)
+                            foreach (var dependency in parentPackage.Dependencies)
                             {
                                 this.ProcessDependency(cargoLockFile, singleFileComponentRecorder, seenAsDependency, packagesByName, parentPackage, parentComponent, dependency);
                             }
@@ -174,13 +174,13 @@ namespace Microsoft.ComponentDetection.Detectors.Rust
                 CargoComponent childComponent = null;
                 foreach (var (candidatePackage, candidateComponent) in candidatePackages)
                 {
-                    if (childVersion != null && candidatePackage.version != childVersion)
+                    if (childVersion != null && candidatePackage.Version != childVersion)
                     {
                         // This does not have the requested version
                         continue;
                     }
 
-                    if (childSource != null && candidatePackage.source != childSource)
+                    if (childSource != null && candidatePackage.Source != childSource)
                     {
                         // This does not have the requested source
                         continue;
@@ -230,7 +230,7 @@ namespace Microsoft.ComponentDetection.Detectors.Rust
             {
                 using var record = new RustCrateDetectorTelemetryRecord();
 
-                record.PackageInfo = $"{parentPackage.name}, {parentPackage.version}, {parentPackage.source}";
+                record.PackageInfo = $"{parentPackage.Name}, {parentPackage.Version}, {parentPackage.Source}";
                 record.Dependencies = dependency;
 
                 this.Logger.LogFailedReadingFile(cargoLockFile.Location, e);

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/RustDependencySpecifierTest.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/RustDependencySpecifierTest.cs
@@ -49,7 +49,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
                     di.Add(specifierName, specifierRange);
                 }
 
-                di.MatchesPackage(new CargoPackage { name = "some-cargo-package", version = "1.2.3" })
+                di.MatchesPackage(new CargoPackage { Name = "some-cargo-package", Version = "1.2.3" })
                     .Should().Be(shouldMatch, caseName);
             }
         }


### PR DESCRIPTION
Related to #202  
fixed 
- CA1707: Identifiers should not contain underscores
- SA1300: Element Must Begin With Upper CaseLetter
- CA1040: Avoid empty interfaces
