### PR TITLE
fix(experiments): properly record metadata

### DIFF
--- a/src/Microsoft.ComponentDetection.Orchestrator/Experiments/IExperimentService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Experiments/IExperimentService.cs
@@ -1,8 +1,9 @@
-﻿namespace Microsoft.ComponentDetection.Orchestrator.Experiments;
+namespace Microsoft.ComponentDetection.Orchestrator.Experiments;
 
-using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.ComponentDetection.Common.DependencyGraph;
 using Microsoft.ComponentDetection.Contracts;
+using Microsoft.ComponentDetection.Orchestrator.ArgumentSets;
 
 /// <summary>
 /// Service for recording detector results and processing the results for any active experiments.
@@ -13,8 +14,9 @@ public interface IExperimentService
     /// Records the results of a detector execution and processes the results for any active experiments.
     /// </summary>
     /// <param name="detector">The detector.</param>
-    /// <param name="components">The detected components from the <paramref name="detector"/>.</param>
-    void RecordDetectorRun(IComponentDetector detector, IEnumerable<DetectedComponent> components);
+    /// <param name="componentRecorder">The detected components from the <paramref name="detector"/>.</param>
+    /// <param name="detectionArguments">The detection arguments.</param>
+    void RecordDetectorRun(IComponentDetector detector, ComponentRecorder componentRecorder, IDetectionArguments detectionArguments);
 
     /// <summary>
     /// Called when all detectors have finished executing. Processes the experiments and reports the results.

--- a/src/Microsoft.ComponentDetection.Orchestrator/Experiments/Models/ExperimentComponent.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Experiments/Models/ExperimentComponent.cs
@@ -1,8 +1,8 @@
-﻿namespace Microsoft.ComponentDetection.Orchestrator.Experiments.Models;
+namespace Microsoft.ComponentDetection.Orchestrator.Experiments.Models;
 
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.ComponentDetection.Contracts;
+using Microsoft.ComponentDetection.Contracts.BcdeModels;
 
 /// <summary>
 /// A model representing a component detected by a detector, as relevant to an experiment.
@@ -10,14 +10,14 @@ using Microsoft.ComponentDetection.Contracts;
 public record ExperimentComponent
 {
     /// <summary>
-    /// Creates a new <see cref="ExperimentComponent"/> from a <see cref="DetectedComponent"/>.
+    /// Creates a new <see cref="ExperimentComponent"/> from a <see cref="ScannedComponent"/>.
     /// </summary>
     /// <param name="detectedComponent">The detected component.</param>
-    public ExperimentComponent(DetectedComponent detectedComponent)
+    public ExperimentComponent(ScannedComponent detectedComponent)
     {
         this.Id = detectedComponent.Component.Id;
-        this.DevelopmentDependency = detectedComponent.DevelopmentDependency ?? false;
-        this.RootIds = detectedComponent.DependencyRoots?.Select(x => x.Id).ToHashSet() ?? new HashSet<string>();
+        this.DevelopmentDependency = detectedComponent.IsDevelopmentDependency ?? false;
+        this.RootIds = detectedComponent.TopLevelReferrers?.Select(x => x.Id).ToHashSet() ?? new HashSet<string>();
     }
 
     /// <summary>

--- a/src/Microsoft.ComponentDetection.Orchestrator/Experiments/Models/ExperimentResults.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Experiments/Models/ExperimentResults.cs
@@ -1,10 +1,10 @@
-﻿namespace Microsoft.ComponentDetection.Orchestrator.Experiments.Models;
+namespace Microsoft.ComponentDetection.Orchestrator.Experiments.Models;
 
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using Microsoft.ComponentDetection.Contracts;
+using Microsoft.ComponentDetection.Contracts.BcdeModels;
 
 /// <summary>
 /// Stores the results of a detector execution for an experiment. Buckets components into a control group and an
@@ -34,17 +34,17 @@ public class ExperimentResults
     /// Adds the components to the control group.
     /// </summary>
     /// <param name="components">The components.</param>
-    public void AddComponentsToControlGroup(IEnumerable<DetectedComponent> components) =>
+    public void AddComponentsToControlGroup(IEnumerable<ScannedComponent> components) =>
         AddComponents(this.controlGroupComponents, components);
 
     /// <summary>
     /// Adds the components to the experimental group.
     /// </summary>
     /// <param name="components">The components.</param>
-    public void AddComponentsToExperimentalGroup(IEnumerable<DetectedComponent> components) =>
+    public void AddComponentsToExperimentalGroup(IEnumerable<ScannedComponent> components) =>
         AddComponents(this.experimentGroupComponents, components);
 
-    private static void AddComponents(ConcurrentDictionary<ExperimentComponent, byte> group, IEnumerable<DetectedComponent> components)
+    private static void AddComponents(ConcurrentDictionary<ExperimentComponent, byte> group, IEnumerable<ScannedComponent> components)
     {
         foreach (var experimentComponent in components.Select(x => new ExperimentComponent(x)))
         {

--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/DetectorProcessingService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/DetectorProcessingService.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.ComponentDetection.Orchestrator.Services;
+namespace Microsoft.ComponentDetection.Orchestrator.Services;
 
 using System;
 using System.Collections.Concurrent;
@@ -109,7 +109,7 @@ public class DetectorProcessingService : IDetectorProcessingService
                     exitCode = resultCode;
                 }
 
-                this.experimentService.RecordDetectorRun(detector, detectedComponents);
+                this.experimentService.RecordDetectorRun(detector, componentRecorder, detectionArguments);
 
                 if (isExperimentalDetector)
                 {

--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/GraphTranslation/DefaultGraphTranslationService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/GraphTranslation/DefaultGraphTranslationService.cs
@@ -212,7 +212,7 @@ public class DefaultGraphTranslationService : IGraphTranslationService
         {
             try
             {
-                var relativePath = rootUri.MakeRelativeUri(new Uri(path)).ToString();
+                var relativePath = rootUri.MakeRelativeUri(new Uri(new Uri("file://"), path)).ToString();
                 if (!relativePath.StartsWith("/"))
                 {
                     relativePath = "/" + relativePath;

--- a/test/Microsoft.ComponentDetection.Orchestrator.Tests/Experiments/ExperimentResultsTests.cs
+++ b/test/Microsoft.ComponentDetection.Orchestrator.Tests/Experiments/ExperimentResultsTests.cs
@@ -1,9 +1,8 @@
-﻿namespace Microsoft.ComponentDetection.Orchestrator.Tests.Experiments;
+namespace Microsoft.ComponentDetection.Orchestrator.Tests.Experiments;
 
 using System.Linq;
 using FluentAssertions;
-using Microsoft.ComponentDetection.Contracts;
-using Microsoft.ComponentDetection.Contracts.TypedComponent;
+using Microsoft.ComponentDetection.Contracts.BcdeModels;
 using Microsoft.ComponentDetection.Orchestrator.Experiments.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -39,9 +38,12 @@ public class ExperimentResultsTests
     [TestMethod]
     public void ExperimentResults_DoesntAddDuplicateIds()
     {
-        var testComponent = new NpmComponent("test", "1.0.0");
-        var componentA = new DetectedComponent(testComponent);
-        var componentB = new DetectedComponent(testComponent) { DevelopmentDependency = true };
+        var componentA = ExperimentTestUtils.CreateRandomScannedComponent();
+        var componentB = new ScannedComponent()
+        {
+            Component = componentA.Component,
+            IsDevelopmentDependency = true,
+        };
 
         var experiment = new ExperimentResults();
         experiment.AddComponentsToControlGroup(new[] { componentA, componentB });

--- a/test/Microsoft.ComponentDetection.Orchestrator.Tests/Experiments/ExperimentServiceTests.cs
+++ b/test/Microsoft.ComponentDetection.Orchestrator.Tests/Experiments/ExperimentServiceTests.cs
@@ -1,13 +1,19 @@
-﻿namespace Microsoft.ComponentDetection.Orchestrator.Tests.Experiments;
+namespace Microsoft.ComponentDetection.Orchestrator.Tests.Experiments;
 
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Microsoft.ComponentDetection.Common.DependencyGraph;
 using Microsoft.ComponentDetection.Contracts;
+using Microsoft.ComponentDetection.Contracts.BcdeModels;
+using Microsoft.ComponentDetection.Orchestrator.ArgumentSets;
 using Microsoft.ComponentDetection.Orchestrator.Experiments;
 using Microsoft.ComponentDetection.Orchestrator.Experiments.Configs;
 using Microsoft.ComponentDetection.Orchestrator.Experiments.Models;
+using Microsoft.ComponentDetection.Orchestrator.Services;
+using Microsoft.ComponentDetection.Orchestrator.Services.GraphTranslation;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -19,19 +25,33 @@ public class ExperimentServiceTests
 {
     private readonly Mock<IExperimentConfiguration> experimentConfigMock;
     private readonly Mock<IExperimentProcessor> experimentProcessorMock;
+    private readonly Mock<IGraphTranslationService> graphTranslationServiceMock;
     private readonly Mock<ILogger<ExperimentService>> loggerMock;
     private readonly Mock<IComponentDetector> detectorMock;
+    private readonly Mock<IDetectionArguments> detectionArgsMock;
+    private readonly ComponentRecorder componentRecorder;
 
     public ExperimentServiceTests()
     {
         this.experimentConfigMock = new Mock<IExperimentConfiguration>();
         this.experimentProcessorMock = new Mock<IExperimentProcessor>();
+        this.graphTranslationServiceMock = new Mock<IGraphTranslationService>();
         this.loggerMock = new Mock<ILogger<ExperimentService>>();
         this.detectorMock = new Mock<IComponentDetector>();
+        this.detectionArgsMock = new Mock<IDetectionArguments>();
+
+        this.componentRecorder = new ComponentRecorder();
 
         this.experimentConfigMock.Setup(x => x.IsInControlGroup(this.detectorMock.Object)).Returns(true);
         this.experimentConfigMock.Setup(x => x.IsInExperimentGroup(this.detectorMock.Object)).Returns(true);
         this.experimentConfigMock.Setup(x => x.ShouldRecord(this.detectorMock.Object, It.IsAny<int>())).Returns(true);
+    }
+
+    private void SetupGraphMock(IEnumerable<ScannedComponent> components)
+    {
+        this.graphTranslationServiceMock
+            .Setup(x => x.GenerateScanResultFromProcessingResult(It.IsAny<DetectorProcessingResult>(), It.IsAny<IDetectionArguments>()))
+            .Returns(new ScanResult() { ComponentsFound = components });
     }
 
     [TestMethod]
@@ -42,9 +62,11 @@ public class ExperimentServiceTests
         var service = new ExperimentService(
             new[] { this.experimentConfigMock.Object },
             Enumerable.Empty<IExperimentProcessor>(),
+            this.graphTranslationServiceMock.Object,
             this.loggerMock.Object);
+        this.SetupGraphMock(components);
 
-        service.RecordDetectorRun(this.detectorMock.Object, components);
+        service.RecordDetectorRun(this.detectorMock.Object, this.componentRecorder, this.detectionArgsMock.Object);
 
         this.experimentConfigMock.Verify(x => x.IsInControlGroup(this.detectorMock.Object), Times.Once());
         this.experimentConfigMock.Verify(x => x.IsInExperimentGroup(this.detectorMock.Object), Times.Once());
@@ -61,13 +83,15 @@ public class ExperimentServiceTests
         filterConfigMock.Setup(x => x.IsInExperimentGroup(this.detectorMock.Object)).Returns(true);
 
         var components = ExperimentTestUtils.CreateRandomComponents();
+        this.SetupGraphMock(components);
 
         var service = new ExperimentService(
             new[] { this.experimentConfigMock.Object, filterConfigMock.Object },
             new[] { this.experimentProcessorMock.Object },
+            this.graphTranslationServiceMock.Object,
             this.loggerMock.Object);
 
-        service.RecordDetectorRun(this.detectorMock.Object, components);
+        service.RecordDetectorRun(this.detectorMock.Object, this.componentRecorder, this.detectionArgsMock.Object);
         await service.FinishAsync();
 
         filterConfigMock.Verify(x => x.ShouldRecord(this.detectorMock.Object, components.Count), Times.Once());
@@ -83,12 +107,14 @@ public class ExperimentServiceTests
     public async Task FinishAsync_ProcessesExperimentsAsync()
     {
         var components = ExperimentTestUtils.CreateRandomComponents();
+        this.SetupGraphMock(components);
 
         var service = new ExperimentService(
             new[] { this.experimentConfigMock.Object },
             new[] { this.experimentProcessorMock.Object },
+            this.graphTranslationServiceMock.Object,
             this.loggerMock.Object);
-        service.RecordDetectorRun(this.detectorMock.Object, components);
+        service.RecordDetectorRun(this.detectorMock.Object, this.componentRecorder, this.detectionArgsMock.Object);
 
         await service.FinishAsync();
 
@@ -106,12 +132,14 @@ public class ExperimentServiceTests
             .ThrowsAsync(new IOException("test exception"));
 
         var components = ExperimentTestUtils.CreateRandomComponents();
+        this.SetupGraphMock(components);
 
         var service = new ExperimentService(
             new[] { this.experimentConfigMock.Object },
             new[] { this.experimentProcessorMock.Object },
+            this.graphTranslationServiceMock.Object,
             this.loggerMock.Object);
-        service.RecordDetectorRun(this.detectorMock.Object, components);
+        service.RecordDetectorRun(this.detectorMock.Object, this.componentRecorder, this.detectionArgsMock.Object);
 
         var act = async () => await service.FinishAsync();
         await act.Should().NotThrowAsync<IOException>();
@@ -123,6 +151,7 @@ public class ExperimentServiceTests
         var service = new ExperimentService(
             new[] { this.experimentConfigMock.Object },
             new[] { this.experimentProcessorMock.Object },
+            this.graphTranslationServiceMock.Object,
             this.loggerMock.Object);
         await service.FinishAsync();
 

--- a/test/Microsoft.ComponentDetection.Orchestrator.Tests/Experiments/ExperimentTestUtils.cs
+++ b/test/Microsoft.ComponentDetection.Orchestrator.Tests/Experiments/ExperimentTestUtils.cs
@@ -1,19 +1,21 @@
-﻿namespace Microsoft.ComponentDetection.Orchestrator.Tests.Experiments;
+namespace Microsoft.ComponentDetection.Orchestrator.Tests.Experiments;
 
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography;
-using Microsoft.ComponentDetection.Contracts;
+using Microsoft.ComponentDetection.Contracts.BcdeModels;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.ComponentDetection.Orchestrator.Experiments.Models;
 
 public static class ExperimentTestUtils
 {
-    public static DetectedComponent CreateRandomComponent() => new(new NpmComponent(Guid.NewGuid().ToString(), CreateRandomVersion()));
+    public static ScannedComponent CreateRandomScannedComponent() => new ScannedComponent() { Component = CreateRandomTypedComponent() };
 
-    public static List<DetectedComponent> CreateRandomComponents(int length = 5) =>
-        Enumerable.Range(0, length).Select(_ => CreateRandomComponent()).ToList();
+    public static TypedComponent CreateRandomTypedComponent() => new NpmComponent(Guid.NewGuid().ToString(), CreateRandomVersion());
+
+    public static List<ScannedComponent> CreateRandomComponents(int length = 5) =>
+        Enumerable.Range(0, length).Select(_ => CreateRandomScannedComponent()).ToList();
 
     public static List<ExperimentComponent> CreateRandomExperimentComponents(int length = 5) =>
         CreateRandomComponents(length).Select(x => new ExperimentComponent(x)).ToList();

--- a/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/DetectorProcessingServiceTests.cs
+++ b/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/DetectorProcessingServiceTests.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Microsoft.ComponentDetection.Common.DependencyGraph;
 using Microsoft.ComponentDetection.Common.Telemetry.Records;
 using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
@@ -539,14 +540,16 @@ public class DetectorProcessingServiceTests
             x =>
                 x.RecordDetectorRun(
                     It.Is<IComponentDetector>(detector => detector == this.firstFileComponentDetectorMock.Object),
-                    It.Is<IEnumerable<DetectedComponent>>(components => components.SequenceEqual(firstComponents))),
+                    It.IsAny<ComponentRecorder>(),
+                    It.Is<IDetectionArguments>(x => x == DefaultArgs)),
             Times.Once());
 
         this.experimentServiceMock.Verify(
             x =>
                 x.RecordDetectorRun(
                     It.Is<IComponentDetector>(detector => detector == this.secondFileComponentDetectorMock.Object),
-                    It.Is<IEnumerable<DetectedComponent>>(components => components.SequenceEqual(secondComponents))),
+                    It.IsAny<ComponentRecorder>(),
+                    It.Is<IDetectionArguments>(x => x == DefaultArgs)),
             Times.Once());
     }
 


### PR DESCRIPTION
`DetectedComponent` has the metadata such as whether the component is a development dependency, and the root components, but this data is not actually set.

Instead, detectors create `DetectedComponent`s with the `TypedComponent`, and the metadata is passed into `ComponentRecorder` which then appends the component to the graph with proper metadata.

This switches experiments from using `DetectedComponent` to `ScannedComponent` by using the `IGraphTranslationService` to parse the data from the `ComponentRecorder`.

Fixes #611 