### PR TITLE
feat: add `--PrintManifest` option

### DIFF
--- a/src/Microsoft.ComponentDetection.Orchestrator/ArgumentSets/BcdeArguments.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/ArgumentSets/BcdeArguments.cs
@@ -38,7 +38,7 @@ public class BcdeArguments : BaseArguments, IDetectionArguments
     [Option("ManifestFile", Required = false, HelpText = "The file to write scan results to.")]
     public FileInfo ManifestFile { get; set; }
 
-    [Option("PrintManifest", Required = false, HelpText = "Prints the manifest to standard output.")]
+    [Option("PrintManifest", Required = false, HelpText = "Prints the manifest to standard output. Logging will be redirected to standard error.")]
     public bool PrintManifest { get; set; }
 
     public string ManifestFileSerialized => this.ManifestFile?.ToString();

--- a/src/Microsoft.ComponentDetection.Orchestrator/ArgumentSets/BcdeArguments.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/ArgumentSets/BcdeArguments.cs
@@ -38,6 +38,9 @@ public class BcdeArguments : BaseArguments, IDetectionArguments
     [Option("ManifestFile", Required = false, HelpText = "The file to write scan results to.")]
     public FileInfo ManifestFile { get; set; }
 
+    [Option("PrintManifest", Required = false, HelpText = "Prints the manifest to standard output.")]
+    public bool PrintManifest { get; set; }
+
     public string ManifestFileSerialized => this.ManifestFile?.ToString();
 
     [Option("DockerImagesToScan", Required = false, Separator = ',', HelpText = "Comma separated list of docker image names or hashes to execute container scanning on, ex: ubuntu:16.04, 56bab49eef2ef07505f6a1b0d5bd3a601dfc3c76ad4460f24c91d6fa298369ab")]

--- a/src/Microsoft.ComponentDetection.Orchestrator/ArgumentSets/IDetectionArguments.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/ArgumentSets/IDetectionArguments.cs
@@ -20,5 +20,7 @@ public interface IDetectionArguments : IScanArguments
 
     FileInfo ManifestFile { get; set; }
 
+    public bool PrintManifest { get; set; }
+
     IEnumerable<string> DockerImagesToScan { get; set; }
 }

--- a/src/Microsoft.ComponentDetection.Orchestrator/Orchestrator.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Orchestrator.cs
@@ -68,7 +68,11 @@ public class Orchestrator
         var reloadableLogger = (ReloadableLogger)Log.Logger;
         reloadableLogger.Reload(configuration =>
             configuration
-                .WriteTo.Console(standardErrorFromLevel: LogEventLevel.Debug)
+                .WriteTo.Console(standardErrorFromLevel: args.Contains(
+                    $"--{nameof(IDetectionArguments.PrintManifest)}",
+                    StringComparer.InvariantCultureIgnoreCase)
+                    ? LogEventLevel.Debug
+                    : null)
                 .WriteTo.Async(x => x.File(logFile))
                 .WriteTo.Providers(this.serviceProvider.GetRequiredService<LoggerProviderCollection>())
                 .MinimumLevel.Is(baseArguments.Verbosity switch

--- a/src/Microsoft.ComponentDetection.Orchestrator/Orchestrator.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Orchestrator.cs
@@ -68,7 +68,7 @@ public class Orchestrator
         var reloadableLogger = (ReloadableLogger)Log.Logger;
         reloadableLogger.Reload(configuration =>
             configuration
-                .WriteTo.Console()
+                .WriteTo.Console(standardErrorFromLevel: LogEventLevel.Debug)
                 .WriteTo.Async(x => x.File(logFile))
                 .WriteTo.Providers(this.serviceProvider.GetRequiredService<LoggerProviderCollection>())
                 .MinimumLevel.Is(baseArguments.Verbosity switch

--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/BcdeScanCommandService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/BcdeScanCommandService.cs
@@ -1,5 +1,6 @@
 ﻿namespace Microsoft.ComponentDetection.Orchestrator.Services;
 
+using System;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.ComponentDetection.Common;
@@ -53,13 +54,20 @@ public class BcdeScanCommandService : IArgumentHandlingService
             this.logger.LogInformation("Scan Manifest file: {ManifestFile}", this.fileWritingService.ResolveFilePath(ManifestRelativePath));
         }
 
+        var manifestJson = JsonConvert.SerializeObject(scanResult, Formatting.Indented);
+
         if (userRequestedManifestPath == null)
         {
-            this.fileWritingService.AppendToFile(ManifestRelativePath, JsonConvert.SerializeObject(scanResult, Formatting.Indented));
+            this.fileWritingService.AppendToFile(ManifestRelativePath, manifestJson);
         }
         else
         {
-            this.fileWritingService.WriteFile(userRequestedManifestPath, JsonConvert.SerializeObject(scanResult, Formatting.Indented));
+            this.fileWritingService.WriteFile(userRequestedManifestPath, manifestJson);
+        }
+
+        if (detectionArguments.PrintManifest)
+        {
+            Console.WriteLine(manifestJson);
         }
     }
 }


### PR DESCRIPTION
This adds the ability to pass `--PrintManifest` to CD and will then output the scan manifest JSON to stdout.

This PR also updates Serilog to only output to standard error, so that the users can simply redirect stdout.

Closes #246