### PR TITLE
refactor: remove unnecessary arguments

### DIFF
--- a/src/Microsoft.ComponentDetection.Orchestrator/ArgumentSets/BaseArguments.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/ArgumentSets/BaseArguments.cs
@@ -1,11 +1,7 @@
 ﻿namespace Microsoft.ComponentDetection.Orchestrator.ArgumentSets;
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using CommandLine;
 using Microsoft.ComponentDetection.Contracts;
-using Newtonsoft.Json;
 
 public class BaseArguments : IScanArguments
 {
@@ -14,15 +10,6 @@ public class BaseArguments : IScanArguments
 
     [Option("DebugTelemetry", Required = false, HelpText = "Used to output all telemetry events to the console.")]
     public bool DebugTelemetry { get; set; }
-
-    [JsonIgnore]
-    [Option("AdditionalPluginDirectories", Separator = ';', Required = false, Hidden = true, HelpText = "Semi-colon delimited list of directories to search for plugins")]
-    public IEnumerable<DirectoryInfo> AdditionalPluginDirectories { get; set; }
-
-    public IEnumerable<string> AdditionalPluginDirectoriesSerialized => this.AdditionalPluginDirectories?.Select(x => x.ToString()) ?? new List<string>();
-
-    [Option("SkipPluginsDirectory", Required = false, Default = false, HelpText = "Skip searching of /Plugins directory for additional component detectors.")]
-    public bool SkipPluginsDirectory { get; set; }
 
     [Option("CorrelationId", Required = false, HelpText = "Identifier used to correlate all telemetry for a given execution. If not provided, a new GUID will be generated.")]
     public Guid CorrelationId { get; set; }

--- a/src/Microsoft.ComponentDetection.Orchestrator/ArgumentSets/IScanArguments.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/ArgumentSets/IScanArguments.cs
@@ -1,15 +1,9 @@
 ﻿namespace Microsoft.ComponentDetection.Orchestrator.ArgumentSets;
 using System;
-using System.Collections.Generic;
-using System.IO;
 using Microsoft.ComponentDetection.Contracts;
 
 public interface IScanArguments
 {
-    IEnumerable<DirectoryInfo> AdditionalPluginDirectories { get; set; }
-
-    bool SkipPluginsDirectory { get; set; }
-
     Guid CorrelationId { get; set; }
 
     VerbosityMode Verbosity { get; set; }

--- a/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/BcdeScanExecutionServiceTests.cs
+++ b/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/BcdeScanExecutionServiceTests.cs
@@ -110,7 +110,6 @@ public class BcdeScanExecutionServiceTests
 
         var args = new BcdeArguments
         {
-            AdditionalPluginDirectories = Enumerable.Empty<DirectoryInfo>(),
             SourceDirectory = this.sourceDirectory,
         };
         var result = await this.DetectComponentsHappyPathAsync(
@@ -149,7 +148,6 @@ public class BcdeScanExecutionServiceTests
         {
             DetectorCategories = new[] { "Category1", "Category2" },
             DetectorsFilter = new[] { "Detector1", "Detector2" },
-            AdditionalPluginDirectories = Enumerable.Empty<DirectoryInfo>(),
             SourceDirectory = this.sourceDirectory,
         };
 
@@ -176,7 +174,6 @@ public class BcdeScanExecutionServiceTests
     {
         var args = new BcdeArguments
         {
-            AdditionalPluginDirectories = Enumerable.Empty<DirectoryInfo>(),
             SourceDirectory = this.sourceDirectory,
         };
 
@@ -204,7 +201,6 @@ public class BcdeScanExecutionServiceTests
 
         var args = new BcdeArguments
         {
-            AdditionalPluginDirectories = Enumerable.Empty<DirectoryInfo>(),
             SourceDirectory = this.sourceDirectory,
         };
 
@@ -227,7 +223,6 @@ public class BcdeScanExecutionServiceTests
 
         var args = new BcdeArguments
         {
-            AdditionalPluginDirectories = Enumerable.Empty<DirectoryInfo>(),
             SourceDirectory = this.sourceDirectory,
         };
 
@@ -285,7 +280,6 @@ public class BcdeScanExecutionServiceTests
 
         var args = new BcdeArguments
         {
-            AdditionalPluginDirectories = Enumerable.Empty<DirectoryInfo>(),
             SourceDirectory = this.sourceDirectory,
         };
 
@@ -356,7 +350,6 @@ public class BcdeScanExecutionServiceTests
         var npmDetector = new Mock<IComponentDetector>();
         var args = new BcdeArguments
         {
-            AdditionalPluginDirectories = Enumerable.Empty<DirectoryInfo>(),
             SourceDirectory = this.sourceDirectory,
         };
 
@@ -390,7 +383,6 @@ public class BcdeScanExecutionServiceTests
         var npmDetector = new Mock<IComponentDetector>();
         var args = new BcdeArguments
         {
-            AdditionalPluginDirectories = Enumerable.Empty<DirectoryInfo>(),
             SourceDirectory = this.sourceDirectory,
         };
 
@@ -426,7 +418,6 @@ public class BcdeScanExecutionServiceTests
         var npmDetector = new Mock<IComponentDetector>();
         var args = new BcdeArguments
         {
-            AdditionalPluginDirectories = Enumerable.Empty<DirectoryInfo>(),
             SourceDirectory = this.sourceDirectory,
         };
 
@@ -457,7 +448,6 @@ public class BcdeScanExecutionServiceTests
         var npmDetector = new Mock<IComponentDetector>();
         var args = new BcdeArguments
         {
-            AdditionalPluginDirectories = Enumerable.Empty<DirectoryInfo>(),
             SourceDirectory = this.sourceDirectory,
         };
 
@@ -509,7 +499,6 @@ public class BcdeScanExecutionServiceTests
         var npmDetector = new Mock<IComponentDetector>();
         var args = new BcdeArguments
         {
-            AdditionalPluginDirectories = Enumerable.Empty<DirectoryInfo>(),
             SourceDirectory = this.sourceDirectory,
         };
 
@@ -550,7 +539,6 @@ public class BcdeScanExecutionServiceTests
         var npmDetector = new Mock<IComponentDetector>();
         var args = new BcdeArguments
         {
-            AdditionalPluginDirectories = Enumerable.Empty<DirectoryInfo>(),
             SourceDirectory = this.sourceDirectory,
         };
 
@@ -588,7 +576,6 @@ public class BcdeScanExecutionServiceTests
         var npmDetector = new Mock<IComponentDetector>();
         var args = new BcdeArguments
         {
-            AdditionalPluginDirectories = Enumerable.Empty<DirectoryInfo>(),
             SourceDirectory = this.sourceDirectory,
         };
 


### PR DESCRIPTION
`AdditionalPluginDirectories` and `SkipPluginsDirectory` are unnecessary after the migration to dependency injection.