### PR TITLE
feat: use `Newtonsoft.Json` streaming methods

### DIFF
--- a/src/Microsoft.ComponentDetection.Common/IFileWritingService.cs
+++ b/src/Microsoft.ComponentDetection.Common/IFileWritingService.cs
@@ -4,18 +4,53 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 
-// All file paths are relative and will replace occurrences of {timestamp} with the shared file timestamp.
+/// <summary>
+/// Provides methods for writing files.
+/// </summary>
 public interface IFileWritingService : IDisposable, IAsyncDisposable
 {
+    /// <summary>
+    /// Initializes the file writing service with the given base path.
+    /// </summary>
+    /// <param name="basePath">The base path to use for all file operations.</param>
     void Init(string basePath);
 
-    void AppendToFile(string relativeFilePath, string text);
+    /// <summary>
+    /// Appends the object to the file as JSON.
+    /// </summary>
+    /// <param name="relativeFilePath">The relative path to the file.</param>
+    /// <param name="obj">The object to append.</param>
+    /// <typeparam name="T">The type of the object to append.</typeparam>
+    void AppendToFile<T>(string relativeFilePath, T obj);
 
+    /// <summary>
+    /// Writes the text to the file.
+    /// </summary>
+    /// <param name="relativeFilePath">The relative path to the file.</param>
+    /// <param name="text">The text to write.</param>
     void WriteFile(string relativeFilePath, string text);
 
+    /// <summary>
+    /// Writes the text to the file.
+    /// </summary>
+    /// <param name="relativeFilePath">The relative path to the file.</param>
+    /// <param name="text">The text to write.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
     Task WriteFileAsync(string relativeFilePath, string text);
 
-    void WriteFile(FileInfo relativeFilePath, string text);
+    /// <summary>
+    /// Writes the object to the file as JSON.
+    /// </summary>
+    /// <param name="relativeFilePath">The relative path to the file.</param>
+    /// <param name="obj">The object to write.</param>
+    /// <typeparam name="T">The type of the object to write.</typeparam>
+    void WriteFile<T>(FileInfo relativeFilePath, T obj);
 
+    /// <summary>
+    /// Resolves the complete file path from the given relative file path.
+    /// Replaces occurrences of {timestamp} with the shared file timestamp.
+    /// </summary>
+    /// <param name="relativeFilePath">The relative path to the file.</param>
+    /// <returns>The complete file path.</returns>
     string ResolveFilePath(string relativeFilePath);
 }

--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/BcdeScanCommandService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/BcdeScanCommandService.cs
@@ -54,20 +54,23 @@ public class BcdeScanCommandService : IArgumentHandlingService
             this.logger.LogInformation("Scan Manifest file: {ManifestFile}", this.fileWritingService.ResolveFilePath(ManifestRelativePath));
         }
 
-        var manifestJson = JsonConvert.SerializeObject(scanResult, Formatting.Indented);
-
         if (userRequestedManifestPath == null)
         {
-            this.fileWritingService.AppendToFile(ManifestRelativePath, manifestJson);
+            this.fileWritingService.AppendToFile(ManifestRelativePath, scanResult);
         }
         else
         {
-            this.fileWritingService.WriteFile(userRequestedManifestPath, manifestJson);
+            this.fileWritingService.WriteFile(userRequestedManifestPath, scanResult);
         }
 
         if (detectionArguments.PrintManifest)
         {
-            Console.WriteLine(manifestJson);
+            using var jsonWriter = new JsonTextWriter(Console.Out);
+            var serializer = new JsonSerializer
+            {
+                Formatting = Formatting.Indented,
+            };
+            serializer.Serialize(jsonWriter, scanResult);
         }
     }
 }


### PR DESCRIPTION
As we're unable to move to `System.Text.Json` with the feature set that is available in .NET 6 (See #231 for more information), this PR optimizes our use of `Newtonsoft.Json` by using streaming methods for our most allocation-heavy methods where possible.

In tests against real world repositories this dropped memory usage by up to 37% when writing the manifest JSON.

There is also some refactoring and tech debt cleanup in tests and documentation.