### PR TITLE
chore: re-encode git-blame-ignore-revs file to utf8 without bom

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,2 @@
-﻿# refactor: use file scoped namespaces
+# refactor: use file scoped namespaces
 0f3fa8a84488f6f8878532d1e5812580998a045e


### PR DESCRIPTION
git and GitHub don't accept the file with the leading UTF8 BOM.