### PR TITLE
Fix: adding conditional operator to prevent NullReferenceException in NugetComponentDetector

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/nuget/NuGetComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/nuget/NuGetComponentDetector.cs
@@ -121,8 +121,15 @@ public class NuGetComponentDetector : FileComponentDetector
 
             var name = metadataNode["id"]?.InnerText;
             var version = metadataNode["version"]?.InnerText;
-
             var authors = metadataNode["authors"]?.InnerText.Split(",").Select(author => author.Trim()).ToArray();
+
+            if (name == null)
+            {
+                this.Logger.LogInformation("Error Parsing 'Name' of NuGet Component", stream.Location);
+                singleFileComponentRecorder.RegisterPackageParseFailure(stream.Location);
+
+                return;
+            }
 
             if (!NuGetVersion.TryParse(version, out var parsedVer))
             {

--- a/src/Microsoft.ComponentDetection.Detectors/nuget/NuGetComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/nuget/NuGetComponentDetector.cs
@@ -125,7 +125,7 @@ public class NuGetComponentDetector : FileComponentDetector
 
             if (name == null)
             {
-                this.Logger.LogInformation("Error Parsing 'Name' of NuGet Component", stream.Location);
+                this.Logger.LogInformation("Could not parse name from Nuspec {NuspecLocation}", stream.Location);
                 singleFileComponentRecorder.RegisterPackageParseFailure(stream.Location);
 
                 return;

--- a/src/Microsoft.ComponentDetection.Detectors/nuget/NuGetComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/nuget/NuGetComponentDetector.cs
@@ -119,8 +119,8 @@ public class NuGetComponentDetector : FileComponentDetector
             XmlNode packageNode = doc["package"];
             XmlNode metadataNode = packageNode["metadata"];
 
-            var name = metadataNode["id"].InnerText;
-            var version = metadataNode["version"].InnerText;
+            var name = metadataNode["id"]?.InnerText;
+            var version = metadataNode["version"]?.InnerText;
 
             var authors = metadataNode["authors"]?.InnerText.Split(",").Select(author => author.Trim()).ToArray();
 


### PR DESCRIPTION
Added conditional operator for name and version variables to prevent NullReferenceException when nuspec file does not contain name/version
#486 