### PR TITLE
perf: process experiments in parallel

### DIFF
--- a/src/Microsoft.ComponentDetection.Orchestrator/Experiments/ExperimentService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Experiments/ExperimentService.cs
@@ -98,16 +98,14 @@ public class ExperimentService : IExperimentService
 
             var diff = new ExperimentDiff(controlComponents, experimentComponents);
 
-            foreach (var processor in this.experimentProcessors)
+            try
             {
-                try
-                {
-                    await processor.ProcessExperimentAsync(config, diff);
-                }
-                catch (Exception e)
-                {
-                    this.logger.LogWarning(e, "Error processing experiment {Experiment}", config.Name);
-                }
+                var tasks = this.experimentProcessors.Select(x => x.ProcessExperimentAsync(config, diff));
+                await Task.WhenAll(tasks);
+            }
+            catch (Exception e)
+            {
+                this.logger.LogError(e, "Error processing experiment {Experiment}", config.Name);
             }
         }
     }


### PR DESCRIPTION
Refactors the `ExperimentDiff` to be immutable, so we can safely process the experiments in parallel. 🦀 

The two processors at the moment, one to write to disk, and a future one to upload to Azure Blob Storage for internal customers, should run in parallel to not slow down CD.