### PR TITLE
fix(experiments): tighten NPM lockfile v3 condition

### DIFF
--- a/src/Microsoft.ComponentDetection.Orchestrator/Experiments/Configs/NpmLockfile3Experiment.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Experiments/Configs/NpmLockfile3Experiment.cs
@@ -2,6 +2,7 @@
 
 using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Detectors.Npm;
+using Microsoft.ComponentDetection.Detectors.Yarn;
 
 /// <summary>
 /// Validating the <see cref="NpmLockfile3Detector"/>.
@@ -18,6 +19,15 @@ public class NpmLockfile3Experiment : IExperimentConfiguration
     public bool IsInExperimentGroup(IComponentDetector componentDetector) => componentDetector is NpmLockfile3Detector;
 
     /// <inheritdoc />
-    public bool ShouldRecord(IComponentDetector componentDetector, int numComponents) =>
-        componentDetector is not NpmComponentDetectorWithRoots || numComponents == 0;
+    public bool ShouldRecord(IComponentDetector componentDetector, int numComponents)
+    {
+        switch (componentDetector)
+        {
+            case NpmComponentDetector when numComponents != 0:
+            case YarnLockComponentDetector when numComponents != 0:
+                return false;
+            default:
+                return true;
+        }
+    }
 }

--- a/src/Microsoft.ComponentDetection.Orchestrator/Experiments/Configs/NpmLockfile3Experiment.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Experiments/Configs/NpmLockfile3Experiment.cs
@@ -30,8 +30,7 @@ public class NpmLockfile3Experiment : IExperimentConfiguration
 
         return componentDetector switch
         {
-            NpmComponentDetector
-                or NpmComponentDetectorWithRoots
+            NpmComponentDetectorWithRoots
                 or PnpmComponentDetector
                 or PoetryComponentDetector
                 or YarnLockComponentDetector => false,

--- a/src/Microsoft.ComponentDetection.Orchestrator/Experiments/Configs/NpmLockfile3Experiment.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Experiments/Configs/NpmLockfile3Experiment.cs
@@ -2,6 +2,8 @@
 
 using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Detectors.Npm;
+using Microsoft.ComponentDetection.Detectors.Pnpm;
+using Microsoft.ComponentDetection.Detectors.Poetry;
 using Microsoft.ComponentDetection.Detectors.Yarn;
 
 /// <summary>
@@ -21,13 +23,19 @@ public class NpmLockfile3Experiment : IExperimentConfiguration
     /// <inheritdoc />
     public bool ShouldRecord(IComponentDetector componentDetector, int numComponents)
     {
-        switch (componentDetector)
+        if (numComponents == 0)
         {
-            case NpmComponentDetector when numComponents != 0:
-            case YarnLockComponentDetector when numComponents != 0:
-                return false;
-            default:
-                return true;
+            return true;
         }
+
+        return componentDetector switch
+        {
+            NpmComponentDetector
+                or NpmComponentDetectorWithRoots
+                or PnpmComponentDetector
+                or PoetryComponentDetector
+                or YarnLockComponentDetector => false,
+            _ => true,
+        };
     }
 }


### PR DESCRIPTION
We want to only capture experiments on repositories that are purely just NPM or NPM lockfile version 3. Any other NPM replacement (like yarn, pnpm, etc.) are noise to the experiment data, as these package managers also restore NPM dependencies, including their `package.json`, which gets detected by the `NpmComponentDetector`.

I've verified that there are repositories that follow this criteria by checking our telemetry.

![image](https://github.com/microsoft/component-detection/assets/26028834/901f5c95-e624-443b-94db-ff2ecd5f1b89)
