### PR TITLE
Fix to hide Http MessageHandler cleanup messages

### DIFF
--- a/src/Microsoft.ComponentDetection/Program.cs
+++ b/src/Microsoft.ComponentDetection/Program.cs
@@ -25,6 +25,7 @@ var serviceCollection = new ServiceCollection()
     .AddComponentDetection()
     .AddLogging(l => l.AddSerilog(new LoggerConfiguration()
         .MinimumLevel.ControlledBy(Interceptor.LogLevel)
+        .MinimumLevel.Override("Microsoft.Extensions.Http.DefaultHttpClientFactory", LogEventLevel.Information)
         .Enrich.With<LoggingEnricher>()
         .Enrich.FromLogContext()
         .WriteTo.Map(


### PR DESCRIPTION
Based on these threads [Stack Overflow](https://stackoverflow.com/questions/63199414/asp-net-core-3-1-httpmessagehandler-cleanup-cycle), [Github](https://github.com/aspnet/HttpClientFactory/issues/165), It seems the multiple cleanup messages are default behavior as it waits to clean up the message handler resources. The suggested thing to do is hide the messages in the logs if we don't want to see them.
