### PR TITLE
refactor: add `FluentAssertions.Analyzers` and fix some warnings

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,6 +10,7 @@
     <PackageVersion Include="coverlet.msbuild" Version="6.0.0" />
     <PackageVersion Include="Docker.DotNet" Version="3.125.15" />
     <PackageVersion Include="FluentAssertions" Version="6.11.0" />
+    <PackageVersion Include="FluentAssertions.Analyzers" Version="0.21.0" />
     <PackageVersion Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />

--- a/test/Microsoft.ComponentDetection.Contracts.Tests/DetectedComponentTests.cs
+++ b/test/Microsoft.ComponentDetection.Contracts.Tests/DetectedComponentTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace Microsoft.ComponentDetection.Contracts.Tests;
 
+using FluentAssertions;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -17,12 +18,10 @@ public class DetectedComponentTests
 
         var component = new DetectedComponent(new NpmComponent(componentName, componentVersion));
 
-        Assert.IsNotNull(component.FilePaths);
-        Assert.AreEqual(0, component.FilePaths.Count);
+        component.FilePaths.Should().NotBeNull().And.HaveCount(0);
 
         component.AddComponentFilePath(filePathToAdd);
 
-        Assert.AreEqual(1, component.FilePaths.Count);
-        Assert.IsTrue(component.FilePaths.Contains(filePathToAdd));
+        component.FilePaths.Should().HaveCount(1).And.Contain(filePathToAdd);
     }
 }

--- a/test/Microsoft.ComponentDetection.Contracts.Tests/Microsoft.ComponentDetection.Contracts.Tests.csproj
+++ b/test/Microsoft.ComponentDetection.Contracts.Tests/Microsoft.ComponentDetection.Contracts.Tests.csproj
@@ -10,6 +10,7 @@
         <PackageReference Include="System.Reactive" />
         <PackageReference Include="System.Threading.Tasks.Dataflow" />
         <PackageReference Include="packageurl-dotnet" />
+        <PackageReference Include="FluentAssertions.Analyzers" PrivateAssets="all" />
     </ItemGroup>
 
 </Project>

--- a/test/Microsoft.ComponentDetection.Orchestrator.Tests/Experiments/ExperimentDiffTests.cs
+++ b/test/Microsoft.ComponentDetection.Orchestrator.Tests/Experiments/ExperimentDiffTests.cs
@@ -90,8 +90,7 @@ public class ExperimentDiffTests
         diff.RemovedRootIds.Should().BeEmpty();
 
         var addedRoot = diff.AddedRootIds[componentA.Component.Id];
-        addedRoot.Should().HaveCount(1);
-        addedRoot.Should().BeEquivalentTo(rootComponent.Id);
+        addedRoot.Should().ContainSingle().And.BeEquivalentTo(rootComponent.Id);
 
         diff.AddedIds.Should().BeEmpty();
         diff.RemovedIds.Should().BeEmpty();
@@ -118,8 +117,7 @@ public class ExperimentDiffTests
         diff.AddedRootIds.Should().BeEmpty();
 
         var removedRoot = diff.RemovedRootIds[componentA.Component.Id];
-        removedRoot.Should().HaveCount(1);
-        removedRoot.Should().BeEquivalentTo(rootComponent.Id);
+        removedRoot.Should().ContainSingle().And.BeEquivalentTo(rootComponent.Id);
 
         diff.AddedIds.Should().BeEmpty();
         diff.RemovedIds.Should().BeEmpty();

--- a/test/Microsoft.ComponentDetection.Orchestrator.Tests/Microsoft.ComponentDetection.Orchestrator.Tests.csproj
+++ b/test/Microsoft.ComponentDetection.Orchestrator.Tests/Microsoft.ComponentDetection.Orchestrator.Tests.csproj
@@ -9,6 +9,7 @@
         <PackageReference Include="Microsoft.Extensions.Logging" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="System.Threading.Tasks.Dataflow" />
+      <PackageReference Include="FluentAssertions.Analyzers" PrivateAssets="all" />
     </ItemGroup>
 
 </Project>

--- a/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/BcdeScanExecutionServiceTests.cs
+++ b/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/BcdeScanExecutionServiceTests.cs
@@ -257,8 +257,7 @@ public class BcdeScanExecutionServiceTests
         var matchingGraph = result.DependencyGraphs.First();
         matchingGraph.Key.Should().Be(mockGraphLocation);
         var explicitlyReferencedComponents = matchingGraph.Value.ExplicitlyReferencedComponentIds;
-        explicitlyReferencedComponents.Count.Should().Be(1);
-        explicitlyReferencedComponents.Should().Contain(this.detectedComponents[0].Component.Id);
+        explicitlyReferencedComponents.Should().ContainSingle().And.Contain(this.detectedComponents[0].Component.Id);
 
         var actualGraph = matchingGraph.Value.Graph;
         actualGraph.Keys.Count.Should().Be(2);
@@ -331,7 +330,7 @@ public class BcdeScanExecutionServiceTests
         var matchingGraph = result.DependencyGraphs.First();
         matchingGraph.Key.Should().Be(mockGraphLocation);
         var explicitlyReferencedComponents = matchingGraph.Value.ExplicitlyReferencedComponentIds;
-        explicitlyReferencedComponents.Count.Should().Be(2);
+        explicitlyReferencedComponents.Should().HaveCount(2);
         explicitlyReferencedComponents.Should().Contain(this.detectedComponents[0].Component.Id);
         explicitlyReferencedComponents.Should().Contain(this.detectedComponents[1].Component.Id);
 

--- a/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/DetectorProcessingServiceTests.cs
+++ b/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/DetectorProcessingServiceTests.cs
@@ -348,32 +348,32 @@ public class DetectorProcessingServiceTests
         // Exclusion predicate is case sensitive and allow windows path, the exclusion list follow the windows path structure and has a case mismatch with the directory path, should not exclude
         args.DirectoryExclusionList = new[] { @"**\source\**" };
         var exclusionPredicate = this.serviceUnderTest.GenerateDirectoryExclusionPredicate(@"C:\somefake\dir", args.DirectoryExclusionList, args.DirectoryExclusionListObsolete, allowWindowsPaths: true, ignoreCase: false);
-        Assert.IsFalse(exclusionPredicate(dn, dp));
+        exclusionPredicate(dn, dp).Should().BeFalse();
 
         // Exclusion predicate is case sensitive and allow windows path, the exclusion list follow the windows path structure and match directory path case, should exclude
         args.DirectoryExclusionList = new[] { @"**\Source\**" };
         exclusionPredicate = this.serviceUnderTest.GenerateDirectoryExclusionPredicate(@"C:\somefake\dir", args.DirectoryExclusionList, args.DirectoryExclusionListObsolete, allowWindowsPaths: true, ignoreCase: false);
-        Assert.IsTrue(exclusionPredicate(dn, dp));
+        exclusionPredicate(dn, dp).Should().BeTrue();
 
         // Exclusion predicate is not case sensitive and allow windows path, the exclusion list follow the windows path, should exclude
         args.DirectoryExclusionList = new[] { @"**\sOuRce\**" };
         exclusionPredicate = this.serviceUnderTest.GenerateDirectoryExclusionPredicate(@"C:\somefake\dir", args.DirectoryExclusionList, args.DirectoryExclusionListObsolete, allowWindowsPaths: true, ignoreCase: true);
-        Assert.IsTrue(exclusionPredicate(dn, dp));
+        exclusionPredicate(dn, dp).Should().BeTrue();
 
         // Exclusion predicate does not support windows path and the exclusion list define the path as a windows path, should not exclude
         args.DirectoryExclusionList = new[] { @"**\Source\**" };
         exclusionPredicate = this.serviceUnderTest.GenerateDirectoryExclusionPredicate(@"C:\somefake\dir", args.DirectoryExclusionList, args.DirectoryExclusionListObsolete, allowWindowsPaths: false, ignoreCase: true);
-        Assert.IsFalse(exclusionPredicate(dn, dp));
+        exclusionPredicate(dn, dp).Should().BeFalse();
 
         // Exclusion predicate support windows path and the exclusion list define the path as a windows path, should exclude
         args.DirectoryExclusionList = new[] { @"**\Source\**" };
         exclusionPredicate = this.serviceUnderTest.GenerateDirectoryExclusionPredicate(@"C:\somefake\dir", args.DirectoryExclusionList, args.DirectoryExclusionListObsolete, allowWindowsPaths: true, ignoreCase: true);
-        Assert.IsTrue(exclusionPredicate(dn, dp));
+        exclusionPredicate(dn, dp).Should().BeTrue();
 
         // Exclusion predicate support windows path and the exclusion list does not define a windows path, should exclude
         args.DirectoryExclusionList = new[] { @"**/Source/**", @"**/Source\**" };
         exclusionPredicate = this.serviceUnderTest.GenerateDirectoryExclusionPredicate(@"C:\somefake\dir", args.DirectoryExclusionList, args.DirectoryExclusionListObsolete, allowWindowsPaths: true, ignoreCase: true);
-        Assert.IsTrue(exclusionPredicate(dn, dp));
+        exclusionPredicate(dn, dp).Should().BeTrue();
     }
 
     [TestMethod]
@@ -602,7 +602,7 @@ public class DetectorProcessingServiceTests
         var check = isPresent.Select(i => i.GetType());
 
         isPresent.All(discovered => shouldBePresent.Contains(discovered));
-        shouldBePresent.Should().HaveCount(isPresent.Count());
+        shouldBePresent.Should().HaveSameCount(isPresent);
     }
 
     private Mock<IComponentDetector> SetupCommandDetectorMock(string id)


### PR DESCRIPTION
This adds `FluentAnalyzers.Assertions` and fixes warnings in `Microsoft.ComponentDetection.Contracts.Tests` and `Microsoft.ComponentDetection.Orchestrator.Tests`

Related to #633