### PR TITLE
Improve the detection of pip components in the CondaLockDetector

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/conda/CondaDependencyResolver.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/conda/CondaDependencyResolver.cs
@@ -105,7 +105,7 @@ public static class CondaDependencyResolver
 
     /// <summary>
     /// Converts a CondaPackage to a TypedComponent.
-    /// If the condapackage is managed by pip it will be converted to a
+    /// If the condapackage is a python package it will be converted to a
     /// PipComponent. Otherwise it will be converted to a CondaComponent.
     ///
     /// For the conda component, only the most necessary information that are
@@ -121,7 +121,19 @@ public static class CondaDependencyResolver
     /// <param name="package">The CondaPackage to convert.</param>
     /// <returns>The TypedComponent.</returns>
     private static TypedComponent CreateComponent(CondaPackage package)
-        => package.Manager.Equals("pip", StringComparison.OrdinalIgnoreCase)
+        => IsPythonPackage(package)
                 ? new PipComponent(package.Name, package.Version)
                 : new CondaComponent(package.Name, package.Version, null, package.Category, null, null, null, null);
+
+    /// <summary>
+    /// Checks if a package is a python package.
+    ///
+    /// If the package is either managed by pip, or if it depends on python
+    /// it is considered a python package.
+    /// </summary>
+    /// <param name="package">The CondaPackage.</param>
+    /// <returns>True if the package is a python package.</returns>
+    private static bool IsPythonPackage(CondaPackage package)
+        => package.Manager.Equals("pip", StringComparison.OrdinalIgnoreCase) ||
+           package.Dependencies.Keys.Any(dependency => dependency.Equals("python", StringComparison.OrdinalIgnoreCase));
 }

--- a/src/Microsoft.ComponentDetection.Detectors/conda/CondaLockComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/conda/CondaLockComponentDetector.cs
@@ -30,7 +30,7 @@ public class CondaLockComponentDetector : FileComponentDetector, IDefaultOffComp
 
     public override IEnumerable<ComponentType> SupportedComponentTypes => new[] { ComponentType.Conda, ComponentType.Pip };
 
-    public override int Version { get; } = 1;
+    public override int Version { get; } = 2;
 
     public override IEnumerable<string> Categories => new List<string> { "Python" };
 


### PR DESCRIPTION
So far, python components have only been created for packages which are managed by pip. However, 90% of the conda packages are python packages, even though they are managed by conda instead of pip. 

This PR is improving the detection by adding support for detecting python packages which are managed by conda.