### PR TITLE
ci: add smoke test

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -85,7 +85,7 @@ jobs:
             await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: 'TEST: Smoke Test Failure',
+              title: 'Smoke Test Failure',
               body: issue_body,
               labels: ['bug']
             })

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,0 +1,93 @@
+name: Smoke Tests
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *" # every day at midnight
+
+jobs:
+  smoke-test:
+    runs-on: ["self-hosted", "1ES.Pool=1ES-OSE-GH-Pool"]
+    strategy:
+      matrix:
+        language:
+          [
+            { name: "CocoaPods", repo: "realm/realm-swift" },
+            { name: "Gradle", repo: "microsoft/ApplicationInsights-Java" },
+            { name: "Go", repo: "kubernetes/kubernetes" },
+            { name: "Maven", repo: "apache/kafka" },
+            { name: "NPM", repo: "axios/axios" },
+            { name: "NuGet", repo: "PowerShell/PowerShell" },
+            { name: "Pip", repo: "django/django" },
+            { name: "Pnpm", repo: "pnpm/pnpm" },
+            { name: "Poetry", repo: "Textualize/rich" },
+            { name: "Ruby", repo: "rails/rails" },
+            { name: "Rust", repo: "alacritty/alacritty" },
+            { name: "Yarn", repo: "gatsbyjs/gatsby" },
+          ]
+      fail-fast: false
+    name: ${{ matrix.language.name }}
+    steps:
+      - name: Checkout Component Detection
+        uses: actions/checkout@v3.5.2
+        with:
+          ref: 555523e957a86c2876f1a91c5073029e2e67b4e0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3.0.3
+
+      - name: Setup NuGet cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.props') }}
+          restore-keys: ${{ runner.os }}-nuget-
+
+      - name: Install Apache Ivy
+        run: curl https://downloads.apache.org/ant/ivy/2.5.1/apache-ivy-2.5.1-bin.tar.gz | tar xOz apache-ivy-2.5.1/ivy-2.5.1.jar > /usr/share/ant/lib/ivy.jar
+
+      - name: Checkout Smoke Test Repo
+        uses: actions/checkout@v3.5.2
+        with:
+          repository: ${{ matrix.language.repo }}
+          path: smoke-test-repo
+
+      - name: Run Smoke Test
+        working-directory: src/Microsoft.ComponentDetection
+        run: |
+          for i in $(seq 1 10); do
+              dotnet run -c Release -- scan --SourceDirectory ${{ github.workspace }}/smoke-test-repo --Verbosity Verbose || exit 1
+          done
+
+  create-issue:
+    runs-on: ubuntu-latest
+    needs: smoke-test
+    name: Create Issue
+    if: always() && github.event_name == 'schedule' && needs.smoke-test.result == 'failure'
+    permissions:
+      issues: write
+    steps:
+      - name: Create GitHub Issue
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const failed_tests = [];
+            const jobs = await github.rest.actions.listJobsForWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId,
+            });
+            for (const job of jobs.data.jobs) {
+              if (job.status === 'completed' && job.conclusion === 'failure') {
+                failed_tests.push('* ' + job.name);
+              }
+            }
+            const issue_body = `# :x: Smoke Test Failure\nThe following smoke tests failed:\n\n${failed_tests.join('\n')}\n\n[View Run](${context.payload.repository.html_url}/actions/runs/${context.runId})\n\ncc: @microsoft/ose-component-detection-maintainers`;
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: 'TEST: Smoke Test Failure',
+              body: issue_body,
+              labels: ['bug']
+            })

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -31,8 +31,6 @@ jobs:
     steps:
       - name: Checkout Component Detection
         uses: actions/checkout@v3.5.2
-        with:
-          ref: 555523e957a86c2876f1a91c5073029e2e67b4e0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v3.0.3


### PR DESCRIPTION
## Description

This PR adds a new GitHub Actions workflow for running smoke tests on various repositories using different package managers. The smoke tests will be executed on every push, pull request, and daily at midnight.

### Smoke Tests Workflow

The new workflow is named "Smoke Tests" and consists of the following steps:

1. Checkout Component Detection.
2. Setup .NET environment.
3. Setup NuGet cache.
4. Install Apache Ivy.
5. Checkout the smoke test repository.
6. Run the smoke test, executing the component detection tool 10 times.

The workflow uses a matrix strategy to run the tests across various repositories using different package managers, including:

- CocoaPods: [realm/realm-swift](https://github.com/realm/realm-swift)
- Gradle: [microsoft/ApplicationInsights-Java](https://github.com/microsoft/ApplicationInsights-Java)
- Go: [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes)
- Maven: [apache/kafka](https://github.com/apache/kafka)
- NPM: [axios/axios](https://github.com/axios/axios)
- NuGet: [PowerShell/PowerShell](https://github.com/PowerShell/PowerShell)
- Pip: [django/django](https://github.com/django/django)
- Pnpm: [pnpm/pnpm](https://github.com/pnpm/pnpm)
- Poetry: [Textualize/rich](https://github.com/Textualize/rich)
- Ruby: [rails/rails](https://github.com/rails/rails)
- Rust: [alacritty/alacritty](https://github.com/alacritty/alacritty)
- Yarn: [gatsbyjs/gatsby](https://github.com/gatsbyjs/gatsby)

If a smoke test fails during a scheduled run, the workflow will create a new GitHub issue with the details of the failed tests. [Example](https://github.com/microsoft/component-detection/issues/542)

## Motivation

This PR aims to improve the reliability of Component Detection by adding smoke tests to ensure that the tool works correctly on a diverse set of repositories and package managers. Additionally, the recent outage proved that our CI is not rigorous enough to ensure that Component Detection actually works E2E. The smoke tests simply ensures that there are no crashes, (or crashes are extremely unlikely).

## Custom GitHub Runner

After the outage, my investigation discovered that the concurrency bugs that caused the LSI were not reproducible in our [Verification Tests](https://github.com/microsoft/component-detection/tree/cd6405a827b256fa6d0881ad495cd7dd5a0a821d/test/Microsoft.ComponentDetection.VerificationTests/resources). Running Component Detection on this proved inefficient, regardless of CPU cores. Additionally, GitHub runners have two cores, which was not enough to properly trigger the bug.

To ensure we trigger any concurrency bugs, I've created a custom 1ES Hosted Pool for GitHub Runners that has 8 cores ([D8ads_v5](https://learn.microsoft.com/en-us/azure/virtual-machines/dasv5-dadsv5-series#dasv5-series)), and dynamically scales up to 20 machines. Only this workflow will run on it, as startup times are higher than GitHub's as we have to provision the machines. I've configured an automatic scale-up that will learn our usage and forecasts our demand for these build machines. These machines will be provisioned before our forecasted demand for them, reducing time.
