### PR TITLE
Feature: Add conan detector that parses conan.lock files of conan package manager version 1.x

### DIFF
--- a/docs/detectors/conan.md
+++ b/docs/detectors/conan.md
@@ -3,7 +3,7 @@
 Conan detection relies on a conan.lock file being present.
 
 ## Detection strategy
-Conan detection is performed by parsing every <em>conan.lock</em> found under the scan directory.
+Conan detection is performed by parsing every **conan.lock** found under the scan directory.
 
 ## Known limitations
 Conan detection will not work if lock files are not being used or not yet generated. So ensure to run the conan build to generate the lock file(s) before running the scan.

--- a/docs/detectors/conan.md
+++ b/docs/detectors/conan.md
@@ -8,4 +8,4 @@ Conan detection is performed by parsing every **conan.lock** found under the sca
 ## Known limitations
 Conan detection will not work if lock files are not being used or not yet generated. So ensure to run the conan build to generate the lock file(s) before running the scan.
 
-Full dependency graph generation is not supported. However, dependency relationships identified/present in the <em>conan.lock</em> file is captured.
+Full dependency graph generation is not supported. However, dependency relationships identified/present in the **conan.lock** file is captured.

--- a/docs/detectors/conan.md
+++ b/docs/detectors/conan.md
@@ -1,0 +1,11 @@
+# Conan Detection
+## Requirements
+Conan detection relies on a conan.lock file being present.
+
+## Detection strategy
+Conan detection is performed by parsing every <em>conan.lock</em> found under the scan directory.
+
+## Known limitations
+Conan detection will not work if lock files are not being used or not yet generated. So ensure to run the conan build to generate the lock file(s) before running the scan.
+
+Full dependency graph generation is not supported. However, dependency relationships identified/present in the <em>conan.lock</em> file is captured.

--- a/src/Microsoft.ComponentDetection.Contracts/BcdeModels/TypedComponentConverter.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/BcdeModels/TypedComponentConverter.cs
@@ -17,6 +17,7 @@ public class TypedComponentConverter : JsonConverter
         { ComponentType.Git, typeof(GitComponent) },
         { ComponentType.RubyGems, typeof(RubyGemsComponent) },
         { ComponentType.Cargo, typeof(CargoComponent) },
+        { ComponentType.Conan, typeof(ConanComponent) },
         { ComponentType.Pip, typeof(PipComponent) },
         { ComponentType.Go, typeof(GoComponent) },
         { ComponentType.DockerImage, typeof(DockerImageComponent) },

--- a/src/Microsoft.ComponentDetection.Contracts/TypedComponent/ComponentType.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/TypedComponent/ComponentType.cs
@@ -53,4 +53,7 @@ public enum ComponentType : byte
 
     [EnumMember]
     DockerReference = 16,
+
+    [EnumMember]
+    Conan = 17,
 }

--- a/src/Microsoft.ComponentDetection.Contracts/TypedComponent/ConanComponent.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/TypedComponent/ConanComponent.cs
@@ -1,0 +1,27 @@
+namespace Microsoft.ComponentDetection.Contracts.TypedComponent;
+
+using PackageUrl;
+
+public class ConanComponent : TypedComponent
+{
+    private ConanComponent()
+    {
+        // reserved for deserialization
+    }
+
+    public ConanComponent(string name, string version)
+    {
+        this.Name = this.ValidateRequiredInput(name, nameof(this.Name), nameof(ComponentType.Conan));
+        this.Version = this.ValidateRequiredInput(version, nameof(this.Version), nameof(ComponentType.Conan));
+    }
+
+    public string Name { get; set; }
+
+    public string Version { get; set; }
+
+    public override ComponentType Type => ComponentType.Conan;
+
+    public override string Id => $"{this.Name} {this.Version} - {this.Type}";
+
+    public override PackageURL PackageUrl => new PackageURL("conan", string.Empty, this.Name, this.Version, null, string.Empty);
+}

--- a/src/Microsoft.ComponentDetection.Detectors/conan/ConanLockComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/conan/ConanLockComponentDetector.cs
@@ -13,8 +13,6 @@ using Microsoft.Extensions.Logging;
 
 public class ConanLockComponentDetector : FileComponentDetector, IDefaultOffComponentDetector
 {
-    private const string ConanLockSearchPattern = "conan.lock";
-
     public ConanLockComponentDetector(
         IComponentStreamEnumerableFactory componentStreamEnumerableFactory,
         IObservableDirectoryWalkerFactory walkerFactory,
@@ -27,7 +25,7 @@ public class ConanLockComponentDetector : FileComponentDetector, IDefaultOffComp
 
     public override string Id => "ConanLock";
 
-    public override IList<string> SearchPatterns => new List<string> { ConanLockSearchPattern };
+    public override IList<string> SearchPatterns => new List<string> { "conan.lock" };
 
     public override IEnumerable<ComponentType> SupportedComponentTypes => new[] { ComponentType.Conan };
 
@@ -40,11 +38,9 @@ public class ConanLockComponentDetector : FileComponentDetector, IDefaultOffComp
         var singleFileComponentRecorder = processRequest.SingleFileComponentRecorder;
         var conanLockFile = processRequest.ComponentStream;
 
-        await Task.CompletedTask;   // Satisfy the async signature of the overridden method.
-
         try
         {
-            var conanLock = JsonSerializer.Deserialize<ConanLock>(conanLockFile.Stream);
+            var conanLock = await JsonSerializer.DeserializeAsync<ConanLock>(conanLockFile.Stream);
             this.RecordLockfileVersion(conanLock.Version);
             if (conanLock.Version != "0.4")
             {

--- a/src/Microsoft.ComponentDetection.Detectors/conan/ConanLockComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/conan/ConanLockComponentDetector.cs
@@ -46,6 +46,11 @@ public class ConanLockComponentDetector : FileComponentDetector, IDefaultOffComp
         {
             var conanLock = JsonSerializer.Deserialize<ConanLock>(conanLockFile.Stream);
             this.RecordLockfileVersion(conanLock.Version);
+            if (conanLock.Version != "0.4")
+            {
+                this.Logger.LogWarning("Unsupported conan.lock file version '{ConanLockVersion}'. Failed to process conan.lock file '{ConanLockLocation}'", conanLock.Version, conanLockFile.Location);
+                return;
+            }
 
             if (!conanLock.HasNodes())
             {
@@ -58,8 +63,8 @@ public class ConanLockComponentDetector : FileComponentDetector, IDefaultOffComp
             if (packagesDictionary.ContainsKey("0"))
             {
                 packagesDictionary.Remove("0", out var rootNode);
-                explicitReferencedDependencies = rootNode.Requires;
-                developmentDependencies = rootNode.BuildRequires;
+                explicitReferencedDependencies = rootNode.Requires ?? Array.Empty<string>();
+                developmentDependencies = rootNode.BuildRequires ?? Array.Empty<string>();
             }
 
             foreach (var (packageIndex, package) in packagesDictionary)

--- a/src/Microsoft.ComponentDetection.Detectors/conan/ConanLockComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/conan/ConanLockComponentDetector.cs
@@ -42,11 +42,6 @@ public class ConanLockComponentDetector : FileComponentDetector, IDefaultOffComp
         {
             var conanLock = await JsonSerializer.DeserializeAsync<ConanLock>(conanLockFile.Stream);
             this.RecordLockfileVersion(conanLock.Version);
-            if (conanLock.Version != "0.4")
-            {
-                this.Logger.LogWarning("Unsupported conan.lock file version '{ConanLockVersion}'. Failed to process conan.lock file '{ConanLockLocation}'", conanLock.Version, conanLockFile.Location);
-                return;
-            }
 
             if (!conanLock.HasNodes())
             {

--- a/src/Microsoft.ComponentDetection.Detectors/conan/ConanLockComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/conan/ConanLockComponentDetector.cs
@@ -1,0 +1,90 @@
+﻿namespace Microsoft.ComponentDetection.Detectors.Conan;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.ComponentDetection.Contracts;
+using Microsoft.ComponentDetection.Contracts.Internal;
+using Microsoft.ComponentDetection.Contracts.TypedComponent;
+using Microsoft.ComponentDetection.Detectors.Conan.Contracts;
+using Microsoft.Extensions.Logging;
+
+public class ConanLockComponentDetector : FileComponentDetector, IDefaultOffComponentDetector
+{
+    private const string ConanLockSearchPattern = "conan.lock";
+
+    public ConanLockComponentDetector(
+        IComponentStreamEnumerableFactory componentStreamEnumerableFactory,
+        IObservableDirectoryWalkerFactory walkerFactory,
+        ILogger<ConanLockComponentDetector> logger)
+    {
+        this.ComponentStreamEnumerableFactory = componentStreamEnumerableFactory;
+        this.Scanner = walkerFactory;
+        this.Logger = logger;
+    }
+
+    public override string Id => "ConanLock";
+
+    public override IList<string> SearchPatterns => new List<string> { ConanLockSearchPattern };
+
+    public override IEnumerable<ComponentType> SupportedComponentTypes => new[] { ComponentType.Conan };
+
+    public override int Version { get; } = 1;
+
+    public override IEnumerable<string> Categories => new List<string> { "Conan" };
+
+    protected override async Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs)
+    {
+        var singleFileComponentRecorder = processRequest.SingleFileComponentRecorder;
+        var conanLockFile = processRequest.ComponentStream;
+
+        await Task.CompletedTask;   // Satisfy the async signature of the overridden method.
+
+        try
+        {
+            var conanLock = JsonSerializer.Deserialize<ConanLock>(conanLockFile.Stream);
+            this.RecordLockfileVersion(conanLock.Version);
+
+            if (!conanLock.HasNodes())
+            {
+                return;
+            }
+
+            var packagesDictionary = conanLock.GraphLock.Nodes;
+            var explicitReferencedDependencies = Array.Empty<string>();
+            string rootComponentId = null;
+            if (packagesDictionary.ContainsKey("0"))
+            {
+                packagesDictionary.Remove("0", out var rootNode);
+                var rootComponent = rootNode.ToComponent();
+                rootComponentId = rootComponent.Id;
+                singleFileComponentRecorder.RegisterUsage(new DetectedComponent(rootComponent), true);
+                explicitReferencedDependencies = rootNode.Requires;
+            }
+
+            foreach (var (packageIndex, package) in packagesDictionary)
+            {
+                var isExplicitReferencedDependency = explicitReferencedDependencies.Contains(packageIndex);
+                var parentId = isExplicitReferencedDependency ? rootComponentId : null;
+                singleFileComponentRecorder.RegisterUsage(new DetectedComponent(package.ToComponent()), isExplicitReferencedDependency, parentId);
+            }
+
+            var packages = packagesDictionary.Values;
+            foreach (var (conanPackageIndex, package) in packagesDictionary)
+            {
+                var parentPackages = packages.Where(package => package.Requires?.Contains(conanPackageIndex) == true);
+                foreach (var parentPackage in parentPackages)
+                {
+                    singleFileComponentRecorder.RegisterUsage(new DetectedComponent(package.ToComponent()), false, parentPackage.ToComponent().Id, isDevelopmentDependency: false);
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            // If something went wrong, just ignore the file
+            this.Logger.LogError(e, "Failed to process conan.lock file '{ConanLockLocation}'", conanLockFile.Location);
+        }
+    }
+}

--- a/src/Microsoft.ComponentDetection.Detectors/conan/ConanLockComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/conan/ConanLockComponentDetector.cs
@@ -54,13 +54,20 @@ public class ConanLockComponentDetector : FileComponentDetector, IDefaultOffComp
             }
 
             var packagesDictionary = conanLock.GraphLock.Nodes;
-            var explicitReferencedDependencies = Array.Empty<string>();
-            var developmentDependencies = Array.Empty<string>();
+            var explicitReferencedDependencies = new HashSet<string>();
+            var developmentDependencies = new HashSet<string>();
             if (packagesDictionary.ContainsKey("0"))
             {
                 packagesDictionary.Remove("0", out var rootNode);
-                explicitReferencedDependencies = rootNode.Requires ?? Array.Empty<string>();
-                developmentDependencies = rootNode.BuildRequires ?? Array.Empty<string>();
+                if (rootNode.Requires != null)
+                {
+                    explicitReferencedDependencies = new HashSet<string>(rootNode.Requires);
+                }
+
+                if (rootNode.BuildRequires != null)
+                {
+                    developmentDependencies = new HashSet<string>(rootNode.BuildRequires);
+                }
             }
 
             foreach (var (packageIndex, package) in packagesDictionary)

--- a/src/Microsoft.ComponentDetection.Detectors/conan/ConanLockComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/conan/ConanLockComponentDetector.cs
@@ -54,12 +54,12 @@ public class ConanLockComponentDetector : FileComponentDetector, IDefaultOffComp
             if (packagesDictionary.ContainsKey("0"))
             {
                 packagesDictionary.Remove("0", out var rootNode);
-                if (rootNode.Requires != null)
+                if (rootNode?.Requires != null)
                 {
                     explicitReferencedDependencies = new HashSet<string>(rootNode.Requires);
                 }
 
-                if (rootNode.BuildRequires != null)
+                if (rootNode?.BuildRequires != null)
                 {
                     developmentDependencies = new HashSet<string>(rootNode.BuildRequires);
                 }

--- a/src/Microsoft.ComponentDetection.Detectors/conan/Contracts/ConanLock.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/conan/Contracts/ConanLock.cs
@@ -1,0 +1,25 @@
+namespace Microsoft.ComponentDetection.Detectors.Conan.Contracts;
+
+using System;
+using System.Text.Json.Serialization;
+
+public class ConanLock
+{
+    [JsonPropertyName("version")]
+    public string Version { get; set; }
+
+    [JsonPropertyName("profile_host")]
+    public string ProfileHost { get; set; }
+
+    [JsonPropertyName("profile_build")]
+    public string ProfileBuild { get; set; }
+
+    [JsonPropertyName("graph_lock")]
+    public ConanLockGraph GraphLock { get; set; }
+
+    public override bool Equals(object obj) => obj is ConanLock conanLock && this.Version == conanLock.Version && this.ProfileHost == conanLock.ProfileHost && this.ProfileBuild == conanLock.ProfileBuild && this.GraphLock.Equals(conanLock.GraphLock);
+
+    public override int GetHashCode() => HashCode.Combine(this.Version, this.ProfileHost, this.ProfileBuild, this.GraphLock);
+
+    internal bool HasNodes() => this.GraphLock?.Nodes?.Count > 0;
+}

--- a/src/Microsoft.ComponentDetection.Detectors/conan/Contracts/ConanLock.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/conan/Contracts/ConanLock.cs
@@ -1,6 +1,5 @@
 namespace Microsoft.ComponentDetection.Detectors.Conan.Contracts;
 
-using System;
 using System.Text.Json.Serialization;
 
 public class ConanLock
@@ -16,10 +15,6 @@ public class ConanLock
 
     [JsonPropertyName("graph_lock")]
     public ConanLockGraph GraphLock { get; set; }
-
-    public override bool Equals(object obj) => obj is ConanLock conanLock && this.Version == conanLock.Version && this.ProfileHost == conanLock.ProfileHost && this.ProfileBuild == conanLock.ProfileBuild && this.GraphLock.Equals(conanLock.GraphLock);
-
-    public override int GetHashCode() => HashCode.Combine(this.Version, this.ProfileHost, this.ProfileBuild, this.GraphLock);
 
     internal bool HasNodes() => this.GraphLock?.Nodes?.Count > 0;
 }

--- a/src/Microsoft.ComponentDetection.Detectors/conan/Contracts/ConanLockGraph.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/conan/Contracts/ConanLockGraph.cs
@@ -1,0 +1,19 @@
+namespace Microsoft.ComponentDetection.Detectors.Conan.Contracts;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Serialization;
+
+public class ConanLockGraph
+{
+    [JsonPropertyName("revisions_enabled")]
+    public bool RevisionsEnabled { get; set; }
+
+    [JsonPropertyName("nodes")]
+    public Dictionary<string, ConanLockNode> Nodes { get; set; }
+
+    public override bool Equals(object obj) => obj is ConanLockGraph graph && this.RevisionsEnabled == graph.RevisionsEnabled && this.Nodes.Count == graph.Nodes.Count && !this.Nodes.Except(graph.Nodes).Any();
+
+    public override int GetHashCode() => HashCode.Combine(this.RevisionsEnabled, this.Nodes);
+}

--- a/src/Microsoft.ComponentDetection.Detectors/conan/Contracts/ConanLockGraph.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/conan/Contracts/ConanLockGraph.cs
@@ -1,8 +1,6 @@
 namespace Microsoft.ComponentDetection.Detectors.Conan.Contracts;
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text.Json.Serialization;
 
 public class ConanLockGraph
@@ -12,8 +10,4 @@ public class ConanLockGraph
 
     [JsonPropertyName("nodes")]
     public Dictionary<string, ConanLockNode> Nodes { get; set; }
-
-    public override bool Equals(object obj) => obj is ConanLockGraph graph && this.RevisionsEnabled == graph.RevisionsEnabled && this.Nodes.Count == graph.Nodes.Count && !this.Nodes.Except(graph.Nodes).Any();
-
-    public override int GetHashCode() => HashCode.Combine(this.RevisionsEnabled, this.Nodes);
 }

--- a/src/Microsoft.ComponentDetection.Detectors/conan/Contracts/ConanLockNode.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/conan/Contracts/ConanLockNode.cs
@@ -1,0 +1,46 @@
+namespace Microsoft.ComponentDetection.Detectors.Conan.Contracts;
+
+using System;
+using System.Linq;
+using System.Text.Json.Serialization;
+using Microsoft.ComponentDetection.Contracts.TypedComponent;
+
+public class ConanLockNode
+{
+    [JsonPropertyName("context")]
+    public string Context { get; set; }
+
+    [JsonPropertyName("modified")]
+    public bool? Modified { get; set; }
+
+    [JsonPropertyName("options")]
+    public string Options { get; set; }
+
+    [JsonPropertyName("package_id")]
+    public string PackageId { get; set; }
+
+    [JsonPropertyName("path")]
+    public string Path { get; set; }
+
+    [JsonPropertyName("prev")]
+    public string Previous { get; set; }
+
+    [JsonPropertyName("ref")]
+    public string Reference { get; set; }
+
+    [JsonPropertyName("requires")]
+    public string[] Requires { get; set; }
+
+    [JsonPropertyName("build_requires")]
+    public string[] BuildRequires { get; set; }
+
+    public override bool Equals(object obj) => obj is ConanLockNode node && this.Context == node.Context && this.Modified == node.Modified && this.Options == node.Options && this.PackageId == node.PackageId && this.Path == node.Path && this.Previous == node.Previous && this.Reference == node.Reference && Enumerable.SequenceEqual(this.Requires, node.Requires);
+
+    public override int GetHashCode() => HashCode.Combine(this.Context, this.Modified, this.Options, this.PackageId, this.Path, this.Previous, this.Reference, this.Requires);
+
+    internal string Name() => this.Reference.Split('/', 2, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).FirstOrDefault("Unknown");
+
+    internal TypedComponent ToComponent() => new ConanComponent(this.Name(), this.Version());
+
+    internal string Version() => this.Reference.Split('/', 2, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).Skip(1).FirstOrDefault("None");
+}

--- a/src/Microsoft.ComponentDetection.Detectors/conan/Contracts/ConanLockNode.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/conan/Contracts/ConanLockNode.cs
@@ -34,10 +34,6 @@ public class ConanLockNode
     [JsonPropertyName("build_requires")]
     public string[] BuildRequires { get; set; }
 
-    public override bool Equals(object obj) => obj is ConanLockNode node && this.Context == node.Context && this.Modified == node.Modified && this.Options == node.Options && this.PackageId == node.PackageId && this.Path == node.Path && this.Previous == node.Previous && this.Reference == node.Reference && Enumerable.SequenceEqual(this.Requires, node.Requires);
-
-    public override int GetHashCode() => HashCode.Combine(this.Context, this.Modified, this.Options, this.PackageId, this.Path, this.Previous, this.Reference, this.Requires);
-
     internal string Name() => this.Reference == null ? string.Empty : this.Reference.Split('/', 2, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).FirstOrDefault("Unknown");
 
     internal TypedComponent ToComponent() => new ConanComponent(this.Name(), this.Version());

--- a/src/Microsoft.ComponentDetection.Detectors/conan/Contracts/ConanLockNode.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/conan/Contracts/ConanLockNode.cs
@@ -7,9 +7,6 @@ using Microsoft.ComponentDetection.Contracts.TypedComponent;
 
 public class ConanLockNode
 {
-    private string[] requires;
-    private string[] buildRequires;
-
     [JsonPropertyName("context")]
     public string Context { get; set; }
 
@@ -32,18 +29,18 @@ public class ConanLockNode
     public string Reference { get; set; }
 
     [JsonPropertyName("requires")]
-    public string[] Requires { get => this.requires; set => this.requires = value ?? Array.Empty<string>(); }
+    public string[] Requires { get; set; }
 
     [JsonPropertyName("build_requires")]
-    public string[] BuildRequires { get => this.buildRequires; set => this.buildRequires = value ?? Array.Empty<string>(); }
+    public string[] BuildRequires { get; set; }
 
     public override bool Equals(object obj) => obj is ConanLockNode node && this.Context == node.Context && this.Modified == node.Modified && this.Options == node.Options && this.PackageId == node.PackageId && this.Path == node.Path && this.Previous == node.Previous && this.Reference == node.Reference && Enumerable.SequenceEqual(this.Requires, node.Requires);
 
     public override int GetHashCode() => HashCode.Combine(this.Context, this.Modified, this.Options, this.PackageId, this.Path, this.Previous, this.Reference, this.Requires);
 
-    internal string Name() => this.Reference.Split('/', 2, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).FirstOrDefault("Unknown");
+    internal string Name() => this.Reference == null ? string.Empty : this.Reference.Split('/', 2, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).FirstOrDefault("Unknown");
 
     internal TypedComponent ToComponent() => new ConanComponent(this.Name(), this.Version());
 
-    internal string Version() => this.Reference.Split('/', 2, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).Skip(1).FirstOrDefault("None");
+    internal string Version() => this.Reference == null ? string.Empty : this.Reference.Split('/', 2, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).Skip(1).FirstOrDefault("None");
 }

--- a/src/Microsoft.ComponentDetection.Detectors/conan/Contracts/ConanLockNode.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/conan/Contracts/ConanLockNode.cs
@@ -7,6 +7,9 @@ using Microsoft.ComponentDetection.Contracts.TypedComponent;
 
 public class ConanLockNode
 {
+    private string[] requires;
+    private string[] buildRequires;
+
     [JsonPropertyName("context")]
     public string Context { get; set; }
 
@@ -29,10 +32,10 @@ public class ConanLockNode
     public string Reference { get; set; }
 
     [JsonPropertyName("requires")]
-    public string[] Requires { get; set; }
+    public string[] Requires { get => this.requires; set => this.requires = value ?? Array.Empty<string>(); }
 
     [JsonPropertyName("build_requires")]
-    public string[] BuildRequires { get; set; }
+    public string[] BuildRequires { get => this.buildRequires; set => this.buildRequires = value ?? Array.Empty<string>(); }
 
     public override bool Equals(object obj) => obj is ConanLockNode node && this.Context == node.Context && this.Modified == node.Modified && this.Options == node.Options && this.PackageId == node.PackageId && this.Path == node.Path && this.Previous == node.Previous && this.Reference == node.Reference && Enumerable.SequenceEqual(this.Requires, node.Requires);
 

--- a/src/Microsoft.ComponentDetection.Orchestrator/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Extensions/ServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@ using Microsoft.ComponentDetection.Common;
 using Microsoft.ComponentDetection.Common.Telemetry;
 using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Detectors.CocoaPods;
+using Microsoft.ComponentDetection.Detectors.Conan;
 using Microsoft.ComponentDetection.Detectors.Dockerfile;
 using Microsoft.ComponentDetection.Detectors.Go;
 using Microsoft.ComponentDetection.Detectors.Gradle;
@@ -76,6 +77,9 @@ public static class ServiceCollectionExtensions
         // Detectors
         // CocoaPods
         services.AddSingleton<IComponentDetector, PodComponentDetector>();
+
+        // Conan
+        services.AddSingleton<IComponentDetector, ConanLockComponentDetector>();
 
         // Conda
         services.AddSingleton<IComponentDetector, CondaLockComponentDetector>();

--- a/test/Microsoft.ComponentDetection.Contracts.Tests/TypedComponentSerializationTests.cs
+++ b/test/Microsoft.ComponentDetection.Contracts.Tests/TypedComponentSerializationTests.cs
@@ -123,6 +123,18 @@ public class TypedComponentSerializationTests
     }
 
     [TestMethod]
+    public void TypedComponent_Serialization_Conan()
+    {
+        TypedComponent tc = new ConanComponent("SomeConanPackage", "1.2.3");
+        var result = JsonConvert.SerializeObject(tc);
+        var deserializedTC = JsonConvert.DeserializeObject<TypedComponent>(result);
+        deserializedTC.Should().BeOfType(typeof(ConanComponent));
+        var conanComponent = (ConanComponent)deserializedTC;
+        conanComponent.Name.Should().Be("SomeConanPackage");
+        conanComponent.Version.Should().Be("1.2.3");
+    }
+
+    [TestMethod]
     public void TypedComponent_Serialization_Pip()
     {
         TypedComponent tc = new PipComponent("SomePipPackage", "1.2.3");

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/ConanLockComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/ConanLockComponentDetectorTests.cs
@@ -161,14 +161,7 @@ public class ConanLockComponentDetectorTests : BaseDetectorTest<ConanLockCompone
 
         rootComponents.ForEach(rootComponentId =>
         {
-            try
-            {
-                graph.IsComponentExplicitlyReferenced(rootComponentId).Should().BeTrue();
-            }
-            catch
-            {
-                Assert.Fail($"Expected Component to be explicitly referenced but it is not: {rootComponentId}");
-            }
+                graph.IsComponentExplicitlyReferenced(rootComponentId).Should().BeTrue($"Expected Component to be explicitly referenced but it is not: {rootComponentId}");
         });
 
         // components without any dependencies

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/ConanLockComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/ConanLockComponentDetectorTests.cs
@@ -242,7 +242,7 @@ public class ConanLockComponentDetectorTests : BaseDetectorTest<ConanLockCompone
         // Verify all packages were detected
         foreach (var expectedPackage in packageVersions.Keys)
         {
-            Assert.IsTrue(componentNames.Contains(expectedPackage));
+            componentNames.Should().Contain(expectedPackage);
         }
     }
 

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/ConanLockComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/ConanLockComponentDetectorTests.cs
@@ -161,7 +161,7 @@ public class ConanLockComponentDetectorTests : BaseDetectorTest<ConanLockCompone
 
         rootComponents.ForEach(rootComponentId =>
         {
-                graph.IsComponentExplicitlyReferenced(rootComponentId).Should().BeTrue($"Expected Component to be explicitly referenced but it is not: {rootComponentId}");
+            graph.IsComponentExplicitlyReferenced(rootComponentId).Should().BeTrue($"Expected Component to be explicitly referenced but it is not: {rootComponentId}");
         });
 
         // components without any dependencies

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/ConanLockComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/ConanLockComponentDetectorTests.cs
@@ -254,6 +254,6 @@ public class ConanLockComponentDetectorTests : BaseDetectorTest<ConanLockCompone
             .ExecuteDetectorAsync();
 
         result.ResultCode.Should().Be(ProcessingResultCode.Success);
-        componentRecorder.GetDetectedComponents().Count().Should().Be(0);
+        componentRecorder.GetDetectedComponents().Should().BeEmpty();
     }
 }

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/ConanLockComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/ConanLockComponentDetectorTests.cs
@@ -161,14 +161,13 @@ public class ConanLockComponentDetectorTests : BaseDetectorTest<ConanLockCompone
             .ExecuteDetectorAsync();
 
         Assert.AreEqual(ProcessingResultCode.Success, result.ResultCode);
-        Assert.AreEqual(7, componentRecorder.GetDetectedComponents().Count());
+        Assert.AreEqual(6, componentRecorder.GetDetectedComponents().Count());
 
         var graph = componentRecorder.GetDependencyGraphsByLocation().Values.First(); // There should only be 1
 
         // Verify explicitly referenced roots
         var rootComponents = new List<string>
         {
-            "MyConanProject None - Conan",
             "libabc 1.2.12#someHashOfLibAbc - Conan",
             "libawesomelibrary 3.2.1#someHashOfLibAwesomeLibrary - Conan",
             "libanotherlibrary1 2.3.4#someHashOfLibAnotherLibrary1 - Conan",
@@ -211,11 +210,10 @@ public class ConanLockComponentDetectorTests : BaseDetectorTest<ConanLockCompone
             .ExecuteDetectorAsync();
 
         Assert.AreEqual(ProcessingResultCode.Success, result.ResultCode);
-        Assert.AreEqual(7, componentRecorder.GetDetectedComponents().Count());
+        Assert.AreEqual(6, componentRecorder.GetDetectedComponents().Count());
 
         IDictionary<string, string> packageVersions = new Dictionary<string, string>()
         {
-            { "MyConanProject", "None" },
             { "libabc", "1.2.12#someHashOfLibAbc" },
             { "libawesomelibrary", "3.2.1#someHashOfLibAwesomeLibrary" },
             { "libanotherlibrary1", "2.3.4#someHashOfLibAnotherLibrary1" },
@@ -226,13 +224,12 @@ public class ConanLockComponentDetectorTests : BaseDetectorTest<ConanLockCompone
 
         IDictionary<string, ISet<string>> packageDependencyRoots = new Dictionary<string, ISet<string>>()
         {
-            { "MyConanProject", new HashSet<string>() { "MyConanProject" } },
-            { "libabc", new HashSet<string>() { "libabc", "MyConanProject", "libawesomelibrary" } },
-            { "libawesomelibrary", new HashSet<string>() { "libawesomelibrary", "MyConanProject" } },
-            { "libanotherlibrary1", new HashSet<string>() { "libanotherlibrary1", "MyConanProject" } },
-            { "libanotherlibrary2", new HashSet<string>() { "libanotherlibrary2", "MyConanProject", "libanotherlibrary1" } },
-            { "libanotherlibrary3", new HashSet<string>() { "libanotherlibrary3", "MyConanProject", "libanotherlibrary1", "libanotherlibrary2" } },
-            { "libanotherlibrary4", new HashSet<string>() { "libanotherlibrary4", "MyConanProject", "libanotherlibrary1" } },
+            { "libabc", new HashSet<string>() { "libabc", "libawesomelibrary" } },
+            { "libawesomelibrary", new HashSet<string>() { "libawesomelibrary" } },
+            { "libanotherlibrary1", new HashSet<string>() { "libanotherlibrary1" } },
+            { "libanotherlibrary2", new HashSet<string>() { "libanotherlibrary2", "libanotherlibrary1" } },
+            { "libanotherlibrary3", new HashSet<string>() { "libanotherlibrary3", "libanotherlibrary1", "libanotherlibrary2" } },
+            { "libanotherlibrary4", new HashSet<string>() { "libanotherlibrary4", "libanotherlibrary1" } },
         };
 
         ISet<string> componentNames = new HashSet<string>();
@@ -269,6 +266,6 @@ public class ConanLockComponentDetectorTests : BaseDetectorTest<ConanLockCompone
             .ExecuteDetectorAsync();
 
         Assert.AreEqual(ProcessingResultCode.Success, result.ResultCode);
-        Assert.AreEqual(1, componentRecorder.GetDetectedComponents().Count());
+        Assert.AreEqual(0, componentRecorder.GetDetectedComponents().Count());
     }
 }

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/ConanLockComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/ConanLockComponentDetectorTests.cs
@@ -96,6 +96,26 @@ public class ConanLockComponentDetectorTests : BaseDetectorTest<ConanLockCompone
 }
 ";
 
+    private readonly string testConanLockStringWithNullValueForRootNode = @"{
+ ""graph_lock"": {
+  ""nodes"": {
+   ""0"": null,
+   ""1"": {
+    ""ref"": ""libabc/1.2.12#someHashOfLibAbc"",
+    ""options"": ""someOptionsString"",
+    ""package_id"": ""packageIdOfLibAbc"",
+    ""prev"": ""someHashOfLibAbc"",
+    ""context"": ""host""
+   }
+  },
+  ""revisions_enabled"": true
+ },
+ ""version"": ""0.4"",
+ ""profile_host"": ""someLongProfileHostSettingsString\n"",
+ ""profile_build"": ""someLongProfileBuildSettingsString\n""
+}
+";
+
     private readonly string testConanLockNoDependenciesString = @"{
  ""graph_lock"": {
   ""nodes"": {
@@ -161,6 +181,20 @@ public class ConanLockComponentDetectorTests : BaseDetectorTest<ConanLockCompone
         var a = graph.GetDependenciesForComponent("libanotherlibrary1 2.3.4#someHashOfLibAnotherLibrary1 - Conan");
         graph.GetDependenciesForComponent("libanotherlibrary1 2.3.4#someHashOfLibAnotherLibrary1 - Conan").Should().BeEquivalentTo(new[] { "libanotherlibrary2 3.4.5#someHashOfLibAnotherLibrary2 - Conan", "libanotherlibrary4 5.6.7#someHashOfLibAnotherLibrary4 - Conan" });
         graph.GetDependenciesForComponent("libanotherlibrary2 3.4.5#someHashOfLibAnotherLibrary2 - Conan").Should().BeEquivalentTo(new[] { "libanotherlibrary3 4.5.6#someHashOfLibAnotherLibrary3 - Conan" });
+    }
+
+    [TestMethod]
+    public async Task TestDetectionForConanLockFileWithNullValuesForRootNodeAsync()
+    {
+        var (result, componentRecorder) = await this.DetectorTestUtility
+            .WithFile("Conan.lock", this.testConanLockStringWithNullValueForRootNode)
+            .ExecuteDetectorAsync();
+
+        result.ResultCode.Should().Be(ProcessingResultCode.Success);
+        componentRecorder.GetDetectedComponents().Count().Should().Be(1);
+
+        (componentRecorder.GetDetectedComponents().First().Component as ConanComponent).Name.Should().Be("libabc");
+        (componentRecorder.GetDetectedComponents().First().Component as ConanComponent).Version.Should().Be("1.2.12#someHashOfLibAbc");
     }
 
     [TestMethod]

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/ConanLockComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/ConanLockComponentDetectorTests.cs
@@ -3,13 +3,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.Json;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.ComponentDetection.Detectors.Conan;
-using Microsoft.ComponentDetection.Detectors.Conan.Contracts;
 using Microsoft.ComponentDetection.Detectors.Tests.Utilities;
 using Microsoft.ComponentDetection.TestsUtilities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -117,51 +115,14 @@ public class ConanLockComponentDetectorTests : BaseDetectorTest<ConanLockCompone
 ";
 
     [TestMethod]
-    public void TestConanLock_SerializeDeserialize()
-    {
-        var sampleConanLock = new ConanLock
-        {
-            Version = "0.4",
-            ProfileBuild = "someProfileBuild",
-            GraphLock = new ConanLockGraph
-            {
-                RevisionsEnabled = true,
-                Nodes = new Dictionary<string, ConanLockNode>()
-                {
-                    {
-                        "0", new ConanLockNode
-                        {
-                            Context = string.Empty,
-                            Modified = false,
-                            Options = string.Empty,
-                            PackageId = "SomePackageId",
-                            Path = "D:/SomePath",
-                            Previous = "SomeOtherId",
-                            Reference = string.Empty,
-                            Requires = new[] { "0" },
-                        }
-                    },
-                },
-            },
-        };
-        var jsonString = JsonSerializer.Serialize(sampleConanLock, new JsonSerializerOptions { DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault });
-        var expectedJsonString = @"{""version"":""0.4"",""profile_build"":""someProfileBuild"",""graph_lock"":{""revisions_enabled"":true,""nodes"":{""0"":{""context"":"""",""modified"":false,""options"":"""",""package_id"":""SomePackageId"",""path"":""D:/SomePath"",""prev"":""SomeOtherId"",""ref"":"""",""requires"":[""0""]}}}}";
-
-        Assert.AreEqual(expectedJsonString, jsonString);
-
-        var deserialisedConanLock = JsonSerializer.Deserialize<ConanLock>(expectedJsonString);
-        Assert.AreEqual(sampleConanLock, deserialisedConanLock);
-    }
-
-    [TestMethod]
     public async Task TestGraphIsCorrectAsync()
     {
         var (result, componentRecorder) = await this.DetectorTestUtility
             .WithFile("Conan.lock", this.testConanLockString)
             .ExecuteDetectorAsync();
 
-        Assert.AreEqual(ProcessingResultCode.Success, result.ResultCode);
-        Assert.AreEqual(6, componentRecorder.GetDetectedComponents().Count());
+        result.ResultCode.Should().Be(ProcessingResultCode.Success);
+        componentRecorder.GetDetectedComponents().Count().Should().Be(6);
 
         var graph = componentRecorder.GetDependencyGraphsByLocation().Values.First(); // There should only be 1
 
@@ -209,8 +170,8 @@ public class ConanLockComponentDetectorTests : BaseDetectorTest<ConanLockCompone
             .WithFile("Conan.lock", this.testConanLockString)
             .ExecuteDetectorAsync();
 
-        Assert.AreEqual(ProcessingResultCode.Success, result.ResultCode);
-        Assert.AreEqual(6, componentRecorder.GetDetectedComponents().Count());
+        result.ResultCode.Should().Be(ProcessingResultCode.Success);
+        componentRecorder.GetDetectedComponents().Count().Should().Be(6);
 
         IDictionary<string, string> packageVersions = new Dictionary<string, string>()
         {
@@ -239,7 +200,7 @@ public class ConanLockComponentDetectorTests : BaseDetectorTest<ConanLockCompone
             var packageName = (discoveredComponent.Component as ConanComponent).Name;
 
             // Verify version
-            Assert.AreEqual(packageVersions[packageName], (discoveredComponent.Component as ConanComponent).Version);
+            (discoveredComponent.Component as ConanComponent).Version.Should().Be(packageVersions[packageName]);
 
             var dependencyRoots = new HashSet<string>();
 
@@ -265,7 +226,7 @@ public class ConanLockComponentDetectorTests : BaseDetectorTest<ConanLockCompone
             .WithFile("conan.lock", this.testConanLockNoDependenciesString)
             .ExecuteDetectorAsync();
 
-        Assert.AreEqual(ProcessingResultCode.Success, result.ResultCode);
-        Assert.AreEqual(0, componentRecorder.GetDetectedComponents().Count());
+        result.ResultCode.Should().Be(ProcessingResultCode.Success);
+        componentRecorder.GetDetectedComponents().Count().Should().Be(0);
     }
 }

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/ConanLockComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/ConanLockComponentDetectorTests.cs
@@ -1,0 +1,274 @@
+﻿namespace Microsoft.ComponentDetection.Detectors.Tests;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.ComponentDetection.Contracts;
+using Microsoft.ComponentDetection.Contracts.TypedComponent;
+using Microsoft.ComponentDetection.Detectors.Conan;
+using Microsoft.ComponentDetection.Detectors.Conan.Contracts;
+using Microsoft.ComponentDetection.Detectors.Tests.Utilities;
+using Microsoft.ComponentDetection.TestsUtilities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[TestClass]
+[TestCategory("Governance/All")]
+[TestCategory("Governance/ComponentDetection")]
+public class ConanLockComponentDetectorTests : BaseDetectorTest<ConanLockComponentDetector>
+{
+    private readonly string testConanLockString = @"{
+ ""graph_lock"": {
+  ""nodes"": {
+   ""0"": {
+    ""ref"": ""MyConanProject/None"",
+    ""options"": ""SomeLongOptionsString"",
+    ""requires"": [
+     ""1"",
+     ""2"",
+     ""3"",
+     ""4"",
+     ""5"",
+     ""6""
+    ],
+    ""path"": ""../conanfile.py"",
+    ""context"": ""host""
+   },
+   ""1"": {
+    ""ref"": ""libabc/1.2.12#someHashOfLibAbc"",
+    ""options"": ""someOptionsString"",
+    ""package_id"": ""packageIdOfLibAbc"",
+    ""prev"": ""someHashOfLibAbc"",
+    ""context"": ""host""
+   },
+   ""2"": {
+    ""ref"": ""libawesomelibrary/3.2.1#someHashOfLibAwesomeLibrary"",
+    ""options"": ""someOptionsString"",
+    ""package_id"": ""packageIdOfLibAwesomeLibrary"",
+    ""prev"": ""someHashOfLibAwesomeLibrary"",
+    ""requires"": [
+        ""1""
+    ],
+    ""context"": ""host""
+    },
+   ""3"": {
+    ""ref"": ""libanotherlibrary1/2.3.4#someHashOfLibAnotherLibrary1"",
+    ""options"": ""someOptionsString"",
+    ""package_id"": ""packageIdOfLibAnotherLibrary1"",
+    ""prev"": ""someHashOfLibAnotherLibrary1"",
+    ""requires"": [
+     ""4"",
+     ""6""
+    ],
+    ""context"": ""host""
+    },
+   ""4"": {
+    ""ref"": ""libanotherlibrary2/3.4.5#someHashOfLibAnotherLibrary2"",
+    ""options"": ""someOptionsString"",
+    ""package_id"": ""packageIdOfLibAnotherLibrary2"",
+    ""prev"": ""someHashOfLibAnotherLibrary2"",
+    ""requires"": [
+     ""5""
+    ],
+    ""context"": ""host""
+    },
+   ""5"": {
+    ""ref"": ""libanotherlibrary3/4.5.6#someHashOfLibAnotherLibrary3"",
+    ""options"": """",
+    ""package_id"": ""packageIdOfLibAnotherLibrary3"",
+    ""prev"": ""someHashOfLibAnotherLibrary3"",
+    ""context"": ""host""
+    },
+   ""6"": {
+    ""ref"": ""libanotherlibrary4/5.6.7#someHashOfLibAnotherLibrary4"",
+    ""options"": ""someOptionsString"",
+    ""package_id"": ""packageIdOfLibAnotherLibrary4"",
+    ""prev"": ""someHashOfLibAnotherLibrary4"",
+    ""modified"": true,
+    ""context"": ""host""
+    }
+  },
+  ""revisions_enabled"": true
+ },
+ ""version"": ""0.4"",
+ ""profile_host"": ""someLongProfileHostSettingsString\n"",
+ ""profile_build"": ""someLongProfileBuildSettingsString\n""
+}
+";
+
+    private readonly string testConanLockNoDependenciesString = @"{
+ ""graph_lock"": {
+  ""nodes"": {
+   ""0"": {
+    ""ref"": ""MyConanProject/None"",
+    ""options"": ""SomeLongOptionsString"",
+    ""path"": ""../conanfile.py"",
+    ""context"": ""host""
+   }
+  },
+  ""revisions_enabled"": true
+ },
+ ""version"": ""0.4"",
+ ""profile_host"": ""someLongProfileHostSettingsString\n"",
+ ""profile_build"": ""someLongProfileBuildSettingsString\n""
+}
+";
+
+    [TestMethod]
+    public void TestConanLock_SerializeDeserialize()
+    {
+        var sampleConanLock = new ConanLock
+        {
+            Version = "0.4",
+            ProfileBuild = "someProfileBuild",
+            GraphLock = new ConanLockGraph
+            {
+                RevisionsEnabled = true,
+                Nodes = new Dictionary<string, ConanLockNode>()
+                {
+                    {
+                        "0", new ConanLockNode
+                        {
+                            Context = string.Empty,
+                            Modified = false,
+                            Options = string.Empty,
+                            PackageId = "SomePackageId",
+                            Path = "D:/SomePath",
+                            Previous = "SomeOtherId",
+                            Reference = string.Empty,
+                            Requires = new[] { "0" },
+                        }
+                    },
+                },
+            },
+        };
+        var jsonString = JsonSerializer.Serialize(sampleConanLock, new JsonSerializerOptions { DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault });
+        var expectedJsonString = @"{""version"":""0.4"",""profile_build"":""someProfileBuild"",""graph_lock"":{""revisions_enabled"":true,""nodes"":{""0"":{""context"":"""",""modified"":false,""options"":"""",""package_id"":""SomePackageId"",""path"":""D:/SomePath"",""prev"":""SomeOtherId"",""ref"":"""",""requires"":[""0""]}}}}";
+
+        Assert.AreEqual(expectedJsonString, jsonString);
+
+        var deserialisedConanLock = JsonSerializer.Deserialize<ConanLock>(expectedJsonString);
+        Assert.AreEqual(sampleConanLock, deserialisedConanLock);
+    }
+
+    [TestMethod]
+    public async Task TestGraphIsCorrectAsync()
+    {
+        var (result, componentRecorder) = await this.DetectorTestUtility
+            .WithFile("Conan.lock", this.testConanLockString)
+            .ExecuteDetectorAsync();
+
+        Assert.AreEqual(ProcessingResultCode.Success, result.ResultCode);
+        Assert.AreEqual(7, componentRecorder.GetDetectedComponents().Count());
+
+        var graph = componentRecorder.GetDependencyGraphsByLocation().Values.First(); // There should only be 1
+
+        // Verify explicitly referenced roots
+        var rootComponents = new List<string>
+        {
+            "MyConanProject None - Conan",
+            "libabc 1.2.12#someHashOfLibAbc - Conan",
+            "libawesomelibrary 3.2.1#someHashOfLibAwesomeLibrary - Conan",
+            "libanotherlibrary1 2.3.4#someHashOfLibAnotherLibrary1 - Conan",
+            "libanotherlibrary2 3.4.5#someHashOfLibAnotherLibrary2 - Conan",
+            "libanotherlibrary3 4.5.6#someHashOfLibAnotherLibrary3 - Conan",
+            "libanotherlibrary4 5.6.7#someHashOfLibAnotherLibrary4 - Conan",
+        };
+
+        var enumerable = graph.GetComponents().ToList();
+
+        rootComponents.ForEach(rootComponentId =>
+        {
+            try
+            {
+                graph.IsComponentExplicitlyReferenced(rootComponentId).Should().BeTrue();
+            }
+            catch
+            {
+                Assert.Fail($"Expected Component to be explicitly referenced but it is not: {rootComponentId}");
+            }
+        });
+
+        // components without any dependencies
+        graph.GetDependenciesForComponent("libabc 1.2.12#someHashOfLibAbc - Conan").Should().BeEmpty();
+        graph.GetDependenciesForComponent("libanotherlibrary3 4.5.6#someHashOfLibAnotherLibrary3 - Conan").Should().BeEmpty();
+        graph.GetDependenciesForComponent("libanotherlibrary4 5.6.7#someHashOfLibAnotherLibrary4 - Conan").Should().BeEmpty();
+
+        // Verify dependencies for other dependencies
+        graph.GetDependenciesForComponent("libawesomelibrary 3.2.1#someHashOfLibAwesomeLibrary - Conan").Should().BeEquivalentTo(new[] { "libabc 1.2.12#someHashOfLibAbc - Conan" });
+        var a = graph.GetDependenciesForComponent("libanotherlibrary1 2.3.4#someHashOfLibAnotherLibrary1 - Conan");
+        graph.GetDependenciesForComponent("libanotherlibrary1 2.3.4#someHashOfLibAnotherLibrary1 - Conan").Should().BeEquivalentTo(new[] { "libanotherlibrary2 3.4.5#someHashOfLibAnotherLibrary2 - Conan", "libanotherlibrary4 5.6.7#someHashOfLibAnotherLibrary4 - Conan" });
+        graph.GetDependenciesForComponent("libanotherlibrary2 3.4.5#someHashOfLibAnotherLibrary2 - Conan").Should().BeEquivalentTo(new[] { "libanotherlibrary3 4.5.6#someHashOfLibAnotherLibrary3 - Conan" });
+    }
+
+    [TestMethod]
+    public async Task TestConanDetectorAsync()
+    {
+        var (result, componentRecorder) = await this.DetectorTestUtility
+            .WithFile("Conan.lock", this.testConanLockString)
+            .ExecuteDetectorAsync();
+
+        Assert.AreEqual(ProcessingResultCode.Success, result.ResultCode);
+        Assert.AreEqual(7, componentRecorder.GetDetectedComponents().Count());
+
+        IDictionary<string, string> packageVersions = new Dictionary<string, string>()
+        {
+            { "MyConanProject", "None" },
+            { "libabc", "1.2.12#someHashOfLibAbc" },
+            { "libawesomelibrary", "3.2.1#someHashOfLibAwesomeLibrary" },
+            { "libanotherlibrary1", "2.3.4#someHashOfLibAnotherLibrary1" },
+            { "libanotherlibrary2", "3.4.5#someHashOfLibAnotherLibrary2" },
+            { "libanotherlibrary3", "4.5.6#someHashOfLibAnotherLibrary3" },
+            { "libanotherlibrary4", "5.6.7#someHashOfLibAnotherLibrary4" },
+        };
+
+        IDictionary<string, ISet<string>> packageDependencyRoots = new Dictionary<string, ISet<string>>()
+        {
+            { "MyConanProject", new HashSet<string>() { "MyConanProject" } },
+            { "libabc", new HashSet<string>() { "libabc", "MyConanProject", "libawesomelibrary" } },
+            { "libawesomelibrary", new HashSet<string>() { "libawesomelibrary", "MyConanProject" } },
+            { "libanotherlibrary1", new HashSet<string>() { "libanotherlibrary1", "MyConanProject" } },
+            { "libanotherlibrary2", new HashSet<string>() { "libanotherlibrary2", "MyConanProject", "libanotherlibrary1" } },
+            { "libanotherlibrary3", new HashSet<string>() { "libanotherlibrary3", "MyConanProject", "libanotherlibrary1", "libanotherlibrary2" } },
+            { "libanotherlibrary4", new HashSet<string>() { "libanotherlibrary4", "MyConanProject", "libanotherlibrary1" } },
+        };
+
+        ISet<string> componentNames = new HashSet<string>();
+        foreach (var discoveredComponent in componentRecorder.GetDetectedComponents())
+        {
+            // Verify each package has the right information
+            var packageName = (discoveredComponent.Component as ConanComponent).Name;
+
+            // Verify version
+            Assert.AreEqual(packageVersions[packageName], (discoveredComponent.Component as ConanComponent).Version);
+
+            var dependencyRoots = new HashSet<string>();
+
+            componentRecorder.AssertAllExplicitlyReferencedComponents(
+                discoveredComponent.Component.Id,
+                packageDependencyRoots[packageName].Select(expectedRoot =>
+                    new Func<ConanComponent, bool>(parentComponent => parentComponent.Name == expectedRoot)).ToArray());
+
+            componentNames.Add(packageName);
+        }
+
+        // Verify all packages were detected
+        foreach (var expectedPackage in packageVersions.Keys)
+        {
+            Assert.IsTrue(componentNames.Contains(expectedPackage));
+        }
+    }
+
+    [TestMethod]
+    public async Task TestConanDetector_SupportNoDependenciesAsync()
+    {
+        var (result, componentRecorder) = await this.DetectorTestUtility
+            .WithFile("conan.lock", this.testConanLockNoDependenciesString)
+            .ExecuteDetectorAsync();
+
+        Assert.AreEqual(ProcessingResultCode.Success, result.ResultCode);
+        Assert.AreEqual(1, componentRecorder.GetDetectedComponents().Count());
+    }
+}

--- a/test/Microsoft.ComponentDetection.VerificationTests/resources/VerificationTest.ps1
+++ b/test/Microsoft.ComponentDetection.VerificationTests/resources/VerificationTest.ps1
@@ -38,14 +38,14 @@ function main()
     Set-Location ((Get-Item  $repoPath).FullName + "\src\Microsoft.ComponentDetection")
     dotnet run scan --SourceDirectory $verificationTestRepo --Output $output `
                     --DockerImagesToScan $dockerImagesToScan `
-                    --DetectorArgs DockerReference=EnableIfDefaultOff,SPDX22SBOM=EnableIfDefaultOff,CondaLock=EnableIfDefaultOff
+                    --DetectorArgs DockerReference=EnableIfDefaultOff,SPDX22SBOM=EnableIfDefaultOff,CondaLock=EnableIfDefaultOff,ConanLock=EnableIfDefaultOff
 
     Set-Location $CDRelease
     dotnet restore
     Set-Location ($CDRelease + "\src\Microsoft.ComponentDetection")
     dotnet run scan --SourceDirectory $verificationTestRepo --Output $releaseOutput `
                     --DockerImagesToScan $dockerImagesToScan `
-                    --DetectorArgs DockerReference=EnableIfDefaultOff,SPDX22SBOM=EnableIfDefaultOff,CondaLock=EnableIfDefaultOff
+                    --DetectorArgs DockerReference=EnableIfDefaultOff,SPDX22SBOM=EnableIfDefaultOff,CondaLock=EnableIfDefaultOff,ConanLock=EnableIfDefaultOff
 
     $env:GITHUB_OLD_ARTIFACTS_DIR = $releaseOutput
     $env:GITHUB_NEW_ARTIFACTS_DIR = $output

--- a/test/Microsoft.ComponentDetection.VerificationTests/resources/conan/conanPythonFile/conan.lock
+++ b/test/Microsoft.ComponentDetection.VerificationTests/resources/conan/conanPythonFile/conan.lock
@@ -1,0 +1,77 @@
+{
+ "graph_lock": {
+  "nodes": {
+   "0": {
+    "ref": "MyAwesomeConanProject/1.2.5",
+    "options": "",
+    "requires": [
+     "1"
+    ],
+    "build_requires": [
+     "6"
+    ],
+    "path": "conanfile.py",
+    "context": "host"
+   },
+   "1": {
+    "ref": "boost/1.82.0",
+    "options": "",
+    "package_id": "dd7f5f958c7381cfd81e611a16062de0c827160a",
+    "prev": "0",
+    "modified": true,
+    "requires": [
+     "2",
+     "3",
+     "4"
+    ],
+    "build_requires": [
+     "5"
+    ],
+    "context": "host"
+   },
+   "2": {
+    "ref": "zlib/1.2.13",
+    "options": "",
+    "package_id": "240c2182163325b213ca6886a7614c8ed2bf1738",
+    "prev": "0",
+    "modified": true,
+    "context": "host"
+   },
+   "3": {
+    "ref": "bzip2/1.0.8",
+    "options": "",
+    "package_id": "238a93dc813ca1550968399f1f8925565feeff8e",
+    "prev": "0",
+    "modified": true,
+    "context": "host"
+   },
+   "4": {
+    "ref": "libbacktrace/cci.20210118",
+    "options": "",
+    "package_id": "240c2182163325b213ca6886a7614c8ed2bf1738",
+    "prev": "0",
+    "modified": true,
+    "context": "host"
+   },
+   "5": {
+    "ref": "b2/4.9.6",
+    "options": "",
+    "package_id": "a5ad5696abf650a25eea8f377806b3d5fe234e6e",
+    "prev": "0",
+    "modified": true,
+    "context": "host"
+   },
+   "6": {
+    "ref": "gtest/1.8.1",
+    "options": "",
+    "package_id": "fb16a498e820fb09d04ff9374a782b5b21da0601",
+    "prev": "0",
+    "modified": true,
+    "context": "host"
+   }
+  },
+  "revisions_enabled": false
+ },
+ "version": "0.4",
+ "profile_host": "\n"
+}

--- a/test/Microsoft.ComponentDetection.VerificationTests/resources/conan/conanPythonFile/conanfile.py
+++ b/test/Microsoft.ComponentDetection.VerificationTests/resources/conan/conanPythonFile/conanfile.py
@@ -1,0 +1,11 @@
+from conans import ConanFile
+
+class MyAwesome(ConanFile):
+    name = "MyAwesomeConanProject"
+    version = "1.2.5"
+
+    def requirements(self):
+        self.requires("boost/1.82.0")
+
+    def build_requirements(self):
+        self.tool_requires("gtest/1.8.1")

--- a/test/Microsoft.ComponentDetection.VerificationTests/resources/conan/conanTextFile/conan.lock
+++ b/test/Microsoft.ComponentDetection.VerificationTests/resources/conan/conanTextFile/conan.lock
@@ -1,0 +1,60 @@
+{
+ "graph_lock": {
+  "nodes": {
+   "0": {
+    "options": "",
+    "requires": [
+     "1"
+    ],
+    "build_requires": [
+     "5"
+    ],
+    "path": "conanfile.txt",
+    "context": "host"
+   },
+   "1": {
+    "ref": "boost/1.82.0",
+    "options": "",
+    "package_id": "dd7f5f958c7381cfd81e611a16062de0c827160a",
+    "prev": "0",
+    "requires": [
+     "2",
+     "3",
+     "4"
+    ],
+    "context": "host"
+   },
+   "2": {
+    "ref": "zlib/1.2.13",
+    "options": "",
+    "package_id": "240c2182163325b213ca6886a7614c8ed2bf1738",
+    "prev": "0",
+    "context": "host"
+   },
+   "3": {
+    "ref": "bzip2/1.0.8",
+    "options": "",
+    "package_id": "238a93dc813ca1550968399f1f8925565feeff8e",
+    "prev": "0",
+    "context": "host"
+   },
+   "4": {
+    "ref": "libbacktrace/cci.20210118",
+    "options": "",
+    "package_id": "240c2182163325b213ca6886a7614c8ed2bf1738",
+    "prev": "0",
+    "context": "host"
+   },
+   "5": {
+    "ref": "gtest/1.8.1",
+    "options": "",
+    "package_id": "fb16a498e820fb09d04ff9374a782b5b21da0601",
+    "prev": "0",
+    "context": "host"
+   }
+  },
+  "revisions_enabled": false
+ },
+ "version": "0.4",
+ "profile_host": "\n"
+}

--- a/test/Microsoft.ComponentDetection.VerificationTests/resources/conan/conanTextFile/conanfile.txt
+++ b/test/Microsoft.ComponentDetection.VerificationTests/resources/conan/conanTextFile/conanfile.txt
@@ -1,0 +1,5 @@
+[requires]
+boost/1.82.0
+
+[tool_requires]
+gtest/1.8.1


### PR DESCRIPTION
This PR adds support for identifying components from conan.lock files created by conan package manager. 

Doesn't require conan package manager to have been installed.