### PR TITLE
Enabling the NuGetPackagesConfigDetector to run by default.

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/nuget/NuGetPackagesConfigDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/nuget/NuGetPackagesConfigDetector.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.ComponentDetection.Detectors.NuGet
+namespace Microsoft.ComponentDetection.Detectors.NuGet
 {
     using System;
     using System.Collections.Generic;
@@ -10,7 +10,7 @@
     using Microsoft.ComponentDetection.Contracts.TypedComponent;
 
     [Export(typeof(IComponentDetector))]
-    public class NuGetPackagesConfigDetector : FileComponentDetector, IExperimentalDetector
+    public class NuGetPackagesConfigDetector : FileComponentDetector
     {
         public override IList<string> SearchPatterns => new[] { "packages.config" };
 


### PR DESCRIPTION
The NuGetPackagesConfigDetector is no longer an expiremental detector. After going through validation, we are turning this detector on by default. 