### PR TITLE
perf: fetch from PyPi in parallel and cache project responses

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/pip/PythonProject.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/PythonProject.cs
@@ -1,10 +1,12 @@
 namespace Microsoft.ComponentDetection.Detectors.Pip;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 /// <summary>
 /// A project on pypi.
 /// </summary>
 public class PythonProject
 {
+    [JsonPropertyName("releases")]
     public Dictionary<string, IList<PythonProjectRelease>> Releases { get; set; }
 }

--- a/src/Microsoft.ComponentDetection.Detectors/pip/PythonProjectRelease.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/PythonProjectRelease.cs
@@ -1,18 +1,21 @@
 namespace Microsoft.ComponentDetection.Detectors.Pip;
 using System;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 /// <summary>
 /// A specific release of a project on pypy.
 /// </summary>
 public class PythonProjectRelease
 {
+    [JsonPropertyName("packagetype")]
     public string PackageType { get; set; }
 
-    [JsonProperty("python_version")]
+    [JsonPropertyName("python_version")]
     public string PythonVersion { get; set; }
 
+    [JsonPropertyName("size")]
     public double Size { get; set; }
 
+    [JsonPropertyName("url")]
     public Uri Url { get; set; }
 }

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/PyPiClientTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/PyPiClientTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Net.Http;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -15,7 +16,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Moq.Protected;
-using Newtonsoft.Json;
 
 [TestClass]
 public class PyPiClientTests
@@ -39,7 +39,7 @@ public class PyPiClientTests
             },
         };
 
-        var mockHandler = this.MockHttpMessageHandler(JsonConvert.SerializeObject(pythonProject));
+        var mockHandler = this.MockHttpMessageHandler(JsonSerializer.Serialize(pythonProject));
         PyPiClient.HttpClient = new HttpClient(mockHandler.Object);
 
         Func<Task> action = async () => await this.pypiClient.GetReleasesAsync(pythonSpecs);
@@ -59,7 +59,7 @@ public class PyPiClientTests
             },
         };
 
-        var mockHandler = this.MockHttpMessageHandler(JsonConvert.SerializeObject(pythonProject));
+        var mockHandler = this.MockHttpMessageHandler(JsonSerializer.Serialize(pythonProject));
         PyPiClient.HttpClient = new HttpClient(mockHandler.Object);
 
         Func<Task> action = async () => await this.pypiClient.GetReleasesAsync(pythonSpecs);
@@ -87,7 +87,7 @@ public class PyPiClientTests
             },
         };
 
-        var mockHandler = this.MockHttpMessageHandler(JsonConvert.SerializeObject(pythonProject));
+        var mockHandler = this.MockHttpMessageHandler(JsonSerializer.Serialize(pythonProject));
         PyPiClient.HttpClient = new HttpClient(mockHandler.Object);
 
         Func<Task> action = async () =>
@@ -157,7 +157,7 @@ public class PyPiClientTests
             },
         };
 
-        var mockHandler = this.MockHttpMessageHandler(JsonConvert.SerializeObject(pythonProject));
+        var mockHandler = this.MockHttpMessageHandler(JsonSerializer.Serialize(pythonProject));
         PyPiClient.HttpClient = new HttpClient(mockHandler.Object);
 
         var mockLogger = new Mock<ILogger<PyPiClient>>();
@@ -193,7 +193,7 @@ public class PyPiClientTests
                 "SendAsync",
                 ItExpr.IsAny<HttpRequestMessage>(),
                 ItExpr.IsAny<CancellationToken>())
-            .ReturnsAsync(new HttpResponseMessage()
+            .ReturnsAsync(() => new HttpResponseMessage()
             {
                 StatusCode = HttpStatusCode.OK,
                 Content = new StringContent(content),


### PR DESCRIPTION
This PR makes two performance related changes:

* Fetch JSON response from PyPi in parallel
* Add second cache method to `IPyPiClient`.
  * Use `System.Text.Json` and not `Newtonsoft.Json` as we can deserialize the content stream asynchronously instead of reading the entire JSON response into memory
  * Cache the actual deserialized `PythonProject` object instead of the JSON response and deserializing it every time it's needed

Benchmarking with hyperfine yields some gains:

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `justinperez/pip-perf` | 6.221 ± 0.385 | 5.999 | 6.907 | 1.00 |
| `origin/main` | 8.205 ± 2.007 | 6.047 | 10.262 | 1.32 ± 0.33 |

I tried to get a successful benchmarking run without outliers, but each run had at least one outlier.

This should help #373  

---

Profiling also shows that `PythonVersion.ctor` is slow, so perhaps future work can optimize this or make it lazy. Unfortunately, most of the overhead comes from downloading the wheels from PyPI to resolve dependencies of dependencies (and so on). While not trivial, we can also later parallelize those downloads.
