### PR TITLE
docs(readme): Fix README dotnet run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ $ git clone https://github.com/microsoft/component-detection
 $ cd component-detection 
 
 # Run the app
-$ dotnet run 
+$ dotnet run --project ".\src\Microsoft.ComponentDetection\Microsoft.ComponentDetection.csproj" scan --SourceDirectory [PATH TO THE REPO TO SCAN]
 ```
 
 View the [detector arguments](docs/detector-arguments.md) for more information on how to use the tool.

--- a/docs/detector-arguments.md
+++ b/docs/detector-arguments.md
@@ -1,7 +1,7 @@
 # Detector arguments
 
 ``` shell
-dotnet run -p "src\Microsoft.ComponentDetection\Microsoft.ComponentDetection.csproj" help scan
+dotnet run --project "src\Microsoft.ComponentDetection\Microsoft.ComponentDetection.csproj" help scan
 ```
 
 ```


### PR DESCRIPTION
Adding instructions to specify the ComponentDetection project with `dotnet run` in the README. 

`-p` is also deprecated in favor of `--project`.