### PR TITLE
refactor: delete `LoaderInteropConstants`

### DIFF
--- a/src/Microsoft.ComponentDetection/LoaderInteropConstants.cs
+++ b/src/Microsoft.ComponentDetection/LoaderInteropConstants.cs
@@ -1,7 +1,0 @@
-﻿namespace Microsoft.ComponentDetection.Loader;
-
-public static class LoaderInteropConstants
-{
-    public static readonly string OrchestratorAssemblyModule = typeof(Orchestrator.Orchestrator).Assembly.GetName().Name;
-    public static readonly string OrchestratorTypeName = typeof(Orchestrator.Orchestrator).FullName;
-}


### PR DESCRIPTION
This was required before the migration to dependency injection