### PR TITLE
chore(deps): add dependency on `System.Text.Json` to `Microsoft.ComponentDetection.Contracts`

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -40,6 +40,7 @@
     <PackageVersion Include="System.Memory" Version="4.5.5" />
     <PackageVersion Include="System.Reactive" Version="5.0.0" />
     <PackageVersion Include="System.Runtime.Loader" Version="4.3.0" />
+    <PackageVersion Include="System.Text.Json" Version="6.0.7" />
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="7.0.0" />
     <PackageVersion Include="Tomlyn.Signed" Version="0.16.2" />
     <PackageVersion Include="yamldotnet" Version="13.1.0" />

--- a/src/Microsoft.ComponentDetection.Contracts/Microsoft.ComponentDetection.Contracts.csproj
+++ b/src/Microsoft.ComponentDetection.Contracts/Microsoft.ComponentDetection.Contracts.csproj
@@ -10,6 +10,7 @@
         <PackageReference Include="packageurl-dotnet" />
         <PackageReference Include="System.Memory" />
         <PackageReference Include="System.Reactive" />
+        <PackageReference Include="System.Text.Json" />
         <PackageReference Include="System.Threading.Tasks.Dataflow" />
     </ItemGroup>
 


### PR DESCRIPTION
This is required as our contracts package targets `netstandard2.0`

Part of #231 