### PR TITLE
fix(pip): trim whitespace in `Requires-Dist`

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/pip/PipDependencySpecification.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/PipDependencySpecification.cs
@@ -66,7 +66,7 @@ public class PipDependencySpecification
 
                 if (string.IsNullOrWhiteSpace(this.Name))
                 {
-                    this.Name = distMatch.Groups[i].Value;
+                    this.Name = distMatch.Groups[i].Value.Trim();
                 }
                 else
                 {
@@ -94,7 +94,9 @@ public class PipDependencySpecification
             }
         }
 
-        this.DependencySpecifiers = this.DependencySpecifiers.Where(x => !x.Contains("python_version")).ToList();
+        this.DependencySpecifiers = this.DependencySpecifiers.Where(x => !x.Contains("python_version"))
+            .Select(x => x.Trim())
+            .ToList();
     }
 
     /// <summary>

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/PipDependencySpecifierTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/PipDependencySpecifierTests.cs
@@ -50,6 +50,7 @@ public class PipDependencySpecifierTests
             ("Requires-Dist: OtherPackage[Optional] (<3,>=1.0.0)", new PipDependencySpecification { Name = "OtherPackage", DependencySpecifiers = new List<string> { "<3", ">=1.0.0" } }),
             ("Requires-Dist: TestPackage (>=3.7.4.3) ; python_version < \"3.8\"", new PipDependencySpecification { Name = "TestPackage", DependencySpecifiers = new List<string> { ">=3.7.4.3" } }),
             ("Requires-Dist: TestPackage ; python_version < \"3.8\"", new PipDependencySpecification { Name = "TestPackage", DependencySpecifiers = new List<string>() }),
+            ("Requires-Dist: SpacePackage >=1.16.0", new PipDependencySpecification() { Name = "SpacePackage", DependencySpecifiers = new List<string>() { ">=1.16.0" } }),
         };
 
         VerifyPipDependencyParsing(specs, true);


### PR DESCRIPTION
Fixes a customer issue where if a `Requires-Dist` package has extra whitespace before the version specifier, that whitespace would be captured by the regex and cause an invalid python version specifier.

We could have also changed the regex, but it is already too complex as it supports a wide variety of `Requires-Dist` formats... 