### PR TITLE
Users/oakeredolu/throttlehttpclient

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/pip/IPyPiClient.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/IPyPiClient.cs
@@ -83,7 +83,7 @@ public sealed class PyPiClient : IPyPiClient, IDisposable
             FinalCacheSize = 0,
         };
         this.logger = logger;
-        this.semaphore = new SemaphoreSlim(10, 10);
+        this.semaphore = new SemaphoreSlim(5);
     }
 
     public static HttpClient HttpClient { get; internal set; } = new HttpClient(HttpClientHandler);

--- a/src/Microsoft.ComponentDetection.Detectors/pip/SimplePypiClient.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/SimplePypiClient.cs
@@ -65,7 +65,7 @@ public sealed class SimplePyPiClient : ISimplePyPiClient, IDisposable
     {
         this.environmentVariableService = environmentVariableService;
         this.logger = logger;
-        this.semaphore = new SemaphoreSlim(10, 10);
+        this.semaphore = new SemaphoreSlim(5);
     }
 
     public static HttpClient HttpClient { get; internal set; } = new HttpClient(HttpClientHandler);
@@ -287,7 +287,6 @@ public sealed class SimplePyPiClient : ISimplePyPiClient, IDisposable
         this.cacheTelemetry.Dispose();
         this.cachedProjectWheelFiles.Dispose();
         this.cachedSimplePyPiProjects.Dispose();
-        HttpClient.Dispose();
         this.semaphore.Dispose();
     }
 }

--- a/src/Microsoft.ComponentDetection.Detectors/pip/SimplePypiClient.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/SimplePypiClient.cs
@@ -41,6 +41,9 @@ public sealed class SimplePyPiClient : ISimplePyPiClient, IDisposable
     // Keep telemetry on how the cache is being used for future refinements
     private readonly SimplePypiCacheTelemetryRecord cacheTelemetry = new SimplePypiCacheTelemetryRecord();
 
+    // Semaphore to limit the number of concurrent calls to pypi.org
+    private readonly SemaphoreSlim semaphore;
+
     /// <summary>
     /// A thread safe cache implementation which contains a mapping of URI -> SimpleProject for simplepypi api projects
     /// and has a limited number of entries which will expire after the cache fills or a specified interval.
@@ -62,6 +65,7 @@ public sealed class SimplePyPiClient : ISimplePyPiClient, IDisposable
     {
         this.environmentVariableService = environmentVariableService;
         this.logger = logger;
+        this.semaphore = new SemaphoreSlim(10, 10);
     }
 
     public static HttpClient HttpClient { get; internal set; } = new HttpClient(HttpClientHandler);
@@ -265,12 +269,14 @@ public sealed class SimplePyPiClient : ISimplePyPiClient, IDisposable
     /// <returns> Returns the httpresponsemessage. </returns>
     private async Task<HttpResponseMessage> GetPypiResponseAsync(Uri uri)
     {
+        await this.semaphore.WaitAsync();
         this.logger.LogInformation("Getting Python data from {Uri}", uri);
         using var request = new HttpRequestMessage(HttpMethod.Get, uri);
         request.Headers.UserAgent.Add(ProductValue);
         request.Headers.UserAgent.Add(CommentValue);
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.pypi.simple.v1+json"));
         var response = await HttpClient.SendAsync(request);
+        this.semaphore.Release();
         return response;
     }
 
@@ -282,5 +288,6 @@ public sealed class SimplePyPiClient : ISimplePyPiClient, IDisposable
         this.cachedProjectWheelFiles.Dispose();
         this.cachedSimplePyPiProjects.Dispose();
         HttpClient.Dispose();
+        this.semaphore.Dispose();
     }
 }


### PR DESCRIPTION
This pr uses semaphore to reduce the amount of http requests to 5 concurrent requests at a time in both pip and simplepip. This is to avoid httpclient timing out due to too many requests at a time. 

The fix also seems to have made the cd scan run faster. It was initially taking over 30 minutes to run on the vienna repo locally, but after throttling the requests the scan is taking about 23 minutes.

I also remove the manual disposal of httpclient, since its [not recommended](https://stackoverflow.com/questions/65363252/how-to-dispose-httpclient-after-its-finished) to manually dispose it. 