### PR TITLE
fix: `Requires-Dist` variants & optional deps

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/pip/PipDependencySpecification.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/PipDependencySpecification.cs
@@ -12,7 +12,7 @@ public class PipDependencySpecification
 {
     // Extracts name and version from a Requires-Dist string that is found in a metadata file
     public static readonly Regex RequiresDistRegex = new Regex(
-        @"Requires-Dist:\s*(?:(.*?)\s*\((.*?)\)|([^\s;]*))",
+        @"Requires-Dist:\s*([^\s;\[<>=!~]+)(?:\[[^\]]+\])?(?:\s*\(([^)]+)\))?([^;]*)",
         RegexOptions.Compiled);
 
     /// <summary>
@@ -31,7 +31,7 @@ public class PipDependencySpecification
 
     // Extracts abcd from a string like abcd==1.*,!=1.3
     private static readonly Regex PipNameExtractionRegex = new Regex(
-        @"^.+?((?=<)|(?=>)|(?=>=)|(?=<=)|(?===)|(?=!=)|(?=~=)|(?====))",
+        @"^.+?((?=<)|(?=>)|(?=>=)|(?=<=)|(?===)|(?=!=)|(?=~=)|(?====)|(?=\[))",
         RegexOptions.Compiled);
 
     // Extracts ==1.*,!=1.3 from a string like abcd==1.*,!=1.3

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/PipDependencySpecifierTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/PipDependencySpecifierTests.cs
@@ -1,4 +1,5 @@
 ﻿namespace Microsoft.ComponentDetection.Detectors.Tests;
+
 using System.Collections.Generic;
 using Microsoft.ComponentDetection.Detectors.Pip;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -6,6 +7,25 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 [TestClass]
 public class PipDependencySpecifierTests
 {
+    private static void VerifyPipDependencyParsing(
+        List<(string SpecString, PipDependencySpecification ReferenceDependencySpecification)> testCases,
+        bool requiresDist = false)
+    {
+        foreach (var (specString, referenceDependencySpecification) in testCases)
+        {
+            var dependencySpecifier = new PipDependencySpecification(specString, requiresDist);
+
+            Assert.AreEqual(referenceDependencySpecification.Name, dependencySpecifier.Name);
+
+            for (var i = 0; i < referenceDependencySpecification.DependencySpecifiers.Count; i++)
+            {
+                Assert.AreEqual(
+                    referenceDependencySpecification.DependencySpecifiers[i],
+                    dependencySpecifier.DependencySpecifiers[i]);
+            }
+        }
+    }
+
     [TestMethod]
     public void TestPipDependencySpecifierConstruction()
     {
@@ -14,19 +34,24 @@ public class PipDependencySpecifierTests
             ("TestPackage==1.0", new PipDependencySpecification { Name = "TestPackage", DependencySpecifiers = new List<string> { "==1.0" } }),
             ("TestPackage>=1.0,!=1.1", new PipDependencySpecification { Name = "TestPackage", DependencySpecifiers = new List<string> { ">=1.0", "!=1.1" } }),
             ("OtherPackage!=1.2,>=1.0,<=1.9,~=1.4", new PipDependencySpecification { Name = "OtherPackage", DependencySpecifiers = new List<string> { "!=1.2", ">=1.0", "<=1.9", "~=1.4" } }),
+            ("TestPackage[Optional]<3,>=1.0.0", new PipDependencySpecification { Name = "TestPackage", DependencySpecifiers = new List<string> { "<3", ">=1.0.0" } }),
         };
 
-        foreach (var spec in specs)
+        VerifyPipDependencyParsing(specs);
+    }
+
+    [TestMethod]
+    public void TestPipDependencyRequireDist()
+    {
+        var specs = new List<(string, PipDependencySpecification)>
         {
-            var (specString, referenceDependencySpecification) = spec;
-            var dependencySpecifier = new PipDependencySpecification(specString);
+            ("Requires-Dist: TestPackage<1.27.0,>=1.19.5", new PipDependencySpecification { Name = "TestPackage", DependencySpecifiers = new List<string> { "<1.27.0", ">=1.19.5" } }),
+            ("Requires-Dist: TestPackage (>=1.0.0) ; sys_platform == \"win32\"", new PipDependencySpecification { Name = "TestPackage", DependencySpecifiers = new List<string> { ">=1.0.0" } }),
+            ("Requires-Dist: OtherPackage[Optional] (<3,>=1.0.0)", new PipDependencySpecification { Name = "OtherPackage", DependencySpecifiers = new List<string> { "<3", ">=1.0.0" } }),
+            ("Requires-Dist: TestPackage (>=3.7.4.3) ; python_version < \"3.8\"", new PipDependencySpecification { Name = "TestPackage", DependencySpecifiers = new List<string> { ">=3.7.4.3" } }),
+            ("Requires-Dist: TestPackage ; python_version < \"3.8\"", new PipDependencySpecification { Name = "TestPackage", DependencySpecifiers = new List<string>() }),
+        };
 
-            Assert.AreEqual(referenceDependencySpecification.Name, dependencySpecifier.Name);
-
-            for (var i = 0; i < referenceDependencySpecification.DependencySpecifiers.Count; i++)
-            {
-                Assert.AreEqual(referenceDependencySpecification.DependencySpecifiers[i], dependencySpecifier.DependencySpecifiers[i]);
-            }
-        }
+        VerifyPipDependencyParsing(specs, true);
     }
 }


### PR DESCRIPTION
Properly handles `Rquires-Dist` like so:

```
Requires-Dist: numpy<1.27.0,>=1.19.5
```

Also, properly handles dependencies with optional dependencies in pip `METADATA` or in `requirements.txt`. We ignore them for now.

```
Requires-Dist: PyJWT[crypto] (<3,>=1.0.0)
```
