### PR TITLE
refactor: add logging test extension helpers

### DIFF
--- a/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/DetectorListingCommandServiceTests.cs
+++ b/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/DetectorListingCommandServiceTests.cs
@@ -1,12 +1,12 @@
 namespace Microsoft.ComponentDetection.Orchestrator.Tests.Services;
 
-using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Orchestrator.ArgumentSets;
 using Microsoft.ComponentDetection.Orchestrator.Services;
+using Microsoft.ComponentDetection.TestsUtilities;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -40,23 +40,7 @@ public class DetectorListingCommandServiceTests
             this.loggerMock.Object);
 
         this.logOutput = new List<string>();
-        this.loggerMock.Setup(x => x.Log(
-                It.IsAny<LogLevel>(),
-                It.IsAny<EventId>(),
-                It.IsAny<It.IsAnyType>(),
-                It.IsAny<Exception>(),
-                (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()))
-            .Callback(new InvocationAction(invocation =>
-            {
-                var state = invocation.Arguments[2];
-                var exception = (Exception)invocation.Arguments[3];
-                var formatter = invocation.Arguments[4];
-
-                var invokeMethod = formatter.GetType().GetMethod("Invoke");
-                var logMessage = (string)invokeMethod?.Invoke(formatter, new[] { state, exception });
-
-                this.logOutput.Add(logMessage);
-            }));
+        this.loggerMock.CaptureLogOutput(this.logOutput);
 
         this.componentDetector2Mock.SetupGet(x => x.Id).Returns("ComponentDetector2");
         this.componentDetector3Mock.SetupGet(x => x.Id).Returns("ComponentDetector3");

--- a/test/Microsoft.ComponentDetection.TestsUtilities/ExtensionMethods.cs
+++ b/test/Microsoft.ComponentDetection.TestsUtilities/ExtensionMethods.cs
@@ -1,6 +1,11 @@
 ﻿namespace Microsoft.ComponentDetection.TestsUtilities;
+
+using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using Microsoft.Extensions.Logging;
+using Moq;
 
 public static class ExtensionMethods
 {
@@ -12,4 +17,29 @@ public static class ExtensionMethods
 
         return stream;
     }
+
+    /// <summary>
+    /// Sets up a mock logger to capture the log output to a <see cref="StringBuilder"/>.
+    /// </summary>
+    /// <param name="mockLogger">The mock logger to save the output from.</param>
+    /// <param name="logOutput">A string builder to append the log output to. Each log out it appended as a line.</param>
+    /// <typeparam name="T">The type of the logger.</typeparam>
+    public static void CaptureLogOutput<T>(this Mock<ILogger<T>> mockLogger, ICollection<string> logOutput) =>
+        mockLogger.Setup(x => x.Log(
+                It.IsAny<LogLevel>(),
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception>(),
+                (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()))
+            .Callback(new InvocationAction(invocation =>
+            {
+                var state = invocation.Arguments[2];
+                var exception = (Exception)invocation.Arguments[3];
+                var formatter = invocation.Arguments[4];
+
+                var invokeMethod = formatter.GetType().GetMethod("Invoke");
+                var logMessage = (string)invokeMethod?.Invoke(formatter, new[] { state, exception });
+                Console.WriteLine("Got log: {0}", logMessage);
+                logOutput.Add(logMessage);
+            }));
 }

--- a/test/Microsoft.ComponentDetection.TestsUtilities/ExtensionMethods.cs
+++ b/test/Microsoft.ComponentDetection.TestsUtilities/ExtensionMethods.cs
@@ -19,10 +19,10 @@ public static class ExtensionMethods
     }
 
     /// <summary>
-    /// Sets up a mock logger to capture the log output to a <see cref="StringBuilder"/>.
+    /// Sets up a mock logger to capture the log output to a <see cref="ICollection{T}"/>.
     /// </summary>
     /// <param name="mockLogger">The mock logger to save the output from.</param>
-    /// <param name="logOutput">A string builder to append the log output to. Each log out it appended as a line.</param>
+    /// <param name="logOutput">A collection to append the log output to. Each log is appended as an element in the collection.</param>
     /// <typeparam name="T">The type of the logger.</typeparam>
     public static void CaptureLogOutput<T>(this Mock<ILogger<T>> mockLogger, ICollection<string> logOutput) =>
         mockLogger.Setup(x => x.Log(

--- a/test/Microsoft.ComponentDetection.TestsUtilities/ExtensionMethods.cs
+++ b/test/Microsoft.ComponentDetection.TestsUtilities/ExtensionMethods.cs
@@ -39,7 +39,7 @@ public static class ExtensionMethods
 
                 var invokeMethod = formatter.GetType().GetMethod("Invoke");
                 var logMessage = (string)invokeMethod?.Invoke(formatter, new[] { state, exception });
-                Console.WriteLine("Got log: {0}", logMessage);
+
                 logOutput.Add(logMessage);
             }));
 }


### PR DESCRIPTION
Adds a new extension method to `Mock<ILogger<T>>` to allow the capturing of log outputs for tests.