### PR TITLE
Add explicit reference to System.Threading.Tasks.Dataflow

### DIFF
--- a/src/Microsoft.ComponentDetection.Common/Microsoft.ComponentDetection.Common.csproj
+++ b/src/Microsoft.ComponentDetection.Common/Microsoft.ComponentDetection.Common.csproj
@@ -11,6 +11,7 @@
         <PackageReference Include="System.Composition.Runtime" />
         <PackageReference Include="System.Composition.TypedParts" />
         <PackageReference Include="System.Reactive" />
+        <PackageReference Include="System.Threading.Tasks.Dataflow" />
     </ItemGroup>
 
     <ItemGroup Label="Package References">

--- a/src/Microsoft.ComponentDetection/Microsoft.ComponentDetection.csproj
+++ b/src/Microsoft.ComponentDetection/Microsoft.ComponentDetection.csproj
@@ -6,6 +6,10 @@
         <RootProjectDirectory>$(MSBuildThisFileDirectory)..\..\</RootProjectDirectory>
     </PropertyGroup>
 
+    <ItemGroup>
+      <PackageReference Include="System.Threading.Tasks.Dataflow" />
+    </ItemGroup>
+
     <ItemGroup Label="Package References">
         <ProjectReference Include="..\Microsoft.ComponentDetection.Common\Microsoft.ComponentDetection.Common.csproj" />
         <ProjectReference Include="..\Microsoft.ComponentDetection.Contracts\Microsoft.ComponentDetection.Contracts.csproj" />

--- a/test/Microsoft.ComponentDetection.Common.Tests/Microsoft.ComponentDetection.Common.Tests.csproj
+++ b/test/Microsoft.ComponentDetection.Common.Tests/Microsoft.ComponentDetection.Common.Tests.csproj
@@ -6,6 +6,7 @@
 
     <ItemGroup Label="Package References">
       <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+      <PackageReference Include="System.Threading.Tasks.Dataflow" />
     </ItemGroup>
 
 </Project>

--- a/test/Microsoft.ComponentDetection.Contracts.Tests/Microsoft.ComponentDetection.Contracts.Tests.csproj
+++ b/test/Microsoft.ComponentDetection.Contracts.Tests/Microsoft.ComponentDetection.Contracts.Tests.csproj
@@ -7,6 +7,7 @@
     <ItemGroup Label="Package References">
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="System.Reactive"/>
+        <PackageReference Include="System.Threading.Tasks.Dataflow" />
         <PackageReference Include="packageurl-dotnet"/>
     </ItemGroup>
 

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/Microsoft.ComponentDetection.Detectors.Tests.csproj
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/Microsoft.ComponentDetection.Detectors.Tests.csproj
@@ -8,6 +8,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="NuGet.Versioning" />
         <PackageReference Include="System.Reactive" />
+        <PackageReference Include="System.Threading.Tasks.Dataflow" />
         <PackageReference Include="packageurl-dotnet" />
     </ItemGroup>
 

--- a/test/Microsoft.ComponentDetection.Orchestrator.Tests/Microsoft.ComponentDetection.Orchestrator.Tests.csproj
+++ b/test/Microsoft.ComponentDetection.Orchestrator.Tests/Microsoft.ComponentDetection.Orchestrator.Tests.csproj
@@ -7,6 +7,7 @@
 
     <ItemGroup Label="Package References">
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+        <PackageReference Include="System.Threading.Tasks.Dataflow" />
     </ItemGroup>
 
 </Project>

--- a/test/Microsoft.ComponentDetection.TestsUtilities/Microsoft.ComponentDetection.TestsUtilities.csproj
+++ b/test/Microsoft.ComponentDetection.TestsUtilities/Microsoft.ComponentDetection.TestsUtilities.csproj
@@ -7,6 +7,7 @@
     <ItemGroup Label="Project References">
         <ProjectReference Include="..\..\src\Microsoft.ComponentDetection.Detectors\Microsoft.ComponentDetection.Detectors.csproj"/>
         <PackageReference Include="System.Reactive"/>
+        <PackageReference Include="System.Threading.Tasks.Dataflow" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Add explicit reference to System.Threading.Tasks.Dataflow to avoid version resolution conflicts.