### PR TITLE
Downgrade invalid `packages.config` files from an error to warning

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/nuget/NuGetPackagesConfigDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/nuget/NuGetPackagesConfigDetector.cs
@@ -10,8 +10,17 @@ using Microsoft.ComponentDetection.Contracts.Internal;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.Extensions.Logging;
 
-public class NuGetPackagesConfigDetector : FileComponentDetector
+/// <summary>
+/// Detects NuGet packages in packages.config files.
+/// </summary>
+public sealed class NuGetPackagesConfigDetector : FileComponentDetector
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NuGetPackagesConfigDetector"/> class.
+    /// </summary>
+    /// <param name="componentStreamEnumerableFactory">The factory for handing back component streams to File detectors.</param>
+    /// <param name="walkerFactory">The factory for creating directory walkers.</param>
+    /// <param name="logger">The logger to use.</param>
     public NuGetPackagesConfigDetector(
         IComponentStreamEnumerableFactory componentStreamEnumerableFactory,
         IObservableDirectoryWalkerFactory walkerFactory,
@@ -22,17 +31,23 @@ public class NuGetPackagesConfigDetector : FileComponentDetector
         this.Logger = logger;
     }
 
+    /// <inheritdoc />
     public override IList<string> SearchPatterns => new[] { "packages.config" };
 
+    /// <inheritdoc />
     public override string Id => "NuGetPackagesConfig";
 
+    /// <inheritdoc />
     public override IEnumerable<string> Categories =>
         new[] { Enum.GetName(typeof(DetectorClass), DetectorClass.NuGet) };
 
+    /// <inheritdoc />
     public override IEnumerable<ComponentType> SupportedComponentTypes => new[] { ComponentType.NuGet };
 
+    /// <inheritdoc />
     public override int Version => 1;
 
+    /// <inheritdoc />
     protected override Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs)
     {
         try
@@ -52,7 +67,7 @@ public class NuGetPackagesConfigDetector : FileComponentDetector
         }
         catch (Exception e) when (e is PackagesConfigReaderException or XmlException)
         {
-            this.Logger.LogError(e, "Failed to read packages.config file {File}", processRequest.ComponentStream.Location);
+            this.Logger.LogWarning(e, "Failed to read packages.config file {File}", processRequest.ComponentStream.Location);
         }
 
         return Task.CompletedTask;

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/nuget/NuGetPackagesConfigDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/nuget/NuGetPackagesConfigDetectorTests.cs
@@ -25,10 +25,29 @@ public class NuGetPackagesConfigDetectorTests : BaseDetectorTest<NuGetPackagesCo
             .WithFile("packages.config", packagesConfig)
             .ExecuteDetectorAsync();
 
+        scanResult.ResultCode.Should().Be(ProcessingResultCode.Success);
         var detectedComponents = componentRecorder.GetDetectedComponents();
         detectedComponents.Should().NotBeEmpty()
             .And.HaveCount(2)
             .And.ContainEquivalentOf(new DetectedComponent(new NuGetComponent("jQuery", "3.1.1")))
             .And.ContainEquivalentOf(new DetectedComponent(new NuGetComponent("NLog", "4.3.10")));
+    }
+
+    [TestMethod]
+    public async Task Should_SkipWithInvalidVersionAsync()
+    {
+        var packagesConfig =
+            @"<?xml version=""1.0"" encoding=""utf-8""?>
+                <packages>
+                    <package id=""jQuery"" version=""3.1.1"" targetFramework=""net46"" />
+                    <package id=""NLog"" version=""
+                 </packages>";
+        var (scanResult, componentRecorder) = await this.DetectorTestUtility
+            .WithFile("packages.config", packagesConfig)
+            .ExecuteDetectorAsync();
+
+        scanResult.ResultCode.Should().Be(ProcessingResultCode.Success);
+        var detectedComponents = componentRecorder.GetDetectedComponents();
+        detectedComponents.Should().BeNull();
     }
 }

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/nuget/NuGetPackagesConfigDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/nuget/NuGetPackagesConfigDetectorTests.cs
@@ -48,6 +48,6 @@ public class NuGetPackagesConfigDetectorTests : BaseDetectorTest<NuGetPackagesCo
 
         scanResult.ResultCode.Should().Be(ProcessingResultCode.Success);
         var detectedComponents = componentRecorder.GetDetectedComponents();
-        detectedComponents.Should().BeNull();
+        detectedComponents.Should().BeEmpty();
     }
 }


### PR DESCRIPTION
This prevents issues for those that have configured error logs in CI to break builds. Really, we should continue, and a single invalid `packages.config` file shouldn't break a build.

Also added documentation and a new test.