### PR TITLE
chore: correct settings for work item sync workflow

### DIFF
--- a/.github/workflows/sync-issues.yml
+++ b/.github/workflows/sync-issues.yml
@@ -24,8 +24,6 @@ jobs:
           ado_project: "AzureDevOps"
           ado_area_path: "AzureDevOps\\Artifacts\\Component Governance"
           ado_wit: "Task"
-          ado_new_state: "New"
-          ado_active_state: "Active"
-          ado_close_state: "Closed"
-          ado_bypassrules: true
-          log_level: 100
+          ado_new_state: "Proposed"
+          ado_active_state: "In Progress"
+          ado_close_state: "Completed"


### PR DESCRIPTION
Changes include:
- Unset `ado_bypassrules` as we don't have bypass rules permissions
- Correctly set states for tasks
- Unset `log_leve` as 100 is the default level