### PR TITLE
Update documentation for detector arguments

### DIFF
--- a/docs/detector-arguments.md
+++ b/docs/detector-arguments.md
@@ -62,6 +62,12 @@ dotnet run --project "src\Microsoft.ComponentDetection\Microsoft.ComponentDetect
 
   --Output                    Output path for log files. Defaults to %TMP%
 
+  --PrintManifest             Prints the manifest to standard output.
+                              Logging will be redirected to standard error.
+
+  --NoSummary                 Do not display the detection summary on the standard
+                              output nor in the logs.
+
   --AdditionalDITargets       Comma separated list of paths to additional
                               dependency injection targets.
 


### PR DESCRIPTION
Following changes in https://github.com/microsoft/component-detection/pull/917 for `--NoSummary`

I also documented `--PrintManifest` which was missing.

cc @annaowens