### PR TITLE
chore(npm): add lockfile version telemetry

### DIFF
--- a/src/Microsoft.ComponentDetection.Common/Telemetry/Records/NpmLockfileVersionTelemetryRecord.cs
+++ b/src/Microsoft.ComponentDetection.Common/Telemetry/Records/NpmLockfileVersionTelemetryRecord.cs
@@ -1,0 +1,11 @@
+﻿namespace Microsoft.ComponentDetection.Common.Telemetry.Records;
+
+public class NpmLockfileVersionTelemetryRecord : BaseDetectionTelemetryRecord
+{
+    public override string RecordName => "NpmLockfileVersion";
+
+    /// <summary>
+    /// Gets or sets the lockfile version in the package-lock.json file.
+    /// </summary>
+    public int LockfileVersion { get; set; }
+}

--- a/src/Microsoft.ComponentDetection.Detectors/npm/NpmComponentDetectorWithRoots.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/npm/NpmComponentDetectorWithRoots.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
 using Microsoft.ComponentDetection.Common;
+using Microsoft.ComponentDetection.Common.Telemetry.Records;
 using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Contracts.Internal;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
@@ -147,6 +148,10 @@ public class NpmComponentDetectorWithRoots : FileComponentDetector
 
     protected void ProcessIndividualPackageJTokens(ISingleFileComponentRecorder singleFileComponentRecorder, JToken packageLockJToken, IEnumerable<IComponentStream> packageJsonComponentStream, bool skipValidation = false)
     {
+        var lockfileVersion = packageLockJToken.Value<int>("lockfileVersion");
+        using var lockfileVersionTelemetry =
+            new NpmLockfileVersionTelemetryRecord() { LockfileVersion = lockfileVersion };
+
         var dependencies = packageLockJToken["dependencies"];
         var topLevelDependencies = new Queue<(JProperty, TypedComponent)>();
 

--- a/src/Microsoft.ComponentDetection.Detectors/npm/NpmComponentDetectorWithRoots.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/npm/NpmComponentDetectorWithRoots.cs
@@ -149,8 +149,7 @@ public class NpmComponentDetectorWithRoots : FileComponentDetector
     protected void ProcessIndividualPackageJTokens(ISingleFileComponentRecorder singleFileComponentRecorder, JToken packageLockJToken, IEnumerable<IComponentStream> packageJsonComponentStream, bool skipValidation = false)
     {
         var lockfileVersion = packageLockJToken.Value<int>("lockfileVersion");
-        using var lockfileVersionTelemetry =
-            new NpmLockfileVersionTelemetryRecord() { LockfileVersion = lockfileVersion };
+        using var lockfileVersionTelemetry = new NpmLockfileVersionTelemetryRecord { LockfileVersion = lockfileVersion };
 
         var dependencies = packageLockJToken["dependencies"];
         var topLevelDependencies = new Queue<(JProperty, TypedComponent)>();


### PR DESCRIPTION
Records the `lockfileVersion` in `package-lock.json` for analysis on the impact of #476 