### PR TITLE
feat(go): break down telemetry on go cli command failures

### DIFF
--- a/src/Microsoft.ComponentDetection.Common/Telemetry/Records/GoGraphTelemetryRecord.cs
+++ b/src/Microsoft.ComponentDetection.Common/Telemetry/Records/GoGraphTelemetryRecord.cs
@@ -1,4 +1,4 @@
-namespace Microsoft.ComponentDetection.Common.Telemetry.Records;
+﻿namespace Microsoft.ComponentDetection.Common.Telemetry.Records;
 
 public class GoGraphTelemetryRecord : BaseDetectionTelemetryRecord
 {
@@ -12,7 +12,9 @@ public class GoGraphTelemetryRecord : BaseDetectionTelemetryRecord
 
     public bool WasGoCliDisabled { get; set; }
 
-    public bool WasGoCliNotFound { get; set; }
-
     public bool WasGoFallbackStrategyUsed { get; set; }
+
+    public bool DidGoCliCommandFail { get; set; }
+
+    public string GoCliCommandError { get; set; }
 }

--- a/src/Microsoft.ComponentDetection.Detectors/go/GoComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/go/GoComponentDetector.cs
@@ -1,4 +1,4 @@
-namespace Microsoft.ComponentDetection.Detectors.Go;
+﻿namespace Microsoft.ComponentDetection.Detectors.Go;
 
 using System;
 using System.Collections.Generic;
@@ -53,15 +53,16 @@ public class GoComponentDetector : FileComponentDetector
     {
         var singleFileComponentRecorder = processRequest.SingleFileComponentRecorder;
         var file = processRequest.ComponentStream;
-        using var record = new GoGraphTelemetryRecord();
-        record.WasGoCliDisabled = false;
-        record.WasGoFallbackStrategyUsed = false;
 
         var projectRootDirectory = Directory.GetParent(file.Location);
         if (this.projectRoots.Any(path => projectRootDirectory.FullName.StartsWith(path)))
         {
             return;
         }
+
+        using var record = new GoGraphTelemetryRecord();
+        record.WasGoCliDisabled = false;
+        record.WasGoFallbackStrategyUsed = false;
 
         var wasGoCliScanSuccessful = false;
         try
@@ -120,7 +121,7 @@ public class GoComponentDetector : FileComponentDetector
     private async Task<bool> UseGoCliToScanAsync(string location, ISingleFileComponentRecorder singleFileComponentRecorder, GoGraphTelemetryRecord record)
     {
         record.WasGraphSuccessful = false;
-        record.WasGoCliNotFound = false;
+        record.DidGoCliCommandFail = false;
         var projectRootDirectory = Directory.GetParent(location);
         record.ProjectRoot = projectRootDirectory.FullName;
 
@@ -130,7 +131,6 @@ public class GoComponentDetector : FileComponentDetector
         if (!isGoAvailable)
         {
             this.Logger.LogInformation("Go CLI was not found in the system");
-            record.WasGoCliNotFound = true;
             return false;
         }
 
@@ -142,6 +142,8 @@ public class GoComponentDetector : FileComponentDetector
         {
             this.Logger.LogError("Go CLI command \"go list -m -json all\" failed with error: {GoDependenciesProcessStdErr}", goDependenciesProcess.StdErr);
             this.Logger.LogError("Go CLI could not get dependency build list at location: {Location}. Fallback go.sum/go.mod parsing will be used.", location);
+            record.DidGoCliCommandFail = true;
+            record.GoCliCommandError = goDependenciesProcess.StdErr;
             return false;
         }
 


### PR DESCRIPTION
**Changes**
- Create telemetry object after project roots command succeeds to avoid empty telemetry objects
- Remove `WasGoCliNotFound` as it was the exact inverse of `IsGoInstalled`
- Add `DidGoCliCommandFail` and `GoCliCommandError` to track `go list` failures