### PR TITLE
Update CD logging to include override for line prefix

### DIFF
--- a/src/Microsoft.ComponentDetection.Common/Logger.cs
+++ b/src/Microsoft.ComponentDetection.Common/Logger.cs
@@ -25,10 +25,13 @@ namespace Microsoft.ComponentDetection.Common
 
         private bool WriteToFile { get; set; }
 
-        public void Init(VerbosityMode verbosity)
+        private bool WriteLinePrefix { get; set; }
+
+        public void Init(VerbosityMode verbosity, bool writeLinePrefix = true)
         {
             this.WriteToFile = true;
             this.Verbosity = verbosity;
+            this.WriteLinePrefix = writeLinePrefix;
             try
             {
                 this.FileWritingService.WriteFile(LogRelativePath, string.Empty);
@@ -144,7 +147,7 @@ namespace Microsoft.ComponentDetection.Common
 
         private void LogInternal(string prefix, string message, VerbosityMode verbosity = VerbosityMode.Normal)
         {
-            var formattedPrefix = string.IsNullOrWhiteSpace(prefix) ? string.Empty : $"[{prefix}] ";
+            var formattedPrefix = (!this.WriteLinePrefix || string.IsNullOrWhiteSpace(prefix)) ? string.Empty : $"[{prefix}] ";
             var text = $"{formattedPrefix}{message} {NewLine}";
 
             this.PrintToConsole(text, verbosity);

--- a/src/Microsoft.ComponentDetection.Orchestrator/Orchestrator.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Orchestrator.cs
@@ -152,7 +152,7 @@ namespace Microsoft.ComponentDetection.Orchestrator
 
                     telemetryRecord.Arguments = JsonConvert.SerializeObject(argumentSet);
                     FileWritingService.Init(argumentSet.Output);
-                    Logger.Init(argumentSet.Verbosity);
+                    Logger.Init(argumentSet.Verbosity, writeLinePrefix: true);
                     Logger.LogInfo($"Run correlation id: {TelemetryConstants.CorrelationId}");
 
                     return await this.Dispatch(argumentSet, cancellationToken);

--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/BcdeScanExecutionService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/BcdeScanExecutionService.cs
@@ -41,7 +41,6 @@ namespace Microsoft.ComponentDetection.Orchestrator.Services
             var detectors = this.DetectorRestrictionService.ApplyRestrictions(detectorRestrictions, initialDetectors).ToImmutableList();
 
             this.Logger.LogVerbose($"Finished applying restrictions to detectors.");
-            this.Logger.LogCreateLoggingGroup();
 
             var processingResult = await this.DetectorProcessingService.ProcessDetectorsAsync(detectionArguments, detectors, detectorRestrictions);
 

--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/DetectorRegistryService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/DetectorRegistryService.cs
@@ -56,7 +56,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Services
             var loadedDetectors = this.LoadComponentDetectorsFromAssemblies(new List<Assembly> { assemblyToSearch }, extraDetectorAssemblies);
 
             var pluralPhrase = loadedDetectors.Count == 1 ? "detector was" : "detectors were";
-            this.Logger.LogInfo($"{loadedDetectors.Count} {pluralPhrase} found in {assemblyToSearch.FullName}\n");
+            this.Logger.LogInfo($"{loadedDetectors.Count} {pluralPhrase} found in {assemblyToSearch.FullName}");
 
             return loadedDetectors;
         }


### PR DESCRIPTION
Add a line prefix override for the Logger class to skip printing [INFO], [VERBOSE], etc. and update log grouping slightly.