### PR TITLE
fix: use `dpkg` get OpenSSL version

### DIFF
--- a/src/Microsoft.ComponentDetection.Orchestrator/Orchestrator.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Orchestrator.cs
@@ -202,7 +202,7 @@ public class Orchestrator
             {
                 var getLibSslPackages = Task.Run(() =>
                 {
-                    var startInfo = new ProcessStartInfo("apt", "list --installed") { RedirectStandardOutput = true };
+                    var startInfo = new ProcessStartInfo("dpkg", "-l") { RedirectStandardOutput = true };
                     var process = new Process { StartInfo = startInfo };
                     process.Start();
                     string aptListResult = null;


### PR DESCRIPTION
Fixes #387 

This does change the format of the telemetry. `dpkg -l` returns like this:

```
ii  libssl3:amd64                  3.0.2-0ubuntu1.8                        amd64        Secure Sockets Layer toolkit - shared libraries
```

But we could also spawn a bash shell and run:

```bash
dpkg -l | grep libssl | tr -s ' ' | cut -d ' ' -f 2,3,4
```

Which would return cleaner telemetry:

```
libssl3:amd64 3.0.2-0ubuntu1.8 amd64
```