### PR TITLE
chore: bump container image to .NET 6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-﻿FROM mcr.microsoft.com/dotnet/sdk:3.1-cbl-mariner1.0 AS build
+﻿FROM mcr.microsoft.com/dotnet/sdk:6.0-cbl-mariner2.0 AS build
 WORKDIR /app
 COPY . .
 RUN dotnet publish -c Release -o out \
@@ -8,18 +8,15 @@ RUN dotnet publish -c Release -o out \
     -p:PublishReadyToRun=false \
     -p:IncludeNativeLibrariesForSelfExtract=true \
     -p:PublishSingleFile=true \
-    -p:PublishTrimmed=true \
-    -p:TrimUnusedDependencies=true \
     ./src/Microsoft.ComponentDetection
 
-FROM mcr.microsoft.com/dotnet/runtime-deps:6.0-cbl-mariner1.0 AS runtime
+FROM mcr.microsoft.com/dotnet/runtime-deps:6.0-cbl-mariner2.0 AS runtime
 WORKDIR /app
 COPY --from=build /app/out ./
 
 RUN tdnf install -y \
     golang \
     moby-engine \
-    gradle \
     maven \
     pnpm \
     poetry \

--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/DetectorProcessingService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/DetectorProcessingService.cs
@@ -137,9 +137,8 @@ namespace Microsoft.ComponentDetection.Orchestrator.Services
 
             if (directoryExclusionListObsolete?.Any() == true)
             {
+                // Note: directory info will *automatically* parent relative paths to the working directory of the current assembly. Hold on to your rear.
                 var directories = directoryExclusionListObsolete
-
-                    // Note: directory info will *automatically* parent relative paths to the working directory of the current assembly. Hold on to your rear.
                     .Select(relativeOrAbsoluteExclusionPath => new DirectoryInfo(relativeOrAbsoluteExclusionPath))
                     .Select(exclusionDirectoryInfo => new
                     {


### PR DESCRIPTION
After #107 and #162 we've migrated the target framework, and related dependencies, to .NET 6. However, the container image at the root of the repository was missed.

This PR:
- changes the base images to their `6.0-cbl-mariner2.0` tags
- Removes `gradle` from the final image (It doesn't appear to be available for Mariner 2.0)
- Removes trimming (Component Detection is incompatible with trimming due to our use of reflection)
- Makes a small linting fix in `DetectorProcessingService.cs` (IDE0055)