### PR TITLE
ci(release): ignore asset upload failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,7 @@ jobs:
 
       - name: Publish CLI tool
         uses: shogo82148/actions-upload-release-asset@953d19cc84d8e8ecf80beec5afef40ca68b7e633 # v1.6.6
+        continue-on-error: true
         with:
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: ./bin/*


### PR DESCRIPTION
We cannot rerun our release pipeline after our Azure Artifacts PAT expired since this step will fail as we already uploaded assets.