### PR TITLE
fix(experiment): don't process if empty or tainted

### DIFF
--- a/src/Microsoft.ComponentDetection.Orchestrator/Experiments/Configs/IExperimentConfiguration.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Experiments/Configs/IExperimentConfiguration.cs
@@ -28,4 +28,15 @@ public interface IExperimentConfiguration
     /// <param name="componentDetector">The detector.</param>
     /// <returns><c>true</c> if the detector is in the experiment group; otherwise, <c>false</c>.</returns>
     bool IsInExperimentGroup(IComponentDetector componentDetector);
+
+    /// <summary>
+    /// Determines if the experiment should be recorded, given a list of all the detectors that ran and the number of
+    /// components that were detected. If any call to this method returns <c>false</c>, the experiment will not be
+    /// recorded.
+    /// </summary>
+    /// <example><see cref="NpmLockfile3Experiment.ShouldRecord"/>.</example>
+    /// <param name="componentDetector">The component detector.</param>
+    /// <param name="numComponents">The number of components found by the <paramref name="componentDetector"/>.</param>
+    /// <returns><c>true</c> if the experiment should be recorded; otherwise, <c>false</c>.</returns>
+    bool ShouldRecord(IComponentDetector componentDetector, int numComponents);
 }

--- a/src/Microsoft.ComponentDetection.Orchestrator/Experiments/Configs/NewNugetExperiment.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Experiments/Configs/NewNugetExperiment.cs
@@ -18,4 +18,7 @@ public class NewNugetExperiment : IExperimentConfiguration
     /// <inheritdoc />
     public bool IsInExperimentGroup(IComponentDetector componentDetector) =>
         componentDetector is NuGetProjectModelProjectCentricComponentDetector or NuGetPackagesConfigDetector;
+
+    /// <inheritdoc />
+    public bool ShouldRecord(IComponentDetector componentDetector, int numComponents) => true;
 }

--- a/src/Microsoft.ComponentDetection.Orchestrator/Experiments/Configs/NpmLockfile3Experiment.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Experiments/Configs/NpmLockfile3Experiment.cs
@@ -16,4 +16,8 @@ public class NpmLockfile3Experiment : IExperimentConfiguration
 
     /// <inheritdoc />
     public bool IsInExperimentGroup(IComponentDetector componentDetector) => componentDetector is NpmLockfile3Detector;
+
+    /// <inheritdoc />
+    public bool ShouldRecord(IComponentDetector componentDetector, int numComponents) =>
+        componentDetector is not NpmComponentDetector || numComponents == 0;
 }

--- a/src/Microsoft.ComponentDetection.Orchestrator/Experiments/ExperimentService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Experiments/ExperimentService.cs
@@ -68,11 +68,7 @@ public class ExperimentService : IExperimentService
 
             if (shouldRemove)
             {
-                this.logger.LogDebug(
-                    "Removing {Experiment} from active experiments because {Id} has {Count} components",
-                    experiment.Config.Name,
-                    detector.Id,
-                    count);
+                this.logger.LogDebug("Removing {Experiment} from active experiments", experiment.Config.Name);
             }
 
             return shouldRemove;

--- a/src/Microsoft.ComponentDetection.Orchestrator/Experiments/ExperimentService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Experiments/ExperimentService.cs
@@ -83,16 +83,24 @@ public class ExperimentService : IExperimentService
     {
         foreach (var (config, experiment) in this.experiments)
         {
-            var oldComponents = experiment.ControlGroupComponents;
-            var newComponents = experiment.ExperimentGroupComponents;
+            var controlComponents = experiment.ControlGroupComponents;
+            var experimentComponents = experiment.ExperimentGroupComponents;
 
             this.logger.LogInformation(
-                "Experiment {Experiment} finished and has {Count} components in the control group and {Count} components in the experiment group.",
+                "Experiment {Experiment} finished with {ControlCount} components in the control group and {ExperimentCount} components in the experiment group",
                 config.Name,
-                oldComponents.Count,
-                newComponents.Count);
+                controlComponents.Count,
+                experimentComponents.Count);
 
-            var diff = new ExperimentDiff(experiment.ControlGroupComponents, experiment.ExperimentGroupComponents);
+            // If there are no components recorded in the experiment, skip processing experiments. We still want to
+            // process empty diffs as this means the experiment was successful.
+            if (!experimentComponents.Any() && !controlComponents.Any())
+            {
+                this.logger.LogWarning("Experiment {Experiment} has no components in either group, skipping processing", config.Name);
+                continue;
+            }
+
+            var diff = new ExperimentDiff(controlComponents, experimentComponents);
 
             foreach (var processor in this.experimentProcessors)
             {

--- a/test/Microsoft.ComponentDetection.Orchestrator.Tests/Experiments/ExperimentServiceTests.cs
+++ b/test/Microsoft.ComponentDetection.Orchestrator.Tests/Experiments/ExperimentServiceTests.cs
@@ -116,4 +116,18 @@ public class ExperimentServiceTests
         var act = async () => await service.FinishAsync();
         await act.Should().NotThrowAsync<IOException>();
     }
+
+    [TestMethod]
+    public async Task FinishAsync_SkipsEmptyExperimentsAsync()
+    {
+        var service = new ExperimentService(
+            new[] { this.experimentConfigMock.Object },
+            new[] { this.experimentProcessorMock.Object },
+            this.loggerMock.Object);
+        await service.FinishAsync();
+
+        this.experimentProcessorMock.Verify(
+            x => x.ProcessExperimentAsync(It.IsAny<IExperimentConfiguration>(), It.IsAny<ExperimentDiff>()),
+            Times.Never());
+    }
 }


### PR DESCRIPTION
The logging in `ExperimentService` was broken as it contained two identical `{Count}` parameters.

In addition, if the results of an experiment are completely empty (_i.e._ no components detected in the control group and experiment group), we should skip processing as an empty diff is indicative of a perfect detector.

Lastly, certain detectors running invalidates the experiment results. For instance, in the NPM Lockfile v3 experiment, if the lockfile v2 detector runs, we would be comparing the `NpmComponentDetector` (which would detect _N_ components), to the `NpmLockfile3Detector` (which would detect _**0**_ components). So, the experiment is tainted and we should not process it.