### PR TITLE
Don't allow re-init of Logger class

### DIFF
--- a/src/Microsoft.ComponentDetection.Common/Logger.cs
+++ b/src/Microsoft.ComponentDetection.Common/Logger.cs
@@ -21,6 +21,8 @@ public class Logger : ILogger
 
     private VerbosityMode Verbosity { get; set; }
 
+    private bool Initialized { get; set; }
+
     private bool WriteToFile { get; set; }
 
     private bool WriteLinePrefix { get; set; }
@@ -30,10 +32,19 @@ public class Logger : ILogger
         this.WriteToFile = true;
         this.Verbosity = verbosity;
         this.WriteLinePrefix = writeLinePrefix;
+
+        // If initialization has already completed, don't attempt to create
+        // the log file again as this throws an exception
+        if (this.Initialized)
+        {
+            return;
+        }
+
         try
         {
             this.fileWritingService.WriteFile(LogRelativePath, string.Empty);
             this.LogInfo($"Log file: {this.fileWritingService.ResolveFilePath(LogRelativePath)}");
+            this.Initialized = true;
         }
         catch (Exception)
         {


### PR DESCRIPTION
Within the logger class there is nothing to prevent re-initialization of the log file if there is an external caller to the Init method. This may cause exceptions such as `The process cannot access the file 'C:\Temp\BuildAgent\_work\1\a\GovCompDisc_Log_20230221094929531.log' because it is being used by another process.` where the file can't be overwritten due to already being in use.

Add an early exit to Logger.Init if already initialized to prevent this.