### PR TITLE
Add a parameter to disable the summary display

### DIFF
--- a/src/Microsoft.ComponentDetection.Orchestrator/Commands/ScanSettings.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Commands/ScanSettings.cs
@@ -72,6 +72,10 @@ public class ScanSettings : BaseSettings
     [TypeConverter(typeof(CommaDelimitedConverter))]
     public IEnumerable<string> DockerImagesToScan { get; set; }
 
+    [CommandOption("--NoSummary")]
+    [Description("Do not display the detection summary on the standard output nor in the logs.")]
+    public bool NoSummary { get; set; }
+
     /// <inheritdoc />
     public override ValidationResult Validate()
     {

--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/DetectorProcessingService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/DetectorProcessingService.cs
@@ -133,7 +133,11 @@ public class DetectorProcessingService : IDetectorProcessingService
         var detectorProcessingResult = this.ConvertDetectorResultsIntoResult(results, exitCode);
 
         var totalElapsedTime = stopwatch.Elapsed.TotalSeconds;
-        this.LogTabularOutput(providerElapsedTime, totalElapsedTime);
+
+        if (!settings.NoSummary)
+        {
+            this.LogTabularOutput(providerElapsedTime, totalElapsedTime);
+        }
 
         // If there are components which are skipped due to connection or parsing
         // errors, log them by detector.


### PR DESCRIPTION
Fixes #900

This PR just adds a parameter to `ScanCommandSettings`: `--NoSummary` to completely disable the rendering/logging of the detection summary.

This is useful when an application directly controls the execution of the `component-detection`. Displaying the detection summary directly on the standard output can interfere with the main application's own output.

The manifest already provides all the necessary information for the host application to display it's own status.

I did not add a test for this super simple feature. Because this is an implementation detail of the `DetectorProcessingService` that doesn't seem easily testable with the available mocks. 

Thanks!