### PR TITLE
refactor: add `Microsoft.Extensions.DependencyInjection` dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,9 @@
         <PackageVersion Include="Docker.DotNet" Version="3.125.12"/>
         <PackageVersion Include="FluentAssertions" Version="6.8.0"/>
         <PackageVersion Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9"/>
-        <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0"/>
+        <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0"/>
+        <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0"/>
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.4.0"/>
         <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1"/>
         <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.4.27"/>

--- a/src/Microsoft.ComponentDetection.Orchestrator/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,13 @@
+﻿namespace Microsoft.ComponentDetection.Orchestrator.Extensions;
+
+using Microsoft.Extensions.DependencyInjection;
+
+internal static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Register Component Detection services.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection" /> to register the services with.</param>
+    /// <returns>The <see cref="IServiceCollection" /> so that additional calls can be chained.</returns>
+    public static IServiceCollection AddComponentDetection(this IServiceCollection services) => services;
+}

--- a/src/Microsoft.ComponentDetection.Orchestrator/Microsoft.ComponentDetection.Orchestrator.csproj
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Microsoft.ComponentDetection.Orchestrator.csproj
@@ -3,6 +3,7 @@
     <ItemGroup>
         <PackageReference Include="CommandLineParser" />
         <PackageReference Include="DotNet.Glob" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
         <PackageReference Include="Newtonsoft.Json" />
         <PackageReference Include="Polly" />
         <PackageReference Include="System.Runtime.Loader" />

--- a/src/Microsoft.ComponentDetection/Microsoft.ComponentDetection.csproj
+++ b/src/Microsoft.ComponentDetection/Microsoft.ComponentDetection.csproj
@@ -7,6 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
       <PackageReference Include="System.Threading.Tasks.Dataflow" />
     </ItemGroup>
 


### PR DESCRIPTION
The first step in moving away from [Managed Extensibility Framework (MEF)][1] to the more modern Dependency Injection framework

[1]: https://learn.microsoft.com/en-us/dotnet/framework/mef/