### PR TITLE
chore: add `codecov.yml`

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,11 @@
+# ref: https://docs.codecov.com/docs/codecovyml-reference
+coverage:
+  range: 60..80
+  round: down
+  precision: 1
+  status:
+    # ref: https://docs.codecov.com/docs/commit-status
+    project:
+      default:
+        # Avoid false negatives
+        threshold: 1%


### PR DESCRIPTION
Ignore 1% differences in coverage and round down with a precision of 1.