### PR TITLE
fix(nuget): allow duplicate packages in `pacakge.config`

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/nuget/NuGetPackagesConfigDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/nuget/NuGetPackagesConfigDetector.cs
@@ -26,7 +26,7 @@ namespace Microsoft.ComponentDetection.Detectors.NuGet
         protected override Task OnFileFound(ProcessRequest processRequest, IDictionary<string, string> detectorArgs)
         {
             var packagesConfig = new PackagesConfigReader(processRequest.ComponentStream.Stream);
-            foreach (var package in packagesConfig.GetPackages())
+            foreach (var package in packagesConfig.GetPackages(allowDuplicatePackageIds: true))
             {
                 processRequest.SingleFileComponentRecorder.RegisterUsage(
                     new DetectedComponent(


### PR DESCRIPTION
Without this we'll throw a `PackagesConfigReaderException`, and while duplicate packages in `packages.config` is not ideal, it is a supported scenario.