### PR TITLE
Fix isExplicitReferencedDependency in Poetry Detector

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/poetry/PoetryComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/poetry/PoetryComponentDetector.cs
@@ -53,12 +53,12 @@ public class PoetryComponentDetector : FileComponentDetector, IExperimentalDetec
             if (package.Source != null && package.Source.Type == "git")
             {
                 var component = new DetectedComponent(new GitComponent(new Uri(package.Source.Url), package.Source.ResolvedReference));
-                singleFileComponentRecorder.RegisterUsage(component, isDevelopmentDependency: isDevelopmentDependency);
+                singleFileComponentRecorder.RegisterUsage(component, isExplicitReferencedDependency: true, isDevelopmentDependency: isDevelopmentDependency);
             }
             else
             {
                 var component = new DetectedComponent(new PipComponent(package.Name, package.Version));
-                singleFileComponentRecorder.RegisterUsage(component, isDevelopmentDependency: isDevelopmentDependency);
+                singleFileComponentRecorder.RegisterUsage(component, isExplicitReferencedDependency: true, isDevelopmentDependency: isDevelopmentDependency);
             }
         });
         await Task.CompletedTask;


### PR DESCRIPTION
This PR is fixing the isExplicitlyReferencedDependency flag for packages detected using the poetry detector. 

See the below screenshot for the verification tests: 

![image](https://github.com/microsoft/component-detection/assets/28487515/56e60fbd-f6c1-4320-9559-2a6f290bdf88)
