### PR TITLE
Make Python detection more resilient to unexpected failure cases

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/pip/IPyPiClient.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/IPyPiClient.cs
@@ -158,7 +158,7 @@ public sealed class PyPiClient : IPyPiClient, IDisposable
                 using var r = new PypiRetryTelemetryRecord { Name = spec.Name, DependencySpecifiers = spec.DependencySpecifiers?.ToArray(), StatusCode = result.Result.StatusCode };
 
                 this.logger.LogWarning(
-                    "Received {StatusCode} {ReasonPhrase} from {RequestUri}. Waiting {TimeSpan} before retry attempt {RetryCount}",
+                    "Received status:{StatusCode} with reason:{ReasonPhrase} from {RequestUri}. Waiting {TimeSpan} before retry attempt {RetryCount}",
                     result.Result.StatusCode,
                     result.Result.ReasonPhrase,
                     requestUri,
@@ -190,7 +190,7 @@ public sealed class PyPiClient : IPyPiClient, IDisposable
         {
             using var r = new PypiFailureTelemetryRecord { Name = spec.Name, DependencySpecifiers = spec.DependencySpecifiers?.ToArray(), StatusCode = request.StatusCode };
 
-            this.logger.LogWarning("Received {StatusCode} {ReasonPhrase} from {RequestUri}", request.StatusCode, request.ReasonPhrase, requestUri);
+            this.logger.LogWarning("Received status:{StatusCode} with reason:{ReasonPhrase} from {RequestUri}", request.StatusCode, request.ReasonPhrase, requestUri);
 
             return new PythonProject();
         }
@@ -212,7 +212,7 @@ public sealed class PyPiClient : IPyPiClient, IDisposable
                     parsedVersion.Valid && parsedVersion.IsReleasedPackage &&
                     PythonVersionUtilities.VersionValidForSpec(release.Key, spec.DependencySpecifiers))
                 {
-                    versions.Releases.Add(release.Key, release.Value);
+                    versions.Releases[release.Key] = release.Value;
                 }
             }
             catch (ArgumentException ae)

--- a/src/Microsoft.ComponentDetection.Detectors/pip/PythonResolverBase.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/PythonResolverBase.cs
@@ -1,0 +1,107 @@
+namespace Microsoft.ComponentDetection.Detectors.Pip;
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.ComponentDetection.Contracts.TypedComponent;
+using Microsoft.Extensions.Logging;
+using MoreLinq;
+using Newtonsoft.Json;
+
+public abstract class PythonResolverBase
+{
+    private readonly ILogger logger;
+
+    internal PythonResolverBase(ILogger logger) => this.logger = logger;
+
+    /// <summary>
+    /// Given a state, node, and new spec, will reprocess a new valid version for the node.
+    /// </summary>
+    /// <param name="state">The PythonResolverState.</param>
+    /// <param name="node">The PipGraphNode.</param>
+    /// <param name="newSpec">The PipDependencySpecification.</param>
+    /// <returns>Returns true if the node can be reprocessed else false.</returns>
+    protected async Task<bool> InvalidateAndReprocessAsync(
+        PythonResolverState state,
+        PipGraphNode node,
+        PipDependencySpecification newSpec)
+    {
+        var pipComponent = node.Value;
+
+        var oldVersions = state.ValidVersionMap[pipComponent.Name].Keys.ToList();
+        var currentSelectedVersion = node.Value.Version;
+        var currentReleases = state.ValidVersionMap[pipComponent.Name][currentSelectedVersion];
+        foreach (var version in oldVersions.Where(version => !PythonVersionUtilities.VersionValidForSpec(version, newSpec.DependencySpecifiers)))
+        {
+            state.ValidVersionMap[pipComponent.Name].Remove(version);
+        }
+
+        if (state.ValidVersionMap[pipComponent.Name].Count == 0)
+        {
+            state.ValidVersionMap[pipComponent.Name][currentSelectedVersion] = currentReleases;
+            return false;
+        }
+
+        var candidateVersion = state.ValidVersionMap[pipComponent.Name].Keys.Any() ? state.ValidVersionMap[pipComponent.Name].Keys.Last() : null;
+
+        node.Value = new PipComponent(pipComponent.Name, candidateVersion, author: pipComponent.Author, license: pipComponent.License);
+
+        var fetchedDependences = await this.FetchPackageDependenciesAsync(state, newSpec);
+        var dependencies = this.ResolveDependencySpecifications(pipComponent, fetchedDependences);
+
+        var toRemove = new List<PipGraphNode>();
+        foreach (var child in node.Children)
+        {
+            var pipChild = child.Value;
+
+            if (!dependencies.TryGetValue(pipChild.Name, out var newDependency))
+            {
+                toRemove.Add(child);
+            }
+            else if (!PythonVersionUtilities.VersionValidForSpec(pipChild.Version, newDependency.DependencySpecifiers))
+            {
+                if (!await this.InvalidateAndReprocessAsync(state, child, newDependency))
+                {
+                    return false;
+                }
+            }
+        }
+
+        foreach (var remove in toRemove)
+        {
+            node.Children.Remove(remove);
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Multiple dependency specification versions can be given for a single package name.
+    /// Until a better method is devised, choose the latest entry.
+    /// See https://github.com/microsoft/component-detection/issues/963.
+    /// </summary>
+    /// <returns>Dictionary of package names to dependency version specifiers.</returns>
+    public Dictionary<string, PipDependencySpecification> ResolveDependencySpecifications(PipComponent component, IList<PipDependencySpecification> fetchedDependences)
+    {
+        var dependencies = new Dictionary<string, PipDependencySpecification>();
+        fetchedDependences.ForEach(d =>
+        {
+            if (!dependencies.TryAdd(d.Name, d))
+            {
+                this.logger.LogWarning(
+                    "Duplicate package dependencies entry for component:{ComponentName} with dependency:{DependencyName}. Existing dependency specifiers: {ExistingSpecifiers}. New dependency specifiers: {NewSpecifiers}.",
+                    component.Name,
+                    d.Name,
+                    JsonConvert.SerializeObject(dependencies[d.Name].DependencySpecifiers),
+                    JsonConvert.SerializeObject(d.DependencySpecifiers));
+                dependencies[d.Name] = d;
+            }
+        });
+
+        return dependencies;
+    }
+
+    protected abstract Task<IList<PipDependencySpecification>> FetchPackageDependenciesAsync(
+        PythonResolverState state,
+        PipDependencySpecification spec);
+}

--- a/src/Microsoft.ComponentDetection.Detectors/pip/SimplePythonResolver.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/SimplePythonResolver.cs
@@ -230,7 +230,12 @@ public class SimplePythonResolver : ISimplePythonResolver
     private SortedDictionary<string, IList<PythonProjectRelease>> ConvertSimplePypiProjectToSortedDictionary(SimplePypiProject simplePypiProject, PipDependencySpecification spec)
     {
         var sortedProjectVersions = new SortedDictionary<string, IList<PythonProjectRelease>>(new PythonVersionComparer());
-        foreach (var file in simplePypiProject?.Files)
+        if (simplePypiProject is null)
+        {
+            return sortedProjectVersions;
+        }
+
+        foreach (var file in simplePypiProject.Files)
         {
             try
             {

--- a/src/Microsoft.ComponentDetection.Detectors/pip/SimplePythonResolver.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/SimplePythonResolver.cs
@@ -13,7 +13,7 @@ using Microsoft.Extensions.Logging;
 using MoreLinq;
 using Newtonsoft.Json;
 
-public class SimplePythonResolver : ISimplePythonResolver
+public class SimplePythonResolver : PythonResolverBase, ISimplePythonResolver
 {
     private static readonly Regex VersionRegex = new(@"-((\d+)((\.)\w+((\+|\.)\w*)*)*)(.tar|-)", RegexOptions.Compiled);
 
@@ -26,6 +26,7 @@ public class SimplePythonResolver : ISimplePythonResolver
     /// <param name="simplePypiClient">The simple PyPi client.</param>
     /// <param name="logger">The logger.</param>
     public SimplePythonResolver(ISimplePyPiClient simplePypiClient, ILogger<SimplePythonResolver> logger)
+        : base(logger)
     {
         this.simplePypiClient = simplePypiClient;
         this.logger = logger;
@@ -275,7 +276,7 @@ public class SimplePythonResolver : ISimplePythonResolver
     /// <param name="state"> The PythonResolverState. </param>
     /// <param name="spec"> The PipDependencySpecification. </param>
     /// <returns> Returns a list of PipDependencySpecification. </returns>
-    private async Task<IList<PipDependencySpecification>> FetchPackageDependenciesAsync(
+    protected override async Task<IList<PipDependencySpecification>> FetchPackageDependenciesAsync(
         PythonResolverState state,
         PipDependencySpecification spec)
     {
@@ -340,82 +341,5 @@ public class SimplePythonResolver : ISimplePythonResolver
         dependencies.AddRange(content.Where(x => !x.Contains("extra ==")).Select(deps => new PipDependencySpecification(deps, true)));
 
         return dependencies;
-    }
-
-    /// <summary>
-    /// Given a state, node, and new spec, will reprocess a new valid version for the node.
-    /// </summary>
-    /// <param name="state"> The PythonResolverState. </param>
-    /// <param name="node"> The PipGraphNode. </param>
-    /// <param name="newSpec"> The PipDependencySpecification. </param>
-    /// <returns> Returns true if the node can be reprocessed else false. </returns>
-    private async Task<bool> InvalidateAndReprocessAsync(
-        PythonResolverState state,
-        PipGraphNode node,
-        PipDependencySpecification newSpec)
-    {
-        var pipComponent = node.Value;
-
-        var oldVersions = state.ValidVersionMap[pipComponent.Name].Keys.ToList();
-        var currentSelectedVersion = node.Value.Version;
-        var currentReleases = state.ValidVersionMap[pipComponent.Name][currentSelectedVersion];
-        foreach (var version in oldVersions.Where(version => !PythonVersionUtilities.VersionValidForSpec(version, newSpec.DependencySpecifiers)))
-        {
-            state.ValidVersionMap[pipComponent.Name].Remove(version);
-        }
-
-        if (state.ValidVersionMap[pipComponent.Name].Count == 0)
-        {
-            state.ValidVersionMap[pipComponent.Name][currentSelectedVersion] = currentReleases;
-            return false;
-        }
-
-        var candidateVersion = state.ValidVersionMap[pipComponent.Name].Keys.Any() ? state.ValidVersionMap[pipComponent.Name].Keys.Last() : null;
-
-        node.Value = new PipComponent(pipComponent.Name, candidateVersion);
-
-        var fetchedDependences = await this.FetchPackageDependenciesAsync(state, newSpec);
-
-        // Multiple dependency specification versions can be given for a single package name
-        // Until a better method is divised, choose the latest entry
-        var dependencies = new Dictionary<string, PipDependencySpecification>();
-        fetchedDependences.ForEach(d =>
-        {
-            if (!dependencies.TryAdd(d.Name, d))
-            {
-                this.logger.LogWarning(
-                    "Duplicate package dependencies entry for component:{ComponentName} with dependency:{DependencyName}. Existing dependency specifiers: {ExistingSpecifiers}. New dependency specifiers: {NewSpecifiers}.",
-                    pipComponent.Name,
-                    d.Name,
-                    JsonConvert.SerializeObject(dependencies[d.Name].DependencySpecifiers),
-                    JsonConvert.SerializeObject(d.DependencySpecifiers));
-                dependencies[d.Name] = d;
-            }
-        });
-
-        var toRemove = new List<PipGraphNode>();
-        foreach (var child in node.Children)
-        {
-            var pipChild = child.Value;
-
-            if (!dependencies.TryGetValue(pipChild.Name, out var newDependency))
-            {
-                toRemove.Add(child);
-            }
-            else if (!PythonVersionUtilities.VersionValidForSpec(pipChild.Version, newDependency.DependencySpecifiers))
-            {
-                if (!await this.InvalidateAndReprocessAsync(state, child, newDependency))
-                {
-                    return false;
-                }
-            }
-        }
-
-        foreach (var remove in toRemove)
-        {
-            node.Children.Remove(remove);
-        }
-
-        return true;
     }
 }


### PR DESCRIPTION
In the Python detectors, there are a few exceptions which are currently unhandled, leading to failures in detection which are not well presented to the user. Add some additional handling when this occurs so users have a good idea of why the error occurred and can investigate themselves to see if detection or their requirements need changes. Related issue #928 

**First case:**
Python package has multiple dependencies specified with the same package name, but differing version constraints. An exception will be hit because of the `ToDictionary` call which expects distinct values.
```
System.ArgumentException: An item with the same key has already been added. Key: portalocker
   at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
   at System.Collections.Generic.Dictionary`2.Add(TKey key, TValue value)
   at System.Linq.Enumerable.ToDictionary[TSource,TKey,TElement](List`1 source, Func`2 keySelector, Func`2 elementSelector, IEqualityComparer`1 comparer)
   at System.Linq.Enumerable.ToDictionary[TSource,TKey,TElement](IEnumerable`1 source, Func`2 keySelector, Func`2 elementSelector, IEqualityComparer`1 comparer)
   at Microsoft.ComponentDetection.Detectors.Pip.PythonResolver.InvalidateAndReprocessAsync(PythonResolverState state, PipGraphNode node, PipDependencySpecification newSpec)
   at Microsoft.ComponentDetection.Detectors.Pip.PythonResolver.ProcessQueueAsync(ISingleFileComponentRecorder singleFileComponentRecorder, PythonResolverState state)
   at Microsoft.ComponentDetection.Detectors.Pip.PythonResolver.ResolveRootsAsync(ISingleFileComponentRecorder singleFileComponentRecorder, IList`1 initialPackages)
   at Microsoft.ComponentDetection.Detectors.Pip.PipComponentDetector.OnFileFoundAsync(ProcessRequest processRequest, IDictionary`2 detectorArgs)
```
I'll be filing an issue here for further investigation, but for now, choose the latest specifier given to avoid skipping the dependency all together.

**Second case:**
Python package is given version constraints either from requirements.txt or package dependency version specifiers which are not resolved in PyPi. Previously only the package name was outputted to the user, meaning they don't know why a valid version wasn't found if the package exists on PyPi.