### PR TITLE
ci: enable detector experiments

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,8 +1,11 @@
 name: Smoke Tests
 
+env:
+  CD_DETECTOR_EXPERIMENTS: 1
+
 on:
   push:
-    branches: 
+    branches:
       - main
   pull_request:
   schedule:
@@ -52,7 +55,7 @@ jobs:
         with:
           repository: ${{ matrix.language.repo }}
           path: smoke-test-repo
-      
+
       - name: Restore Smoke Test NuGet Packages
         if: ${{ matrix.language.name == 'NuGet'}}
         working-directory: smoke-test-repo/src

--- a/.github/workflows/snapshot-publish.yml
+++ b/.github/workflows/snapshot-publish.yml
@@ -1,5 +1,8 @@
 name: Publish snapshot of test scan
 
+env:
+  CD_DETECTOR_EXPERIMENTS: 1
+
 on:
   push:
     branches:
@@ -51,8 +54,8 @@ jobs:
       - name: Scan verification repo
         working-directory: src/Microsoft.ComponentDetection
         run: dotnet run scan --Verbosity Verbose --SourceDirectory ${{ github.workspace }}/test/Microsoft.ComponentDetection.VerificationTests/resources --Output ${{ github.workspace }}/output
-                                                 --DockerImagesToScan "docker.io/library/debian@sha256:9b0e3056b8cd8630271825665a0613cc27829d6a24906dc0122b3b4834312f7d,mcr.microsoft.com/cbl-mariner/base/core@sha256:c1bc83a3d385eccbb2f7f7da43a726c697e22a996f693a407c35ac7b4387cd59,docker.io/library/alpine@sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870"
-                                                 --DetectorArgs DockerReference=EnableIfDefaultOff,SPDX22SBOM=EnableIfDefaultOff
+          --DockerImagesToScan "docker.io/library/debian@sha256:9b0e3056b8cd8630271825665a0613cc27829d6a24906dc0122b3b4834312f7d,mcr.microsoft.com/cbl-mariner/base/core@sha256:c1bc83a3d385eccbb2f7f7da43a726c697e22a996f693a407c35ac7b4387cd59,docker.io/library/alpine@sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870"
+          --DetectorArgs DockerReference=EnableIfDefaultOff,SPDX22SBOM=EnableIfDefaultOff
 
       - name: Upload output folder
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3

--- a/.github/workflows/snapshot-publish.yml
+++ b/.github/workflows/snapshot-publish.yml
@@ -53,7 +53,8 @@ jobs:
 
       - name: Scan verification repo
         working-directory: src/Microsoft.ComponentDetection
-        run: dotnet run scan --Verbosity Verbose --SourceDirectory ${{ github.workspace }}/test/Microsoft.ComponentDetection.VerificationTests/resources --Output ${{ github.workspace }}/output
+        run:
+          dotnet run scan --Verbosity Verbose --SourceDirectory ${{ github.workspace }}/test/Microsoft.ComponentDetection.VerificationTests/resources --Output ${{ github.workspace }}/output
           --DockerImagesToScan "docker.io/library/debian@sha256:9b0e3056b8cd8630271825665a0613cc27829d6a24906dc0122b3b4834312f7d,mcr.microsoft.com/cbl-mariner/base/core@sha256:c1bc83a3d385eccbb2f7f7da43a726c697e22a996f693a407c35ac7b4387cd59,docker.io/library/alpine@sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870"
           --DetectorArgs DockerReference=EnableIfDefaultOff,SPDX22SBOM=EnableIfDefaultOff
 

--- a/.github/workflows/snapshot-verify.yml
+++ b/.github/workflows/snapshot-verify.yml
@@ -1,5 +1,8 @@
 name: Verify snapshot of test scan
 
+env:
+  CD_DETECTOR_EXPERIMENTS: 1
+
 on: [pull_request]
 
 permissions:


### PR DESCRIPTION
CI needs to run detector experiments to verify it works.

Also reformatted the workflows.