### PR TITLE
fix: update MinVer prerelease tag

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -2,7 +2,7 @@
 
     <Target Name="Versioning" BeforeTargets="MinVer">
         <PropertyGroup Label="Build">
-            <MinVerDefaultPreReleasePhase>preview</MinVerDefaultPreReleasePhase>
+            <MinVerDefaultPreReleaseIdentifiers>preview.0</MinVerDefaultPreReleaseIdentifiers>
             <MinVerTagPrefix>v</MinVerTagPrefix>
             <MinVerVerbosity>normal</MinVerVerbosity>
         </PropertyGroup>


### PR DESCRIPTION
We've been seeing these nag messages in our build logs for quite some time now:

> MinVer : warning MINVER1008: MinVerDefaultPreReleasePhase is deprecated and will be removed in the next major version. Use MinVerDefaultPreReleaseIdentifiers instead, with an additional "0" identifier. For example, if you are setting MinVerDefaultPreReleasePhase to "preview", set MinVerDefaultPreReleaseIdentifiers to "preview.0" instead.]

We previously set `MinVerDefaultPreReleasePhase` to `preview`, and this PR follows their recommendation and sets `MinVerDefaultPreReleaseIdentifiers` to `preview.0`