### PR TITLE
feat: record telemetry on Go fallback detection strategy

### DIFF
--- a/src/Microsoft.ComponentDetection.Common/Telemetry/Records/GoGraphTelemetryRecord.cs
+++ b/src/Microsoft.ComponentDetection.Common/Telemetry/Records/GoGraphTelemetryRecord.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.ComponentDetection.Common.Telemetry.Records;
+namespace Microsoft.ComponentDetection.Common.Telemetry.Records;
 
 public class GoGraphTelemetryRecord : BaseDetectionTelemetryRecord
 {
@@ -9,4 +9,10 @@ public class GoGraphTelemetryRecord : BaseDetectionTelemetryRecord
     public bool IsGoAvailable { get; set; }
 
     public bool WasGraphSuccessful { get; set; }
+
+    public bool WasGoCliDisabled { get; set; }
+
+    public bool WasGoCliNotFound { get; set; }
+
+    public bool WasGoFallbackStrategyUsed { get; set; }
 }


### PR DESCRIPTION
Extending the `GoGraph` telemetry object to report on when and why we are using the Go fallback detection strategy so that we may assess strategy distribution and reasoning for fallback strategy use. 