### PR TITLE
fix: validate `--Output`

### DIFF
--- a/src/Microsoft.ComponentDetection.Orchestrator/Commands/BaseSettings.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Commands/BaseSettings.cs
@@ -2,6 +2,7 @@ namespace Microsoft.ComponentDetection.Orchestrator.Commands;
 
 using System;
 using System.ComponentModel;
+using System.IO;
 using Serilog.Events;
 using Spectre.Console;
 using Spectre.Console.Cli;
@@ -42,6 +43,11 @@ public abstract class BaseSettings : CommandSettings
         if (this.Timeout is <= 0)
         {
             return ValidationResult.Error($"{nameof(this.Timeout)} must be a positive integer");
+        }
+
+        if (!string.IsNullOrEmpty(this.Output) && !Directory.Exists(this.Output))
+        {
+            return ValidationResult.Error($"{nameof(this.Output)} must be a valid path");
         }
 
         return base.Validate();

--- a/test/Microsoft.ComponentDetection.Orchestrator.Tests/Commands/BaseSettingsTests.cs
+++ b/test/Microsoft.ComponentDetection.Orchestrator.Tests/Commands/BaseSettingsTests.cs
@@ -1,0 +1,55 @@
+namespace Microsoft.ComponentDetection.Orchestrator.Tests.Commands;
+
+using System.IO;
+using FluentAssertions;
+using Microsoft.ComponentDetection.Orchestrator.Commands;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[TestClass]
+[TestCategory("Governance/All")]
+[TestCategory("Governance/ComponentDetection")]
+public class BaseSettingsTests
+{
+    [TestMethod]
+    public void Validate_FailsNegativeTimeout()
+    {
+        var settings = new TestBaseSettings
+        {
+            Timeout = -1,
+        };
+
+        var result = settings.Validate();
+
+        result.Successful.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void Validate_Success_Empty_Output()
+    {
+        var settings = new TestBaseSettings
+        {
+            Output = string.Empty,
+        };
+
+        var result = settings.Validate();
+
+        result.Successful.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void Validate_Fails_Output_NotExists()
+    {
+        var setting = new TestBaseSettings
+        {
+            Output = Path.Combine(Path.GetTempPath(), Path.GetTempFileName()),
+        };
+
+        var result = setting.Validate();
+
+        result.Successful.Should().BeFalse();
+    }
+
+    private class TestBaseSettings : BaseSettings
+    {
+    }
+}


### PR DESCRIPTION
This used to be validated in the Orchestrator
