### PR TITLE
feat(experiments): record rust cli if `cargo` exists

### DIFF
--- a/src/Microsoft.ComponentDetection.Orchestrator/Experiments/Configs/IExperimentConfiguration.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Experiments/Configs/IExperimentConfiguration.cs
@@ -1,5 +1,6 @@
 ﻿namespace Microsoft.ComponentDetection.Orchestrator.Experiments.Configs;
 
+using System.Threading.Tasks;
 using Microsoft.ComponentDetection.Contracts;
 
 /// <summary>
@@ -14,6 +15,12 @@ public interface IExperimentConfiguration
     /// The name of the experiment.
     /// </summary>
     string Name { get; }
+
+    /// <summary>
+    /// Initializes the experiment configuration.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    Task InitAsync() => Task.CompletedTask;
 
     /// <summary>
     /// Specifies if the detector is in the control group.

--- a/src/Microsoft.ComponentDetection.Orchestrator/Experiments/Configs/RustCliDetectorExperiment.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Experiments/Configs/RustCliDetectorExperiment.cs
@@ -1,5 +1,6 @@
 namespace Microsoft.ComponentDetection.Orchestrator.Experiments.Configs;
 
+using System.Threading.Tasks;
 using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Detectors.Rust;
 
@@ -8,6 +9,15 @@ using Microsoft.ComponentDetection.Detectors.Rust;
 /// </summary>
 public class RustCliDetectorExperiment : IExperimentConfiguration
 {
+    private readonly ICommandLineInvocationService commandLineInvocationService;
+    private bool cargoCliAvailable;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RustCliDetectorExperiment"/> class.
+    /// </summary>
+    /// <param name="commandLineInvocationService">The command line invocation service.</param>
+    public RustCliDetectorExperiment(ICommandLineInvocationService commandLineInvocationService) => this.commandLineInvocationService = commandLineInvocationService;
+
     /// <inheritdoc />
     public string Name => "RustCliDetector";
 
@@ -18,5 +28,8 @@ public class RustCliDetectorExperiment : IExperimentConfiguration
     public bool IsInExperimentGroup(IComponentDetector componentDetector) => componentDetector is RustCliDetector;
 
     /// <inheritdoc />
-    public bool ShouldRecord(IComponentDetector componentDetector, int numComponents) => true;
+    public bool ShouldRecord(IComponentDetector componentDetector, int numComponents) => this.cargoCliAvailable;
+
+    /// <inheritdoc />
+    public async Task InitAsync() => this.cargoCliAvailable = await this.commandLineInvocationService.CanCommandBeLocatedAsync("cargo", null);
 }

--- a/src/Microsoft.ComponentDetection.Orchestrator/Experiments/ExperimentService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Experiments/ExperimentService.cs
@@ -44,6 +44,23 @@ public class ExperimentService : IExperimentService
     }
 
     /// <inheritdoc />
+    public async Task InitializeAsync()
+    {
+        foreach (var config in this.experiments.Keys)
+        {
+            try
+            {
+                await config.InitAsync();
+            }
+            catch (Exception e)
+            {
+                this.logger.LogWarning(e, "Failed to initialize experiment {Experiment}, skipping it", config.Name);
+                this.experiments.TryRemove(config, out _);
+            }
+        }
+    }
+
+    /// <inheritdoc />
     public void RecordDetectorRun(
         IComponentDetector detector,
         ComponentRecorder componentRecorder,

--- a/src/Microsoft.ComponentDetection.Orchestrator/Experiments/IExperimentService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Experiments/IExperimentService.cs
@@ -12,6 +12,12 @@ using Microsoft.ComponentDetection.Orchestrator.Commands;
 public interface IExperimentService
 {
     /// <summary>
+    /// Initializes the experiment services by preparing the experiment configurations.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    Task InitializeAsync();
+
+    /// <summary>
     /// Records the results of a detector execution and processes the results for any active experiments.
     /// </summary>
     /// <param name="detector">The detector.</param>

--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/DetectorProcessingService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/DetectorProcessingService.cs
@@ -55,6 +55,7 @@ public class DetectorProcessingService : IDetectorProcessingService
             ? this.GenerateDirectoryExclusionPredicate(settings.SourceDirectory.ToString(), settings.DirectoryExclusionList, settings.DirectoryExclusionListObsolete, allowWindowsPaths: false, ignoreCase: false)
             : this.GenerateDirectoryExclusionPredicate(settings.SourceDirectory.ToString(), settings.DirectoryExclusionList, settings.DirectoryExclusionListObsolete, allowWindowsPaths: true, ignoreCase: true);
 
+        await this.experimentService.InitializeAsync();
         this.experimentService.RemoveUnwantedExperimentsbyDetectors(detectorRestrictions.DisabledDetectors);
 
         IEnumerable<Task<(IndividualDetectorScanResult, ComponentRecorder, IComponentDetector)>> scanTasks = detectors

--- a/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/DetectorProcessingServiceTests.cs
+++ b/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/DetectorProcessingServiceTests.cs
@@ -321,17 +321,17 @@ public class DetectorProcessingServiceTests
     public void GenerateDirectoryExclusionPredicate_IgnoreCaseAndAllowWindowsPathsWorksAsExpected()
     {
         /*
-        * We can't test a scenario like:
-        *
-        * SourceDirectory = /Some/Source/Directory
-        * DirectoryExclusionList = *Some/*
-        * allowWindowsPath = false
-        *
-        * and expect to exclude the directory, because when
-        * we pass the SourceDirectory path to DirectoryInfo and we are running the test on Windows,
-        * DirectoryInfo transalate it to C:\\Some\Source\Directory
-        * making the test fail
-        */
+         * We can't test a scenario like:
+         *
+         * SourceDirectory = /Some/Source/Directory
+         * DirectoryExclusionList = *Some/*
+         * allowWindowsPath = false
+         *
+         * and expect to exclude the directory, because when
+         * we pass the SourceDirectory path to DirectoryInfo and we are running the test on Windows,
+         * DirectoryInfo transalate it to C:\\Some\Source\Directory
+         * making the test fail
+         */
 
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
@@ -532,6 +532,19 @@ public class DetectorProcessingServiceTests
                     It.IsAny<ComponentRecorder>(),
                     It.Is<ScanSettings>(x => x == DefaultArgs)),
             Times.Once());
+    }
+
+    [TestMethod]
+    public async Task ProcessDetectorsAsync_InitializesExperimentsAsync()
+    {
+        this.detectorsToUse = new[]
+        {
+            this.firstFileComponentDetectorMock.Object, this.secondFileComponentDetectorMock.Object,
+        };
+
+        await this.serviceUnderTest.ProcessDetectorsAsync(DefaultArgs, this.detectorsToUse, new DetectorRestrictions());
+
+        this.experimentServiceMock.Verify(x => x.InitializeAsync(), Times.Once);
     }
 
     private Mock<FileComponentDetector> SetupFileDetectorMock(string id)


### PR DESCRIPTION
Adds a new `InitAsync` method to configurations that allows them to do some setup. Useful for the `RustCliExperiment` as we only want to record this experiment if `cargo` is available.

This had to be made into a separate method as the experiment methods aren't async, and the `CommandLineInvocationService` is async. 
