### PR TITLE
Added spdx package component information from SPDX file

### DIFF
--- a/src/Microsoft.ComponentDetection.Contracts/TypedComponent/SpdxPackageComponent.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/TypedComponent/SpdxPackageComponent.cs
@@ -2,13 +2,14 @@ namespace Microsoft.ComponentDetection.Contracts.TypedComponent;
 
 public class SpdxPackageComponent : TypedComponent
 {
-    public SpdxPackageComponent(string name, string version, string supplier, string packageSource, string copyrightText)
+    public SpdxPackageComponent(string name, string version, string supplier, string packageSource, string downloadLocation, string copyrightText)
     {
         this.Name = this.ValidateRequiredInput(name, nameof(this.Name), nameof(ComponentType.Spdx));
         this.Version = this.ValidateRequiredInput(version, nameof(this.Version), nameof(ComponentType.Spdx));
         this.Supplier = this.ValidateRequiredInput(supplier, nameof(this.Supplier), nameof(ComponentType.Spdx));
-        this.CopyrightText = this.ValidateRequiredInput(copyrightText, nameof(this.CopyrightText), nameof(ComponentType.Spdx));
         this.PackageSource = this.ValidateRequiredInput(packageSource, nameof(this.PackageSource), nameof(ComponentType.Spdx));
+        this.DownloadLocation = this.ValidateRequiredInput(downloadLocation, nameof(this.DownloadLocation), nameof(ComponentType.Spdx));
+        this.CopyrightText = this.ValidateRequiredInput(copyrightText, nameof(this.CopyrightText), nameof(ComponentType.Spdx));
     }
 
     private SpdxPackageComponent()
@@ -17,6 +18,8 @@ public class SpdxPackageComponent : TypedComponent
     }
 
     public string CopyrightText { get; }
+
+    public string DownloadLocation { get; }
 
     public override string Id => $"{this.Name} {this.Version} - {this.Type}";
 

--- a/src/Microsoft.ComponentDetection.Contracts/TypedComponent/SpdxPackageComponent.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/TypedComponent/SpdxPackageComponent.cs
@@ -1,0 +1,32 @@
+namespace Microsoft.ComponentDetection.Contracts.TypedComponent;
+
+public class SpdxPackageComponent : TypedComponent
+{
+    public SpdxPackageComponent(string name, string version, string supplier, string packageSource, string copyrightText)
+    {
+        this.Name = this.ValidateRequiredInput(name, nameof(this.Name), nameof(ComponentType.Spdx));
+        this.Version = this.ValidateRequiredInput(version, nameof(this.Version), nameof(ComponentType.Spdx));
+        this.Supplier = this.ValidateRequiredInput(supplier, nameof(this.Supplier), nameof(ComponentType.Spdx));
+        this.CopyrightText = this.ValidateRequiredInput(copyrightText, nameof(this.CopyrightText), nameof(ComponentType.Spdx));
+        this.PackageSource = this.ValidateRequiredInput(packageSource, nameof(this.PackageSource), nameof(ComponentType.Spdx));
+    }
+
+    private SpdxPackageComponent()
+    {
+        // reserved for deserialization
+    }
+
+    public string CopyrightText { get; }
+
+    public override string Id => $"{this.Name} {this.Version} - {this.Type}";
+
+    public string Name { get; }
+
+    public string PackageSource { get; }
+
+    public string Supplier { get; }
+
+    public override ComponentType Type => ComponentType.Spdx;
+
+    public string Version { get; }
+}

--- a/src/Microsoft.ComponentDetection.Contracts/TypedComponent/SpdxPackageComponent.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/TypedComponent/SpdxPackageComponent.cs
@@ -1,16 +1,20 @@
 namespace Microsoft.ComponentDetection.Contracts.TypedComponent;
 
+using PackageUrl;
+
 public class SpdxPackageComponent : TypedComponent
 {
-    public SpdxPackageComponent(string name, string version, string supplier, string packageSource, string downloadLocation, string copyrightText)
+    public SpdxPackageComponent(string name, string version, string supplier, string copyrightText, string downloadLocation)
     {
         this.Name = this.ValidateRequiredInput(name, nameof(this.Name), nameof(ComponentType.Spdx));
         this.Version = this.ValidateRequiredInput(version, nameof(this.Version), nameof(ComponentType.Spdx));
         this.Supplier = this.ValidateRequiredInput(supplier, nameof(this.Supplier), nameof(ComponentType.Spdx));
-        this.PackageSource = this.ValidateRequiredInput(packageSource, nameof(this.PackageSource), nameof(ComponentType.Spdx));
-        this.DownloadLocation = this.ValidateRequiredInput(downloadLocation, nameof(this.DownloadLocation), nameof(ComponentType.Spdx));
         this.CopyrightText = this.ValidateRequiredInput(copyrightText, nameof(this.CopyrightText), nameof(ComponentType.Spdx));
+        this.DownloadLocation = this.ValidateRequiredInput(downloadLocation, nameof(this.DownloadLocation), nameof(ComponentType.Spdx));
     }
+
+    public SpdxPackageComponent(string name, string version, string supplier, string copyrightText, string downloadLocation, string packageUrl)
+        : this(name, version, supplier, copyrightText, downloadLocation) => this.PackageUrl = new PackageURL(packageUrl);
 
     private SpdxPackageComponent()
     {
@@ -25,7 +29,7 @@ public class SpdxPackageComponent : TypedComponent
 
     public string Name { get; }
 
-    public string PackageSource { get; }
+    public override PackageURL PackageUrl { get; }
 
     public string Supplier { get; }
 

--- a/src/Microsoft.ComponentDetection.Detectors/spdx/Contracts/CreationInfo.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/spdx/Contracts/CreationInfo.cs
@@ -1,0 +1,13 @@
+namespace Microsoft.ComponentDetection.Detectors.Spdx.Contracts;
+
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+public class CreationInfo
+{
+    [JsonProperty("created")]
+    public string Created { get; set; }
+
+    [JsonProperty("creators")]
+    public IEnumerable<string> Creators { get; set; }
+}

--- a/src/Microsoft.ComponentDetection.Detectors/spdx/Contracts/SpdxExternalRefs.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/spdx/Contracts/SpdxExternalRefs.cs
@@ -1,0 +1,15 @@
+namespace Microsoft.ComponentDetection.Detectors.Spdx.Contracts;
+
+using Newtonsoft.Json;
+
+public class SpdxExternalRefs
+{
+    [JsonProperty("referenceCategory")]
+    public string Category { get; set; }
+
+    [JsonProperty("referenceLocator")]
+    public string Locator { get; set; }
+
+    [JsonProperty("referenceType")]
+    public string Type { get; set; }
+}

--- a/src/Microsoft.ComponentDetection.Detectors/spdx/Contracts/SpdxFileData.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/spdx/Contracts/SpdxFileData.cs
@@ -1,0 +1,34 @@
+namespace Microsoft.ComponentDetection.Detectors.Spdx.Contracts;
+
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+
+public class SpdxFileData
+{
+    [JsonProperty("creationInfo")]
+    public CreationInfo CreationInfo { get; set; }
+
+    [JsonProperty("dataLicense")]
+    public string DataLicense { get; set; }
+
+    [JsonProperty("documentDescribes")]
+    public IEnumerable<string> DocumentDescribes { get; set; }
+
+    [JsonProperty("documentNamespace")]
+    public string DocumentNamespace { get; set; }
+
+    [JsonProperty("name")]
+    public string Name { get; set; }
+
+    [JsonProperty("packages")]
+    public IEnumerable<SpdxPackage> Packages { get; set; }
+
+    [JsonProperty(nameof(SPDXID))]
+    public string SPDXID { get; set; }
+
+    [JsonProperty("spdxVersion")]
+    public string Version { get; set; }
+
+    internal bool HasPackages() => this.Packages?.Count() > 0;
+}

--- a/src/Microsoft.ComponentDetection.Detectors/spdx/Contracts/SpdxPackage.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/spdx/Contracts/SpdxPackage.cs
@@ -1,0 +1,34 @@
+namespace Microsoft.ComponentDetection.Detectors.Spdx.Contracts;
+
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+public class SpdxPackage
+{
+    [JsonProperty("copyrightText")]
+    public string CopyrightText { get; set; }
+
+    [JsonProperty("downloadLocation")]
+    public string DownloadLocation { get; set; }
+
+    [JsonProperty("externalRefs")]
+    public IEnumerable<SpdxExternalRefs> ExternalRefs { get; set; }
+
+    [JsonProperty("licenseConcluded")]
+    public string LicenseConcluded { get; set; }
+
+    [JsonProperty("licenseDeclared")]
+    public string LicenseDeclared { get; set; }
+
+    [JsonProperty("name")]
+    public string Name { get; set; }
+
+    [JsonProperty(nameof(SPDXID))]
+    public string SPDXID { get; set; }
+
+    [JsonProperty("supplier")]
+    public string Supplier { get; set; }
+
+    [JsonProperty("versionInfo")]
+    public string Version { get; set; }
+}

--- a/src/Microsoft.ComponentDetection.Detectors/spdx/Spdx22ComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/spdx/Spdx22ComponentDetector.cs
@@ -80,7 +80,18 @@ public class Spdx22ComponentDetector : FileComponentDetector, IDefaultOffCompone
             {
                 foreach (var package in spdxFileData.Packages)
                 {
-                    var spdxPackageComponent = new SpdxPackageComponent(package.Name, package.Version, package.Supplier, processRequest.ComponentStream.Location, package.DownloadLocation, package.CopyrightText);
+                    SpdxPackageComponent spdxPackageComponent;
+
+                    var extRefLocator = package.ExternalRefs?.FirstOrDefault(x => x.Type == "purl")?.Locator;
+                    if (extRefLocator is not null)
+                    {
+                        spdxPackageComponent = new SpdxPackageComponent(package.Name, package.Version, package.Supplier, package.CopyrightText, package.DownloadLocation, extRefLocator);
+                    }
+                    else
+                    {
+                        spdxPackageComponent = new SpdxPackageComponent(package.Name, package.Version, package.Supplier, package.CopyrightText, package.DownloadLocation);
+                    }
+
                     singleFileComponentRecorder.RegisterUsage(new DetectedComponent(spdxPackageComponent));
                 }
             }

--- a/src/Microsoft.ComponentDetection.Detectors/spdx/Spdx22ComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/spdx/Spdx22ComponentDetector.cs
@@ -80,7 +80,7 @@ public class Spdx22ComponentDetector : FileComponentDetector, IDefaultOffCompone
             {
                 foreach (var package in spdxFileData.Packages)
                 {
-                    var spdxPackageComponent = new SpdxPackageComponent(package.Name, package.Version, package.Supplier, processRequest.ComponentStream.Location, package.CopyrightText);
+                    var spdxPackageComponent = new SpdxPackageComponent(package.Name, package.Version, package.Supplier, processRequest.ComponentStream.Location, package.DownloadLocation, package.CopyrightText);
                     singleFileComponentRecorder.RegisterUsage(new DetectedComponent(spdxPackageComponent));
                 }
             }

--- a/src/Microsoft.ComponentDetection.Detectors/spdx/Spdx22ComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/spdx/Spdx22ComponentDetector.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.ComponentDetection.Detectors.Spdx;
+namespace Microsoft.ComponentDetection.Detectors.Spdx;
 
 using System;
 using System.Collections.Generic;
@@ -9,9 +9,9 @@ using System.Threading.Tasks;
 using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Contracts.Internal;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
+using Microsoft.ComponentDetection.Detectors.Spdx.Contracts;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 /// <summary>
 /// Spdx22ComponentDetector discover SPDX SBOM files in JSON format and create components with the information about
@@ -46,6 +46,7 @@ public class Spdx22ComponentDetector : FileComponentDetector, IDefaultOffCompone
     {
         this.Logger.LogDebug("Discovered SPDX2.2 manifest file at: {ManifestLocation}", processRequest.ComponentStream.Location);
         var file = processRequest.ComponentStream;
+        var singleFileComponentRecorder = processRequest.SingleFileComponentRecorder;
 
         try
         {
@@ -58,30 +59,35 @@ public class Spdx22ComponentDetector : FileComponentDetector, IDefaultOffCompone
             using var reader = new JsonTextReader(sr);
             var serializer = new JsonSerializer();
 
-            try
+            var spdxFileData = serializer.Deserialize<SpdxFileData>(reader);
+
+            if (spdxFileData == null)
             {
-                var document = serializer.Deserialize<JObject>(reader);
-                if (document != null)
+                this.Logger.LogWarning("Discovered SPDX file at {ManifestLocation} is not a valid document, skipping", processRequest.ComponentStream.Location);
+                return Task.CompletedTask;
+            }
+
+            if (!this.IsSPDXVersionSupported(spdxFileData.Version))
+            {
+                this.Logger.LogWarning("Discovered SPDX at {ManifestLocation} is not SPDX-2.2 document, skipping", processRequest.ComponentStream.Location);
+                return Task.CompletedTask;
+            }
+
+            var sbomComponent = this.ConvertJObjectToSbomComponent(processRequest, spdxFileData, hash);
+            singleFileComponentRecorder.RegisterUsage(new DetectedComponent(sbomComponent));
+
+            if (spdxFileData.HasPackages())
+            {
+                foreach (var package in spdxFileData.Packages)
                 {
-                    if (this.IsSPDXVersionSupported(document))
-                    {
-                        var sbomComponent = this.ConvertJObjectToSbomComponent(processRequest, document, hash);
-                        processRequest.SingleFileComponentRecorder.RegisterUsage(new DetectedComponent(sbomComponent));
-                    }
-                    else
-                    {
-                        this.Logger.LogWarning("Discovered SPDX at {ManifestLocation} is not SPDX-2.2 document, skipping", processRequest.ComponentStream.Location);
-                    }
-                }
-                else
-                {
-                    this.Logger.LogWarning("Discovered SPDX file at {ManifestLocation} is not a valid document, skipping", processRequest.ComponentStream.Location);
+                    var spdxPackageComponent = new SpdxPackageComponent(package.Name, package.Version, package.Supplier, processRequest.ComponentStream.Location, package.CopyrightText);
+                    singleFileComponentRecorder.RegisterUsage(new DetectedComponent(spdxPackageComponent));
                 }
             }
-            catch (JsonReaderException)
-            {
-                this.Logger.LogWarning("Unable to parse file at {ManifestLocation}, skipping", processRequest.ComponentStream.Location);
-            }
+        }
+        catch (JsonException je)
+        {
+            this.Logger.LogWarning(je, "Unable to parse file at {ManifestLocation}, skipping", processRequest.ComponentStream.Location);
         }
         catch (Exception e)
         {
@@ -91,16 +97,13 @@ public class Spdx22ComponentDetector : FileComponentDetector, IDefaultOffCompone
         return Task.CompletedTask;
     }
 
-    private bool IsSPDXVersionSupported(JObject document) => this.supportedSPDXVersions.Contains(document["spdxVersion"]?.ToString(), StringComparer.OrdinalIgnoreCase);
+    private bool IsSPDXVersionSupported(string version) => this.supportedSPDXVersions.Contains(version?.ToString(), StringComparer.OrdinalIgnoreCase);
 
-    private SpdxComponent ConvertJObjectToSbomComponent(ProcessRequest processRequest, JObject document, string fileHash)
+    private SpdxComponent ConvertJObjectToSbomComponent(ProcessRequest processRequest, SpdxFileData spdxFileData, string fileHash)
     {
-        var sbomNamespace = document["documentNamespace"]?.ToString();
-        var rootElements = document["documentDescribes"]?.ToObject<string[]>();
-        var name = document["name"]?.ToString();
-        var spdxVersion = document["spdxVersion"]?.ToString();
+        var rootElements = spdxFileData.DocumentDescribes;
 
-        if (rootElements?.Length > 1)
+        if (rootElements?.Count() > 1)
         {
             this.Logger.LogWarning("SPDX file at {ManifestLocation} has more than one element in documentDescribes, first will be selected as root element.", processRequest.ComponentStream.Location);
         }
@@ -112,7 +115,7 @@ public class Spdx22ComponentDetector : FileComponentDetector, IDefaultOffCompone
 
         var rootElementId = rootElements?.FirstOrDefault() ?? "SPDXRef-Document";
         var path = processRequest.ComponentStream.Location;
-        var component = new SpdxComponent(spdxVersion, new Uri(sbomNamespace), name, fileHash, rootElementId, path);
+        var component = new SpdxComponent(spdxFileData.Version, new Uri(spdxFileData.DocumentNamespace), spdxFileData.Name, fileHash, rootElementId, path);
 
         return component;
     }

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/SPDX22ComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/SPDX22ComponentDetectorTests.cs
@@ -59,7 +59,7 @@ public class Spdx22ComponentDetectorTests : BaseDetectorTest<Spdx22ComponentDete
         {
             ""name"": ""package"",
             ""SPDXID"": ""SPDXRef-RootPackage"",
-            ""downloadLocation"": ""NOASSERTION"",
+            ""downloadLocation"": ""https://www.sbom.microsoft"",
             ""packageVerificationCode"": {
                 ""packageVerificationCodeValue"": ""12fa1211046c12118936384b6c8683f1ac9b790a""
             },
@@ -135,6 +135,7 @@ public class Spdx22ComponentDetectorTests : BaseDetectorTest<Spdx22ComponentDete
         Assert.AreEqual(spdxPackageComponent.Version, "1.0.0");
         Assert.AreEqual(spdxPackageComponent.CopyrightText, "NOASSERTION");
         Assert.AreEqual(spdxPackageComponent.Supplier, "Organization: Microsoft");
+        Assert.AreEqual(spdxPackageComponent.DownloadLocation, "https://www.sbom.microsoft");
         Assert.AreEqual(spdxPackageComponent.PackageSource, spdxFilePath);
     }
 


### PR DESCRIPTION
right now, component detection was correctly detecting the SBOM file(s) if any present in the project folder,  but it was not including packages information from already present SBOM file to newly generated file.

example -> Project A reference Project B 

Steps 
1) Generate SBOM for Project B  and include SBOM file in Project A 
2) Generate SBOM for Project A

Expected Result -> SBOM file generated for project A should include packages information from SBOM file generated for Project B
Actual Result -> SBOM file is identified but the package information is not considered.