### PR TITLE
Resolve Python2 setup.py incorrect None package detection

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/pip/PythonCommandService.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/PythonCommandService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Composition;
 using System.IO;
@@ -65,6 +65,12 @@ public class PythonCommandService : IPythonCommandService
         var result = command.StdOut;
 
         result = result.Trim('[', ']', '\r', '\n').Trim();
+
+        // For Python2 if there are no packages (Result: "None") skip any parsing
+        if (result.Equals("None", StringComparison.OrdinalIgnoreCase) && !command.StdOut.StartsWith('['))
+        {
+            return new List<string>();
+        }
 
         return result.Split(new string[] { "'," }, StringSplitOptions.RemoveEmptyEntries).Select(x => x.Trim().Trim('\'').Trim()).ToList();
     }
@@ -140,6 +146,6 @@ public class PythonCommandService : IPythonCommandService
 
     private async Task<bool> CanCommandBeLocated(string pythonPath)
     {
-        return await this.CommandLineInvocationService.CanCommandBeLocated(pythonPath, new List<string> { "python3", "python2" }, "--version");
+        return await this.CommandLineInvocationService.CanCommandBeLocated(pythonPath, new List<string> { "python3", "python" }, "--version");
     }
 }

--- a/src/Microsoft.ComponentDetection.Detectors/pip/PythonCommandService.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/PythonCommandService.cs
@@ -146,6 +146,6 @@ public class PythonCommandService : IPythonCommandService
 
     private async Task<bool> CanCommandBeLocated(string pythonPath)
     {
-        return await this.CommandLineInvocationService.CanCommandBeLocated(pythonPath, new List<string> { "python3", "python" }, "--version");
+        return await this.CommandLineInvocationService.CanCommandBeLocated(pythonPath, new List<string> { "python3", "python2" }, "--version");
     }
 }

--- a/src/Microsoft.ComponentDetection.Orchestrator/Orchestrator.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Orchestrator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Composition;
 using System.Composition.Hosting;

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/PythonCommandServiceTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/PythonCommandServiceTests.cs
@@ -113,6 +113,41 @@ other=2.1";
     }
 
     [TestMethod]
+    public async Task PythonCommandService_ParsesEmptySetupPyOutputCorrectly_Python27()
+    {
+        var fakePath = @"c:\the\fake\path.py";
+        var fakePathAsPassedToPython = fakePath.Replace("\\", "/");
+
+        this.commandLineInvokationService.Setup(x => x.CanCommandBeLocated("python", It.IsAny<IEnumerable<string>>(), "--version")).ReturnsAsync(true);
+        this.commandLineInvokationService.Setup(x => x.ExecuteCommand("python", It.IsAny<IEnumerable<string>>(), It.Is<string>(c => c.Contains(fakePathAsPassedToPython))))
+            .ReturnsAsync(new CommandLineExecutionResult { ExitCode = 0, StdOut = "None", StdErr = string.Empty });
+
+        var service = new PythonCommandService { CommandLineInvocationService = this.commandLineInvokationService.Object };
+
+        var result = await service.ParseFile(fakePath);
+
+        Assert.AreEqual(0, result.Count);
+    }
+
+    [TestMethod]
+    public async Task PythonCommandService_ParsesSetupPyOutputCorrectly_Python27NonePkg()
+    {
+        var fakePath = @"c:\the\fake\path.py";
+        var fakePathAsPassedToPython = fakePath.Replace("\\", "/");
+
+        this.commandLineInvokationService.Setup(x => x.CanCommandBeLocated("python", It.IsAny<IEnumerable<string>>(), "--version")).ReturnsAsync(true);
+        this.commandLineInvokationService.Setup(x => x.ExecuteCommand("python", It.IsAny<IEnumerable<string>>(), It.Is<string>(c => c.Contains(fakePathAsPassedToPython))))
+            .ReturnsAsync(new CommandLineExecutionResult { ExitCode = 0, StdOut = "['None']", StdErr = string.Empty });
+
+        var service = new PythonCommandService { CommandLineInvocationService = this.commandLineInvokationService.Object };
+
+        var result = await service.ParseFile(fakePath);
+
+        Assert.AreEqual(1, result.Count);
+        Assert.AreEqual("None", result.First().PackageString);
+    }
+
+    [TestMethod]
     public async Task PythonCommandService_ParsesRegularSetupPyOutputCorrectly()
     {
         var fakePath = @"c:\the\fake\path.py";


### PR DESCRIPTION
Fixes #313 by checking the Setup.py command output against the empty result set of None after trimming. If the output is only None and not the package None, skip any parsing attempts for the file.