### PR TITLE
fix(rust): don't mark build deps as dev deps

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/rust/RustCliDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/rust/RustCliDetector.cs
@@ -110,7 +110,7 @@ public class RustCliDetector : FileComponentDetector, IDefaultOffComponentDetect
     {
         try
         {
-            var isDevelopmentDependency = depInfo?.DepKinds.Any(x => x.Kind is Kind.Dev or Kind.Build) ?? false;
+            var isDevelopmentDependency = depInfo?.DepKinds.Any(x => x.Kind is Kind.Dev) ?? false;
             var (name, version) = ParseNameAndVersion(id);
             var detectedComponent = new DetectedComponent(new CargoComponent(name, version));
 


### PR DESCRIPTION
Fixes #844 