### PR TITLE
fix: support concurrent runs of CD

### DIFF
--- a/src/Microsoft.ComponentDetection.Orchestrator/Orchestrator.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Orchestrator.cs
@@ -63,7 +63,7 @@ public class Orchestrator
 
         var logFile = Path.Combine(
             baseArguments.Output ?? Path.GetTempPath(),
-            $"GovCompDisc_Log{DateTime.Now:yyyyMMddHHmmssfff}.log");
+            $"GovCompDisc_Log_{Environment.ProcessId}_{DateTime.Now:yyyyMMddHHmmssfff}.log");
 
         var reloadableLogger = (ReloadableLogger)Log.Logger;
         reloadableLogger.Reload(configuration =>


### PR DESCRIPTION
This adds the current PID of component detection to the log file name to support concurrent executions of component detection without the two separate instances attempting to use the same file.

We add the PID before the timestamp to that the log files are still sortable.

Fixes #403 