### PR TITLE
ci: upload snapshot verify logs

### DIFF
--- a/.github/workflows/snapshot-verify.yml
+++ b/.github/workflows/snapshot-verify.yml
@@ -88,3 +88,9 @@ jobs:
           GITHUB_OLD_ARTIFACTS_DIR: ${{ github.workspace }}/release-output
           GITHUB_NEW_ARTIFACTS_DIR: ${{ github.workspace }}/output
           ALLOWED_TIME_DRIFT_RATIO: '.75'
+          
+      - name: Upload logs
+        uses: actions/upload-artifact@v3.1.2
+        with:
+          name: verify-snapshot-output-${{ matrix.os }}
+          path: ${{ github.workspace }}/output


### PR DESCRIPTION
This updates our `Verify snapshot of test scan` workflow to upload the logs it took scanning the test repo.

This is to help diagnose the recent golang verification failures.