### PR TITLE
perf: add buffering to `FileWritingService`

### DIFF
--- a/src/Microsoft.ComponentDetection.Common/FileWritingService.cs
+++ b/src/Microsoft.ComponentDetection.Common/FileWritingService.cs
@@ -2,6 +2,7 @@ namespace Microsoft.ComponentDetection.Common;
 using System;
 using System.Collections.Concurrent;
 using System.IO;
+using System.Threading.Tasks;
 using Microsoft.ComponentDetection.Common.Exceptions;
 
 public sealed class FileWritingService : IFileWritingService
@@ -90,5 +91,14 @@ public sealed class FileWritingService : IFileWritingService
     {
         this.Dispose(true);
         GC.SuppressFinalize(this);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        foreach (var (filename, streamWriter) in this.bufferedStreams)
+        {
+            await streamWriter.DisposeAsync();
+            this.bufferedStreams.TryRemove(filename, out _);
+        }
     }
 }

--- a/src/Microsoft.ComponentDetection.Common/IFileWritingService.cs
+++ b/src/Microsoft.ComponentDetection.Common/IFileWritingService.cs
@@ -1,8 +1,10 @@
 ﻿namespace Microsoft.ComponentDetection.Common;
+
+using System;
 using System.IO;
 
 // All file paths are relative and will replace occurrences of {timestamp} with the shared file timestamp.
-public interface IFileWritingService
+public interface IFileWritingService : IDisposable
 {
     void Init(string basePath);
 

--- a/src/Microsoft.ComponentDetection.Common/IFileWritingService.cs
+++ b/src/Microsoft.ComponentDetection.Common/IFileWritingService.cs
@@ -4,7 +4,7 @@ using System;
 using System.IO;
 
 // All file paths are relative and will replace occurrences of {timestamp} with the shared file timestamp.
-public interface IFileWritingService : IDisposable
+public interface IFileWritingService : IDisposable, IAsyncDisposable
 {
     void Init(string basePath);
 

--- a/src/Microsoft.ComponentDetection/Program.cs
+++ b/src/Microsoft.ComponentDetection/Program.cs
@@ -32,6 +32,9 @@ try
 
     Console.WriteLine($"Execution finished, status: {exitCode}.");
 
+    // Manually dispose to flush logs as we force exit
+    await serviceProvider.DisposeAsync();
+
     // force an exit, not letting any lingering threads not responding.
     Environment.Exit(exitCode);
 }

--- a/test/Microsoft.ComponentDetection.Common.Tests/FileWritingServiceTests.cs
+++ b/test/Microsoft.ComponentDetection.Common.Tests/FileWritingServiceTests.cs
@@ -41,6 +41,7 @@ public class FileWritingServiceTests
         var fileLocation = Path.Combine(this.tempFolder, relativeDir);
         File.Create(fileLocation).Dispose();
         this.serviceUnderTest.AppendToFile(relativeDir, "someSampleText");
+        this.serviceUnderTest.Dispose();
         var text = File.ReadAllText(Path.Combine(this.tempFolder, relativeDir));
         text
             .Should().Be("someSampleText");
@@ -62,6 +63,7 @@ public class FileWritingServiceTests
         var relativeDir = "somefile_{timestamp}.txt";
         this.serviceUnderTest.WriteFile(relativeDir, "sampleText");
         this.serviceUnderTest.AppendToFile(relativeDir, "sampleText2");
+        this.serviceUnderTest.Dispose();
         var files = Directory.GetFiles(this.tempFolder);
         files
             .Should().NotBeEmpty();


### PR DESCRIPTION
This adds buffering to the `FileWritingService`. Previously, every log message synchronously called `File.AppendAllText`.

This should help increase performance for #373 and across the board.

Profiling Component Detection lead to serious performance gains:

Before:
![image](https://user-images.githubusercontent.com/26028834/219509928-667e42f0-b98b-419c-aac1-7ded444a73c3.png)

After:
![image](https://user-images.githubusercontent.com/26028834/219509949-b438f84b-e514-41d8-abf1-816385ea148a.png)
