### PR TITLE
Adding TargetFrameworks to the list of data retreived from NuGet packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,6 +26,7 @@
         <PackageVersion Include="Newtonsoft.Json" Version="13.0.1"/>
         <PackageVersion Include="NuGet.ProjectModel" Version="5.11.3"/>
         <PackageVersion Include="NuGet.Versioning" Version="5.11.3"/>
+        <PackageVersion Include="NuGet.Packaging" Version="5.6.0"/>
         <PackageVersion Include="packageurl-dotnet" Version="1.0.0"/>
         <PackageVersion Include="Polly" Version="7.2.3"/>
         <PackageVersion Include="Semver" Version="2.2.0"/>

--- a/src/Microsoft.ComponentDetection.Contracts/TypedComponent/NugetComponent.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/TypedComponent/NugetComponent.cs
@@ -1,4 +1,4 @@
-using PackageUrl;
+﻿using PackageUrl;
 
 namespace Microsoft.ComponentDetection.Contracts.TypedComponent
 {
@@ -9,11 +9,12 @@ namespace Microsoft.ComponentDetection.Contracts.TypedComponent
             /* Reserved for deserialization */
         }
 
-        public NuGetComponent(string name, string version, string[] authors = null)
+        public NuGetComponent(string name, string version, string[] authors = null, string[] targetFrameworks = null)
         {
             this.Name = this.ValidateRequiredInput(name, nameof(this.Name), nameof(ComponentType.NuGet));
             this.Version = this.ValidateRequiredInput(version, nameof(this.Version), nameof(ComponentType.NuGet));
             this.Authors = authors;
+            this.TargetFrameworks = targetFrameworks;
         }
 
         public string Name { get; set; }
@@ -21,6 +22,8 @@ namespace Microsoft.ComponentDetection.Contracts.TypedComponent
         public string Version { get; set; }
 
         public string[] Authors { get; set; }
+
+        public string[] TargetFrameworks { get; set; }
 
         public override ComponentType Type => ComponentType.NuGet;
 

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/NuGetComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/NuGetComponentDetectorTests.cs
@@ -47,7 +47,9 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
             var testComponentName = "TestComponentName";
             var testVersion = "1.2.3";
             var testAuthors = new string[] { "author 1", "author 2" };
-            var nuspec = NugetTestUtilities.GetValidNuspec(testComponentName, testVersion, testAuthors);
+            var testTargetFrameworks = new string[] { "net48", "net472", "netstandard2.1" };
+            var testTargetFrameworksConverted = new string[] { ".NETFramework,Version=v4.8", ".NETFramework,Version=v4.7.2", ".NETStandard,Version=v2.1" };
+            var nuspec = NugetTestUtilities.GetValidNuspec(testComponentName, testVersion, testAuthors, testTargetFrameworks);
 
             var (scanResult, componentRecorder) = await this.detectorTestUtility
                                                     .WithFile("*.nuspec", nuspec)
@@ -61,6 +63,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
             Assert.AreEqual(testComponentName, nuGetComponent.Name, "Component name does not match.");
             Assert.AreEqual(testVersion, nuGetComponent.Version, "Component version does not match.");
             CollectionAssert.AreEqual(testAuthors, nuGetComponent.Authors, "Authors does not match.");
+            CollectionAssert.AreEqual(testTargetFrameworksConverted, nuGetComponent.TargetFrameworks, "TargetFrameworks does not match.");
         }
 
         [TestMethod]

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/NuGetNuspecUtilitiesTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/NuGetNuspecUtilitiesTests.cs
@@ -2,8 +2,10 @@
 using System.IO;
 using System.IO.Compression;
 using System.Threading.Tasks;
+using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Detectors.NuGet;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
 
 namespace Microsoft.ComponentDetection.Detectors.Tests
 {
@@ -13,20 +15,20 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
     public class NuGetNuspecUtilitiesTests
     {
         [TestMethod]
-        public async Task GetNuspecBytes_FailsOnEmptyStream()
+        public void GetNuspecBytes_FailsOnEmptyStream()
         {
             using var stream = new MemoryStream();
 
-            async Task ShouldThrow() => await NuGetNuspecUtilities.GetNuspecBytesAsync(stream);
+            void ShouldThrow() => NuGetNuspecUtilities.GetNuspecDataFromNuspecStream(stream);
 
-            await Assert.ThrowsExceptionAsync<ArgumentException>(ShouldThrow);
+            Assert.ThrowsException<ArgumentException>(ShouldThrow);
 
             // The position should always be reset to 0
             Assert.AreEqual(0, stream.Position);
         }
 
         [TestMethod]
-        public async Task GetNuspecBytes_FailsOnTooSmallStream()
+        public void GetNuspecBytes_FailsOnTooSmallStream()
         {
             using var stream = new MemoryStream();
 
@@ -37,16 +39,21 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
 
             stream.Seek(0, SeekOrigin.Begin);
 
-            async Task ShouldThrow() => await NuGetNuspecUtilities.GetNuspecBytesAsync(stream);
+            var getFileMock = new Mock<IComponentStream>();
+            getFileMock.SetupGet(x => x.Stream).Returns(stream);
+            getFileMock.SetupGet(x => x.Pattern).Returns(default(string));
+            getFileMock.SetupGet(x => x.Location).Returns("test.nupkg");
 
-            await Assert.ThrowsExceptionAsync<ArgumentException>(ShouldThrow);
+            void ShouldThrow() => NuGetNuspecUtilities.GetNuGetPackageDataFromNupkg(getFileMock.Object);
+
+            Assert.ThrowsException<ArgumentException>(ShouldThrow);
 
             // The position should always be reset to 0
             Assert.AreEqual(0, stream.Position);
         }
 
         [TestMethod]
-        public async Task GetNuspecBytes_FailsIfNuspecNotPresent()
+        public void GetNuspecBytes_FailsIfNuspecNotPresent()
         {
             using var stream = new MemoryStream();
 
@@ -57,10 +64,15 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
 
             stream.Seek(0, SeekOrigin.Begin);
 
-            async Task ShouldThrow() => await NuGetNuspecUtilities.GetNuspecBytesAsync(stream);
+            var getFileMock = new Mock<IComponentStream>();
+            getFileMock.SetupGet(x => x.Stream).Returns(stream);
+            getFileMock.SetupGet(x => x.Pattern).Returns(default(string));
+            getFileMock.SetupGet(x => x.Location).Returns("test.nupkg");
+
+            void ShouldThrow() => NuGetNuspecUtilities.GetNuGetPackageDataFromNupkg(getFileMock.Object);
 
             // No Nuspec File is in the archive
-            await Assert.ThrowsExceptionAsync<FileNotFoundException>(ShouldThrow);
+            Assert.ThrowsException<FileNotFoundException>(ShouldThrow);
 
             // The position should always be reset to 0
             Assert.AreEqual(0, stream.Position);
@@ -69,7 +81,8 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
         [TestMethod]
         public async Task GetNuspecBytes_ReadsNuspecBytes()
         {
-            byte[] randomBytes = { 0xDE, 0xAD, 0xC0, 0xDE };
+            var nuspecContent = NugetTestUtilities.GetValidNuspec("Test", "1.2.3", new[] { "Test1", "Test2" });
+            var bytes = System.Text.Encoding.UTF8.GetBytes(nuspecContent);
 
             using var stream = new MemoryStream();
 
@@ -77,21 +90,37 @@ namespace Microsoft.ComponentDetection.Detectors.Tests
             {
                 var entry = archive.CreateEntry("test.nuspec");
 
-                using var entryStream = entry.Open();
+                using (var entryStream = entry.Open())
+                {
+                    await entryStream.WriteAsync(bytes, 0, bytes.Length);
+                }
 
-                await entryStream.WriteAsync(randomBytes, 0, randomBytes.Length);
+                var libEntry = archive.CreateEntry(@"lib\net48\test.dll");
             }
 
             stream.Seek(0, SeekOrigin.Begin);
 
-            var bytes = await NuGetNuspecUtilities.GetNuspecBytesAsync(stream);
+            var getFileMock = new Mock<IComponentStream>();
+            getFileMock.SetupGet(x => x.Stream).Returns(stream);
+            getFileMock.SetupGet(x => x.Pattern).Returns(default(string));
+            getFileMock.SetupGet(x => x.Location).Returns("test.nupkg");
 
-            Assert.AreEqual(randomBytes.Length, bytes.Length);
+            var packageData = NuGetNuspecUtilities.GetNuGetPackageDataFromNupkg(getFileMock.Object);
 
-            for (var i = 0; i < randomBytes.Length; i++)
+            Assert.AreEqual("Test", packageData.Name);
+            Assert.AreEqual("1.2.3", packageData.Version);
+            Assert.AreEqual(2, packageData.Authors.Length);
+            Assert.AreEqual("Test1", packageData.Authors[0]);
+            Assert.AreEqual("Test2", packageData.Authors[1]);
+            var set = false;
+            foreach (var framework in packageData.TargetFrameworks)
             {
-                Assert.AreEqual(randomBytes[i], bytes[i]);
+                Assert.IsFalse(set, "We got more target frameworks than anticipated");
+                Assert.AreEqual(".NETFramework,Version=v4.8", framework);
+                set = true;
             }
+
+            Assert.IsTrue(set, "We didn't get the target framework");
 
             // The position should always be reset to 0
             Assert.AreEqual(0, stream.Position);


### PR DESCRIPTION
Successor to #79 

Original PR description:
> Per a conversation about adding target framework information to the component detection data, this is a PR that shows what that could look like.
>
>Things get slightly tricky here since packages declare target frameworks through the dependency declarations in the nuspec, as well as the folder structure of the package. This hasn't been through much testing beyond the unit tests, but they've been augmented to test some potential patterns.
>
>I mainly want to get some feedback on this before I spend much more time on testing. I can potentially test this against all NuGet.org packages pretty easily, which also gives us a test oracle since they calculate target frameworks as well.
>
>Things that might need consideration:
>* Addition of NuGet.Packaging as a dependency
>* how the data is plumbed through the NuGetComponent (I followed the Authors example as an array of >additional strings)
>* Removal of async from ProcessFile (nothing in there was async when I finished)
>* Shifting more responsibility to NuGetNuspecUtilities even through it's not strictly nuspec-related >anymore.
>* Using the nuspec reader rather than bespoke XML parsing
>
>I'm open to any and all feedback here.