### PR TITLE
fix: remove `AdditionalDITargets` argument

### DIFF
--- a/src/Microsoft.ComponentDetection.Orchestrator/ArgumentSets/BaseArguments.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/ArgumentSets/BaseArguments.cs
@@ -35,7 +35,4 @@ public class BaseArguments : IScanArguments
 
     [Option("Output", Required = false, HelpText = "Output path for log files. Defaults to %TMP%")]
     public string Output { get; set; }
-
-    [Option("AdditionalDITargets", Required = false, Separator = ',', HelpText = "Comma separated list of paths to additional dependency injection targets.")]
-    public IEnumerable<string> AdditionalDITargets { get; set; }
 }

--- a/src/Microsoft.ComponentDetection.Orchestrator/ArgumentSets/IScanArguments.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/ArgumentSets/IScanArguments.cs
@@ -8,8 +8,6 @@ public interface IScanArguments
 {
     IEnumerable<DirectoryInfo> AdditionalPluginDirectories { get; set; }
 
-    IEnumerable<string> AdditionalDITargets { get; set; }
-
     bool SkipPluginsDirectory { get; set; }
 
     Guid CorrelationId { get; set; }


### PR DESCRIPTION
This is no longer necessary after removing MEF