### PR TITLE
feat(go): record version in `go.mod`

### DIFF
--- a/src/Microsoft.ComponentDetection.Common/Telemetry/Records/GoGraphTelemetryRecord.cs
+++ b/src/Microsoft.ComponentDetection.Common/Telemetry/Records/GoGraphTelemetryRecord.cs
@@ -17,4 +17,6 @@ public class GoGraphTelemetryRecord : BaseDetectionTelemetryRecord
     public bool DidGoCliCommandFail { get; set; }
 
     public string GoCliCommandError { get; set; }
+
+    public string GoModVersion { get; set; }
 }

--- a/src/Microsoft.ComponentDetection.Detectors/go/GoComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/go/GoComponentDetector.cs
@@ -97,7 +97,7 @@ public class GoComponentDetector : FileComponentDetector
                     case ".MOD":
                     {
                         this.Logger.LogDebug("Found Go.mod: {Location}", file.Location);
-                        this.ParseGoModFile(singleFileComponentRecorder, file);
+                        this.ParseGoModFile(singleFileComponentRecorder, file, record);
                         break;
                     }
 
@@ -161,13 +161,19 @@ public class GoComponentDetector : FileComponentDetector
 
     private void ParseGoModFile(
         ISingleFileComponentRecorder singleFileComponentRecorder,
-        IComponentStream file)
+        IComponentStream file,
+        GoGraphTelemetryRecord goGraphTelemetryRecord)
     {
         using var reader = new StreamReader(file.Stream);
 
         var line = reader.ReadLine();
         while (line != null && !line.StartsWith("require ("))
         {
+            if (line.StartsWith("go "))
+            {
+                goGraphTelemetryRecord.GoModVersion = line[3..].Trim();
+            }
+
             line = reader.ReadLine();
         }
 


### PR DESCRIPTION
Records the go version stored in `go.mod` for telemetry.

Example `go.mod` file, where go > 1.17:

```
module example/web-service-gin

go 1.18

require github.com/gin-gonic/gin v1.9.1

require (
        github.com/bytedance/sonic v1.9.1 // indirect
        github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 // indirect
        github.com/gabriel-vasile/mimetype v1.4.2 // indirect
        github.com/gin-contrib/sse v0.1.0 // indirect
        github.com/go-playground/locales v0.14.1 // indirect
        github.com/go-playground/universal-translator v0.18.1 // indirect
        github.com/go-playground/validator/v10 v10.14.0 // indirect
        github.com/goccy/go-json v0.10.2 // indirect
        github.com/json-iterator/go v1.1.12 // indirect
        github.com/klauspost/cpuid/v2 v2.2.4 // indirect
        github.com/leodido/go-urn v1.2.4 // indirect
        github.com/mattn/go-isatty v0.0.19 // indirect
        github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
        github.com/modern-go/reflect2 v1.0.2 // indirect
        github.com/pelletier/go-toml/v2 v2.0.8 // indirect
        github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
        github.com/ugorji/go/codec v1.2.11 // indirect
        golang.org/x/arch v0.3.0 // indirect
        golang.org/x/crypto v0.9.0 // indirect
        golang.org/x/net v0.10.0 // indirect
        golang.org/x/sys v0.8.0 // indirect
        golang.org/x/text v0.9.0 // indirect
        google.golang.org/protobuf v1.30.0 // indirect
        gopkg.in/yaml.v3 v3.0.1 // indirect
)
```

Part of #737 