### PR TITLE
Revert "chore(deps): update dependency moq to v4.20.1"

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,7 +22,7 @@
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.6.40" />
     <PackageVersion Include="DotNet.Glob" Version="2.1.1" />
     <PackageVersion Include="MinVer" Version="4.3.0" />
-    <PackageVersion Include="Moq" Version="4.20.1" />
+    <PackageVersion Include="Moq" Version="4.18.4" />
     <PackageVersion Include="morelinq" Version="3.4.2" />
     <PackageVersion Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageVersion Include="MSTest.TestFramework" Version="3.1.1" />


### PR DESCRIPTION
Reverts microsoft/component-detection#698

Spyware. See https://github.com/moq/moq/issues/1372