### PR TITLE
ci(smoke-test): restore nuget packages

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -18,7 +18,7 @@ jobs:
             { name: "Go", repo: "kubernetes/kubernetes" },
             { name: "Maven", repo: "apache/kafka" },
             { name: "NPM", repo: "axios/axios" },
-            { name: "NuGet", repo: "PowerShell/PowerShell" },
+            { name: "NuGet", repo: "jellyfin/jellyfin" },
             { name: "Pip", repo: "django/django" },
             { name: "Pnpm", repo: "pnpm/pnpm" },
             { name: "Poetry", repo: "Textualize/rich" },
@@ -50,6 +50,11 @@ jobs:
         with:
           repository: ${{ matrix.language.repo }}
           path: smoke-test-repo
+      
+      - name: Restore Smoke Test NuGet Packages
+        if: ${{ matrix.language.name == 'NuGet'}}
+        working-directory: smoke-test-repo
+        run: dotnet restore
 
       - name: Run Smoke Test
         working-directory: src/Microsoft.ComponentDetection

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -18,7 +18,7 @@ jobs:
             { name: "Go", repo: "kubernetes/kubernetes" },
             { name: "Maven", repo: "apache/kafka" },
             { name: "NPM", repo: "axios/axios" },
-            { name: "NuGet", repo: "jellyfin/jellyfin" },
+            { name: "NuGet", repo: "Radarr/Radarr" },
             { name: "Pip", repo: "django/django" },
             { name: "Pnpm", repo: "pnpm/pnpm" },
             { name: "Poetry", repo: "Textualize/rich" },
@@ -53,7 +53,7 @@ jobs:
       
       - name: Restore Smoke Test NuGet Packages
         if: ${{ matrix.language.name == 'NuGet'}}
-        working-directory: smoke-test-repo
+        working-directory: smoke-test-repo/src
         run: dotnet restore
 
       - name: Run Smoke Test


### PR DESCRIPTION
The NuGet smoke test didn't restore NuGet packages, resulting in no packages being detected.

We switched to ~https://github.com/jellyfin/jellyfin~ https://github.com/Radarr/Radarr as Powershell requires .NET 8.