### PR TITLE
Resolve Pip TryAdd exception on duplicates

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/pip/IPyPiClient.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/IPyPiClient.cs
@@ -215,7 +215,7 @@ public sealed class PyPiClient : IPyPiClient, IDisposable
             {
                 this.logger.LogError(
                     ae,
-                    "Component {ReleaseKey} : {ReleaseValue)} could not be added to the sorted list of pip components for spec={SpecName}. Usually this happens with unexpected PyPi version formats (e.g. prerelease/dev versions).",
+                    "Component {ReleaseKey} : {ReleaseValue} could not be added to the sorted list of pip components for spec={SpecName}. Usually this happens with unexpected PyPi version formats (e.g. prerelease/dev versions).",
                     release.Key,
                     JsonConvert.SerializeObject(release.Value),
                     spec.Name);


### PR DESCRIPTION
Fixes #862 where multiple threads are attempting to parse the version RegEx at once and `.Add` failing due to duplicates.