### PR TITLE
ci: always upload logs unless cancelled

### DIFF
--- a/.github/workflows/snapshot-verify.yml
+++ b/.github/workflows/snapshot-verify.yml
@@ -91,6 +91,7 @@ jobs:
           
       - name: Upload logs
         uses: actions/upload-artifact@v3.1.2
+        if: !cancelled()
         with:
           name: verify-snapshot-output-${{ matrix.os }}
           path: ${{ github.workspace }}/output


### PR DESCRIPTION
Should fix the logs, only uploading if the verification test was successful.