### PR TITLE
ci: limit smoke tests push trigger to main

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -2,6 +2,8 @@ name: Smoke Tests
 
 on:
   push:
+    branches: 
+      - main
   pull_request:
   schedule:
     - cron: "0 0 * * *" # every day at midnight


### PR DESCRIPTION
Every PR runs two copies of the smoke test, one because a user pushed to their local branch, and another from the pull request trigger.

I think it's best to leave `push` and `pull_request` triggers, as I'm not sure if `push` will trigger on a PR from a fork.