### PR TITLE
remove category usage from the poetry detector

### DIFF
--- a/docs/detectors/poetry.md
+++ b/docs/detectors/poetry.md
@@ -6,6 +6,8 @@ Poetry detection relies on a poetry.lock file being present.
 Poetry detection is performed by parsing a <em>poetry.lock</em> found under the scan directory.
 
 ## Known limitations
-Poetry detection will not work if lock files are not being used.
+1. Poetry detection will not work if lock files are not being used.
+2. Dev dependencies are flagged as normal dependencies since it is not possible to determine whether or not
+a dependency is a development dependency via the lockfile alone.
 
 Full dependency graph generation is not supported.

--- a/src/Microsoft.ComponentDetection.Detectors/poetry/Contracts/PoetryPackage.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/poetry/Contracts/PoetryPackage.cs
@@ -6,9 +6,6 @@ using System.Runtime.Serialization;
 [DataContract]
 public class PoetryPackage
 {
-    [DataMember(Name = "category")]
-    public string Category { get; set; }
-
     [DataMember(Name = "name")]
     public string Name { get; set; }
 

--- a/src/Microsoft.ComponentDetection.Detectors/poetry/PoetryComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/poetry/PoetryComponentDetector.cs
@@ -54,17 +54,15 @@ public class PoetryComponentDetector : FileComponentDetector, IExperimentalDetec
 
         poetryLock.Package.ToList().ForEach(package =>
         {
-            var isDevelopmentDependency = package.Category != "main";
-
             if (package.Source != null && package.Source.Type == "git")
             {
                 var component = new DetectedComponent(new GitComponent(new Uri(package.Source.Url), package.Source.ResolvedReference));
-                singleFileComponentRecorder.RegisterUsage(component, isDevelopmentDependency: isDevelopmentDependency);
+                singleFileComponentRecorder.RegisterUsage(component, isDevelopmentDependency: false);
             }
             else
             {
                 var component = new DetectedComponent(new PipComponent(package.Name, package.Version));
-                singleFileComponentRecorder.RegisterUsage(component, isDevelopmentDependency: isDevelopmentDependency);
+                singleFileComponentRecorder.RegisterUsage(component, isDevelopmentDependency: false);
             }
         });
         await Task.CompletedTask;

--- a/src/Microsoft.ComponentDetection.Detectors/poetry/PoetryComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/poetry/PoetryComponentDetector.cs
@@ -30,7 +30,7 @@ public class PoetryComponentDetector : FileComponentDetector, IExperimentalDetec
 
     public override IEnumerable<ComponentType> SupportedComponentTypes => new[] { ComponentType.Pip };
 
-    public override int Version { get; } = 2;
+    public override int Version { get; } = 3;
 
     public override IEnumerable<string> Categories => new List<string> { "Python" };
 

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/PoetryComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/PoetryComponentDetectorTests.cs
@@ -23,7 +23,6 @@ public class PoetryComponentDetectorTests : BaseDetectorTest<PoetryComponentDete
 name = ""certifi""
 version = ""2021.10.8""
 description = ""Python package for providing Mozilla's CA Bundle.""
-category = ""main""
 optional = false
 python-versions = ""*""
 
@@ -48,40 +47,12 @@ reference = ""custom""
     }
 
     [TestMethod]
-    public async Task TestPoetryDetector_TestDevDependencyAsync()
-    {
-        var poetryLockContent = @"[[package]]
-name = ""certifi""
-version = ""2021.10.8""
-description = ""Python package for providing Mozilla's CA Bundle.""
-category = ""dev""
-optional = false
-python-versions = ""*""
-";
-
-        var (scanResult, componentRecorder) = await this.DetectorTestUtility
-            .WithFile("poetry.lock", poetryLockContent)
-            .ExecuteDetectorAsync();
-
-        scanResult.ResultCode.Should().Be(ProcessingResultCode.Success);
-
-        var detectedComponents = componentRecorder.GetDetectedComponents();
-        detectedComponents.Should().ContainSingle();
-
-        this.AssertPipComponentNameAndVersion(detectedComponents, "certifi", "2021.10.8");
-
-        var queryString = detectedComponents.Single(component => ((PipComponent)component.Component).Name.Contains("certifi"));
-        componentRecorder.GetEffectiveDevDependencyValue(queryString.Component.Id).GetValueOrDefault(false).Should().BeTrue();
-    }
-
-    [TestMethod]
     public async Task TestPoetryDetector_TestGitDependencyAsync()
     {
         var poetryLockContent = @"[[package]]
 name = ""certifi""
 version = ""2021.10.8""
 description = ""Python package for providing Mozilla's CA Bundle.""
-category = ""dev""
 optional = false
 python-versions = ""*""
 
@@ -89,7 +60,6 @@ python-versions = ""*""
 name = ""requests""
 version = ""2.26.0""
 description = ""Python HTTP for Humans.""
-category = ""main""
 optional = false
 python-versions = "">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*""
 develop = false


### PR DESCRIPTION
As of poetry 1.5.0 this field is no longer recorded in lockfiles: https://github.com/python-poetry/poetry/blob/master/CHANGELOG.md#150---2023-05-19

This causes the poetry detector to misclassify normal dependencies as dev dependencies, due to the existing logic of classifying dependencies as normal if and only if the category field is present and "main".

This follows the approach of https://github.com/microsoft/component-detection/pull/117, which conservatively adds all dependencies from the lockfile as normal dependencies lest dev dependencies be misclassified inadvertently.