### PR TITLE
Fix Rust detector exception for non-source dependency

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/rust/RustCrateDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/rust/RustCrateDetector.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.ComponentDetection.Detectors.Rust;
+namespace Microsoft.ComponentDetection.Detectors.Rust;
 
 using System;
 using System.Collections.Generic;
@@ -213,12 +213,7 @@ public class RustCrateDetector : FileComponentDetector
 
             if (IsLocalPackage(childPackage))
             {
-                if (!IsLocalPackage(parentPackage))
-                {
-                    throw new FormatException($"In package with source '{parentComponent.Id}' found non-source dependency string: '{dependency}'");
-                }
-
-                // This is a dependency between packages without source
+                // This is a dependency on a package without a source
                 return;
             }
 


### PR DESCRIPTION
Remove Rust detector exception for a Source dependency having a dependency on a non-Source dependency.

This is seen in the Rust project's lockfile: https://github.com/rust-lang/rust/blob/1554942cdc0099e081d5cd673d45f8a09cfd0eb0/Cargo.lock#L6 where `rustc-std-workspace-alloc` has no `source`, dispite being a dependency of `addr2line` (which does have a `source`).