### PR TITLE
fix(experiments): don't overwrite file locations

### DIFF
--- a/src/Microsoft.ComponentDetection.Orchestrator/Experiments/ExperimentService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Experiments/ExperimentService.cs
@@ -55,7 +55,8 @@ public class ExperimentService : IExperimentService
                     ContainersDetailsMap = new Dictionary<int, ContainerDetails>(),
                     ResultCode = ProcessingResultCode.Success,
                 },
-                detectionArguments);
+                detectionArguments,
+                false);
 
             var components = scanResult.ComponentsFound;
             this.FilterExperiments(detector, components.Count());

--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/GraphTranslation/DefaultGraphTranslationService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/GraphTranslation/DefaultGraphTranslationService.cs
@@ -21,6 +21,7 @@ public class DefaultGraphTranslationService : IGraphTranslationService
 
     public DefaultGraphTranslationService(ILogger<DefaultGraphTranslationService> logger) => this.logger = logger;
 
+    /// <inheritdoc/>
     public ScanResult GenerateScanResultFromProcessingResult(DetectorProcessingResult detectorProcessingResult, IDetectionArguments detectionArguments, bool updateLocations = true)
     {
         var recorderDetectorPairs = detectorProcessingResult.ComponentRecorders;

--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/GraphTranslation/DefaultGraphTranslationService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/GraphTranslation/DefaultGraphTranslationService.cs
@@ -92,6 +92,8 @@ public class DefaultGraphTranslationService : IGraphTranslationService
                         // Return in a format that allows us to add the additional files for the components
                         var locations = dependencyGraph.GetAdditionalRelatedFiles();
 
+                        // Experiments uses this service to build the dependency graph for analysis. In this case, we do not want to update the locations of the component.
+                        // Updating the locations of the component will propogate to the final depenendcy graph and cause the graph to be incorrect.
                         if (updateLocations)
                         {
                             // graph authoritatively stores the location of the component

--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/GraphTranslation/IGraphTranslationService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/GraphTranslation/IGraphTranslationService.cs
@@ -5,5 +5,13 @@ using Microsoft.ComponentDetection.Orchestrator.ArgumentSets;
 
 public interface IGraphTranslationService
 {
+    /// <summary>
+    /// Merges the results of multiple detectors into a single <see cref="ScanResult"/>, building the dependency graph.
+    /// </summary>
+    /// <param name="detectorProcessingResult">The detector processing result.</param>
+    /// <param name="detectionArguments">The detector arguments.</param>
+    /// <param name="updateLocations"><c>true</c> to set the component's locations found at. This should typically be set to true.
+    /// Since the components are passed by reference, any updates to the components will be propogated globally.</param>
+    /// <returns>A <see cref="ScanResult"/> with the final output of component detection.</returns>
     ScanResult GenerateScanResultFromProcessingResult(DetectorProcessingResult detectorProcessingResult, IDetectionArguments detectionArguments, bool updateLocations = true);
 }

--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/GraphTranslation/IGraphTranslationService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/GraphTranslation/IGraphTranslationService.cs
@@ -5,5 +5,5 @@ using Microsoft.ComponentDetection.Orchestrator.ArgumentSets;
 
 public interface IGraphTranslationService
 {
-    ScanResult GenerateScanResultFromProcessingResult(DetectorProcessingResult detectorProcessingResult, IDetectionArguments detectionArguments);
+    ScanResult GenerateScanResultFromProcessingResult(DetectorProcessingResult detectorProcessingResult, IDetectionArguments detectionArguments, bool updateLocations = true);
 }

--- a/test/Microsoft.ComponentDetection.Orchestrator.Tests/Experiments/ExperimentServiceTests.cs
+++ b/test/Microsoft.ComponentDetection.Orchestrator.Tests/Experiments/ExperimentServiceTests.cs
@@ -50,7 +50,7 @@ public class ExperimentServiceTests
     private void SetupGraphMock(IEnumerable<ScannedComponent> components)
     {
         this.graphTranslationServiceMock
-            .Setup(x => x.GenerateScanResultFromProcessingResult(It.IsAny<DetectorProcessingResult>(), It.IsAny<IDetectionArguments>()))
+            .Setup(x => x.GenerateScanResultFromProcessingResult(It.IsAny<DetectorProcessingResult>(), It.IsAny<IDetectionArguments>(), It.IsAny<bool>()))
             .Returns(new ScanResult() { ComponentsFound = components });
     }
 
@@ -70,6 +70,12 @@ public class ExperimentServiceTests
 
         this.experimentConfigMock.Verify(x => x.IsInControlGroup(this.detectorMock.Object), Times.Once());
         this.experimentConfigMock.Verify(x => x.IsInExperimentGroup(this.detectorMock.Object), Times.Once());
+
+        // verify that we always call the graph translation service with updateLocations = false so we dont
+        // corrupt file location paths
+        this.graphTranslationServiceMock.Verify(
+            x => x.GenerateScanResultFromProcessingResult(It.IsAny<DetectorProcessingResult>(), It.IsAny<IDetectionArguments>(), It.Is<bool>(x => !x)),
+            Times.Once());
     }
 
     [TestMethod]


### PR DESCRIPTION
Fixes experiments overwriting file locations and corrupting them with bad relative paths.