### PR TITLE
feat: switch CLI log level arguments

### DIFF
--- a/.github/workflows/snapshot-publish.yml
+++ b/.github/workflows/snapshot-publish.yml
@@ -40,9 +40,10 @@ jobs:
 
       - name: Scan verification repo
         working-directory: src/Microsoft.ComponentDetection
-        run: dotnet run scan --Verbosity Verbose --SourceDirectory ${{ github.workspace }}/test/Microsoft.ComponentDetection.VerificationTests/resources --Output ${{ github.workspace }}/output
-                                                 --DockerImagesToScan "docker.io/library/debian@sha256:9b0e3056b8cd8630271825665a0613cc27829d6a24906dc0122b3b4834312f7d,mcr.microsoft.com/cbl-mariner/base/core@sha256:c1bc83a3d385eccbb2f7f7da43a726c697e22a996f693a407c35ac7b4387cd59,docker.io/library/alpine@sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870"
-                                                 --DetectorArgs DockerReference=EnableIfDefaultOff,SPDX22SBOM=EnableIfDefaultOff
+        run:
+          dotnet run scan --LogLevel Debug --SourceDirectory ${{ github.workspace }}/test/Microsoft.ComponentDetection.VerificationTests/resources --Output ${{ github.workspace }}/output
+          --DockerImagesToScan "docker.io/library/debian@sha256:9b0e3056b8cd8630271825665a0613cc27829d6a24906dc0122b3b4834312f7d,mcr.microsoft.com/cbl-mariner/base/core@sha256:c1bc83a3d385eccbb2f7f7da43a726c697e22a996f693a407c35ac7b4387cd59,docker.io/library/alpine@sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870"
+          --DetectorArgs DockerReference=EnableIfDefaultOff,SPDX22SBOM=EnableIfDefaultOff
 
       - name: Upload output folder
         uses: actions/upload-artifact@v3

--- a/.github/workflows/snapshot-verify.yml
+++ b/.github/workflows/snapshot-verify.yml
@@ -77,9 +77,10 @@ jobs:
 
       - name: Scan verification repo
         working-directory: src/Microsoft.ComponentDetection
-        run: dotnet run scan --Verbosity Verbose --SourceDirectory ${{ github.workspace }}/test/Microsoft.ComponentDetection.VerificationTests/resources --Output ${{ github.workspace }}/output
-                                                 --DockerImagesToScan "docker.io/library/debian@sha256:9b0e3056b8cd8630271825665a0613cc27829d6a24906dc0122b3b4834312f7d,mcr.microsoft.com/cbl-mariner/base/core@sha256:c1bc83a3d385eccbb2f7f7da43a726c697e22a996f693a407c35ac7b4387cd59,docker.io/library/alpine@sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870"
-                                                 --DetectorArgs DockerReference=EnableIfDefaultOff,SPDX22SBOM=EnableIfDefaultOff
+        run:
+          dotnet run scan --LogLevel Debug --SourceDirectory ${{ github.workspace }}/test/Microsoft.ComponentDetection.VerificationTests/resources --Output ${{ github.workspace }}/output
+          --DockerImagesToScan "docker.io/library/debian@sha256:9b0e3056b8cd8630271825665a0613cc27829d6a24906dc0122b3b4834312f7d,mcr.microsoft.com/cbl-mariner/base/core@sha256:c1bc83a3d385eccbb2f7f7da43a726c697e22a996f693a407c35ac7b4387cd59,docker.io/library/alpine@sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870"
+          --DetectorArgs DockerReference=EnableIfDefaultOff,SPDX22SBOM=EnableIfDefaultOff
 
       - name: Run Verification Tests
         working-directory: test/Microsoft.ComponentDetection.VerificationTests
@@ -87,4 +88,4 @@ jobs:
         env:
           GITHUB_OLD_ARTIFACTS_DIR: ${{ github.workspace }}/release-output
           GITHUB_NEW_ARTIFACTS_DIR: ${{ github.workspace }}/output
-          ALLOWED_TIME_DRIFT_RATIO: '.75'
+          ALLOWED_TIME_DRIFT_RATIO: ".75"

--- a/src/Microsoft.ComponentDetection.Orchestrator/ArgumentSets/BaseArguments.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/ArgumentSets/BaseArguments.cs
@@ -1,7 +1,7 @@
 ﻿namespace Microsoft.ComponentDetection.Orchestrator.ArgumentSets;
 using System;
 using CommandLine;
-using Microsoft.ComponentDetection.Contracts;
+using Serilog.Events;
 
 public class BaseArguments : IScanArguments
 {
@@ -14,8 +14,8 @@ public class BaseArguments : IScanArguments
     [Option("CorrelationId", Required = false, HelpText = "Identifier used to correlate all telemetry for a given execution. If not provided, a new GUID will be generated.")]
     public Guid CorrelationId { get; set; }
 
-    [Option("Verbosity", HelpText = "Flag indicating what level of logging to output to console during execution. Options are: Verbose, Normal, or Quiet.", Default = VerbosityMode.Normal)]
-    public VerbosityMode Verbosity { get; set; }
+    [Option("LogLevel", HelpText = "Flag indicating what level of logging to output to console during execution. Options are: Verbose, Debug, Information, Warning, Error, or Fatal.", Default = LogEventLevel.Information)]
+    public LogEventLevel LogLevel { get; set; }
 
     [Option("Timeout", Required = false, HelpText = "An integer representing the time limit (in seconds) before detection is cancelled")]
     public int Timeout { get; set; }

--- a/src/Microsoft.ComponentDetection.Orchestrator/ArgumentSets/IScanArguments.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/ArgumentSets/IScanArguments.cs
@@ -1,12 +1,12 @@
 ﻿namespace Microsoft.ComponentDetection.Orchestrator.ArgumentSets;
 using System;
-using Microsoft.ComponentDetection.Contracts;
+using Serilog.Events;
 
 public interface IScanArguments
 {
     Guid CorrelationId { get; set; }
 
-    VerbosityMode Verbosity { get; set; }
+    LogEventLevel LogLevel { get; set; }
 
     int Timeout { get; set; }
 

--- a/src/Microsoft.ComponentDetection.Orchestrator/Orchestrator.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Orchestrator.cs
@@ -22,7 +22,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Serilog;
-using Serilog.Events;
 using Serilog.Extensions.Hosting;
 using Serilog.Extensions.Logging;
 
@@ -71,13 +70,7 @@ public class Orchestrator
                 .WriteTo.Console()
                 .WriteTo.Async(x => x.File(logFile))
                 .WriteTo.Providers(this.serviceProvider.GetRequiredService<LoggerProviderCollection>())
-                .MinimumLevel.Is(baseArguments.Verbosity switch
-                {
-                    VerbosityMode.Quiet => LogEventLevel.Error,
-                    VerbosityMode.Normal => LogEventLevel.Information,
-                    VerbosityMode.Verbose => LogEventLevel.Debug,
-                    _ => throw new ArgumentOutOfRangeException(nameof(baseArguments.Verbosity), "Invalid verbosity level"),
-                })
+                .MinimumLevel.Is(baseArguments.LogLevel)
                 .Enrich.FromLogContext());
 
         this.logger.LogInformation("Log file: {LogFile}", logFile);


### PR DESCRIPTION
Removes the `--Verbosity` command line argument and replaces it with `--LogLevel`.

We can now pass in:

* Verbose
* Debug
* Information
* Warning
* Error
* Fatal


Closes #442 