### PR TITLE
docs: correct pip default cache enties

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -10,6 +10,6 @@ Otherwise, the Go detector uses go-cli command: `go list -m all` to discover Go 
 ## `PyPiMaxCacheEntries`
 
 The environment variable `PyPiMaxCacheEntries` is used to control the size of the in-memory LRU cache that caches responses from PyPi.
-The default value is 128.
+The default value is 4096.
 
 [1]: https://go.dev/ref/mod#go-mod-graph


### PR DESCRIPTION
This was updated to 4096 in https://github.com/microsoft/component-detection/pull/385

https://github.com/microsoft/component-detection/blob/804182a508109a36e72f7ecced7d74452c96e405/src/Microsoft.ComponentDetection.Detectors/pip/IPyPiClient.cs#L33