### PR TITLE
chore(deps): downgrade `Spectre.Console` to v0.47.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -40,7 +40,7 @@
     <PackageVersion Include="Serilog.Sinks.Console" Version="4.1.0" />
     <PackageVersion Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageVersion Include="Serilog.Sinks.Map" Version="1.0.2" />
-    <PackageVersion Include="Spectre.Console" Version="0.47.1-preview.0.23" />
+    <PackageVersion Include="Spectre.Console" Version="0.47.0" />
     <PackageVersion Include="Spectre.Console.Cli" Version="0.47.0" />
     <PackageVersion Include="Spectre.Console.Cli.Extensions.DependencyInjection" Version="0.1.0" />
     <PackageVersion Include="Spectre.Console.Testing" Version="0.47.0" />


### PR DESCRIPTION
We cannot release a version of CD with a pre-release version of a dependency or MinVer will break the build.