### PR TITLE
Add --all-features per issue #894

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/rust/RustCliDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/rust/RustCliDetector.cs
@@ -68,6 +68,8 @@ public class RustCliDetector : FileComponentDetector, IDefaultOffComponentDetect
                 "cargo",
                 null,
                 "metadata",
+                // Use --all-features to ensure that even optional feature dependencies are detected.
+                "--all-features",
                 "--manifest-path",
                 componentStream.Location,
                 "--format-version=1",

--- a/src/Microsoft.ComponentDetection.Detectors/rust/RustCliDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/rust/RustCliDetector.cs
@@ -64,11 +64,11 @@ public class RustCliDetector : FileComponentDetector, IDefaultOffComponentDetect
                 return;
             }
 
+            // Use --all-features to ensure that even optional feature dependencies are detected.
             var cliResult = await this.cliService.ExecuteCommandAsync(
                 "cargo",
                 null,
                 "metadata",
-                // Use --all-features to ensure that even optional feature dependencies are detected.
                 "--all-features",
                 "--manifest-path",
                 componentStream.Location,


### PR DESCRIPTION
Issue #894 suggests using the `--all-features` flag for `cargo metadata` to avoid potential false negatives from dependencies that aren't used by default.

This PR adds that flag to the `cargo metadata` command line in the Rust CLI detector.
