### PR TITLE
ci: cache NuGet packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,13 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
 
+      - name: Setup NuGet cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.props') }}
+          restore-keys: ${{ runner.os }}-nuget-
+
       - name: Restore packages
         run: dotnet restore
 

--- a/.github/workflows/snapshot-publish.yml
+++ b/.github/workflows/snapshot-publish.yml
@@ -20,6 +20,13 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v3
 
+      - name: Setup NuGet cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.props') }}
+          restore-keys: ${{ runner.os }}-nuget-
+
       - run: dotnet restore
 
       - name: Install Apache Ivy

--- a/.github/workflows/snapshot-verify.yml
+++ b/.github/workflows/snapshot-verify.yml
@@ -49,6 +49,13 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v3
 
+      - name: Setup NuGet cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.props') }}
+          restore-keys: ${{ runner.os }}-nuget-
+
       - run: dotnet restore
 
       - name: Install Apache Ivy
@@ -77,9 +84,10 @@ jobs:
 
       - name: Scan verification repo
         working-directory: src/Microsoft.ComponentDetection
-        run: dotnet run scan --Verbosity Verbose --SourceDirectory ${{ github.workspace }}/test/Microsoft.ComponentDetection.VerificationTests/resources --Output ${{ github.workspace }}/output
-                                                 --DockerImagesToScan "docker.io/library/debian@sha256:9b0e3056b8cd8630271825665a0613cc27829d6a24906dc0122b3b4834312f7d,mcr.microsoft.com/cbl-mariner/base/core@sha256:c1bc83a3d385eccbb2f7f7da43a726c697e22a996f693a407c35ac7b4387cd59,docker.io/library/alpine@sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870"
-                                                 --DetectorArgs DockerReference=EnableIfDefaultOff,SPDX22SBOM=EnableIfDefaultOff
+        run:
+          dotnet run scan --Verbosity Verbose --SourceDirectory ${{ github.workspace }}/test/Microsoft.ComponentDetection.VerificationTests/resources --Output ${{ github.workspace }}/output
+          --DockerImagesToScan "docker.io/library/debian@sha256:9b0e3056b8cd8630271825665a0613cc27829d6a24906dc0122b3b4834312f7d,mcr.microsoft.com/cbl-mariner/base/core@sha256:c1bc83a3d385eccbb2f7f7da43a726c697e22a996f693a407c35ac7b4387cd59,docker.io/library/alpine@sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870"
+          --DetectorArgs DockerReference=EnableIfDefaultOff,SPDX22SBOM=EnableIfDefaultOff
 
       - name: Run Verification Tests
         working-directory: test/Microsoft.ComponentDetection.VerificationTests
@@ -87,8 +95,8 @@ jobs:
         env:
           GITHUB_OLD_ARTIFACTS_DIR: ${{ github.workspace }}/release-output
           GITHUB_NEW_ARTIFACTS_DIR: ${{ github.workspace }}/output
-          ALLOWED_TIME_DRIFT_RATIO: '.75'
-          
+          ALLOWED_TIME_DRIFT_RATIO: ".75"
+
       - name: Upload logs
         uses: actions/upload-artifact@v3.1.2
         if: ${{ !cancelled() }}


### PR DESCRIPTION
Uses [actions/cache](https://github.com/actions/cache) to cache NuGet packages. Should speed up CI.

This is similar to other .NET projects CI workflow:

See Polly's CI: https://github.com/App-vNext/Polly/blob/a1ef1bb54c9aabd95b684d4c5cfde6dfc693a5ae/.github/workflows/build.yml#L37-L49

Omitted caching the release workflow, as we should rebuild from scratch when releasing.