### PR TITLE
Catch version spec failures in Python detection

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/pip/PipComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/PipComponentDetector.cs
@@ -37,7 +37,7 @@ public class PipComponentDetector : FileComponentDetector
 
     public override IEnumerable<ComponentType> SupportedComponentTypes { get; } = new[] { ComponentType.Pip };
 
-    public override int Version { get; } = 6;
+    public override int Version { get; } = 7;
 
     protected override async Task<IObservable<ProcessRequest>> OnPrepareDetectionAsync(IObservable<ProcessRequest> processRequests, IDictionary<string, string> detectorArgs)
     {

--- a/src/Microsoft.ComponentDetection.Detectors/pip/SimplePipComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/SimplePipComponentDetector.cs
@@ -37,7 +37,7 @@ public class SimplePipComponentDetector : FileComponentDetector, IDefaultOffComp
 
     public override IEnumerable<ComponentType> SupportedComponentTypes { get; } = new[] { ComponentType.Pip };
 
-    public override int Version { get; } = 1;
+    public override int Version { get; } = 2;
 
     protected override async Task<IObservable<ProcessRequest>> OnPrepareDetectionAsync(IObservable<ProcessRequest> processRequests, IDictionary<string, string> detectorArgs)
     {

--- a/src/Microsoft.ComponentDetection.Detectors/pip/SimplePythonResolver.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/SimplePythonResolver.cs
@@ -161,60 +161,70 @@ public class SimplePythonResolver : PythonResolverBase, ISimplePythonResolver
 
             foreach (var dependencyNode in dependencies)
             {
-                // if we have already seen the dependency and the version we have is valid, just add the dependency to the graph
-                if (state.NodeReferences.TryGetValue(dependencyNode.Name, out var node) &&
-                    PythonVersionUtilities.VersionValidForSpec(node.Value.Version, dependencyNode.DependencySpecifiers))
+                try
                 {
-                    state.NodeReferences[currentNode.Name].Children.Add(node);
-                    node.Parents.Add(state.NodeReferences[currentNode.Name]);
-                }
-                else if (node != null)
-                {
-                    this.logger.LogWarning("Candidate version ({NodeValueId}) for {DependencyName} already exists in map and the version is NOT valid.", node.Value.Id, dependencyNode.Name);
-                    this.logger.LogWarning("Specifiers: {DependencySpecifiers} for package {CurrentNodeName} caused this.", string.Join(',', dependencyNode.DependencySpecifiers), currentNode.Name);
-
-                    // The currently selected version is invalid, try to see if there is another valid version available
-                    if (!await this.InvalidateAndReprocessAsync(state, node, dependencyNode))
+                    // if we have already seen the dependency and the version we have is valid, just add the dependency to the graph
+                    if (state.NodeReferences.TryGetValue(dependencyNode.Name, out var node) &&
+                        PythonVersionUtilities.VersionValidForSpec(node.Value.Version, dependencyNode.DependencySpecifiers))
                     {
-                        this.logger.LogWarning(
-                            "Version Resolution for {DependencyName} failed, assuming last valid version is used.",
-                            dependencyNode.Name);
-
-                        // there is no valid version available for the node, dependencies are incompatible,
+                        state.NodeReferences[currentNode.Name].Children.Add(node);
+                        node.Parents.Add(state.NodeReferences[currentNode.Name]);
                     }
-                }
-                else
-                {
-                    // We haven't encountered this package before, so let's fetch it and find a candidate
-                    var newProject = await this.simplePypiClient.GetSimplePypiProjectAsync(dependencyNode);
-
-                    if (newProject == null || !newProject.Files.Any())
+                    else if (node != null)
                     {
-                        this.logger.LogWarning(
-                             "Dependency Package {DependencyName} not found in Pypi. Skipping package",
-                             dependencyNode.Name);
-                        singleFileComponentRecorder.RegisterPackageParseFailure(dependencyNode.Name);
-                    }
+                        this.logger.LogWarning("Candidate version ({NodeValueId}) for {DependencyName} already exists in map and the version is NOT valid.", node.Value.Id, dependencyNode.Name);
+                        this.logger.LogWarning("Specifiers: {DependencySpecifiers} for package {CurrentNodeName} caused this.", string.Join(',', dependencyNode.DependencySpecifiers), currentNode.Name);
 
-                    var result = this.ConvertSimplePypiProjectToSortedDictionary(newProject, dependencyNode);
-                    if (result.Keys.Any())
-                    {
-                        state.ValidVersionMap[dependencyNode.Name] = result;
-                        var candidateVersion = state.ValidVersionMap[dependencyNode.Name].Keys.Any()
-                            ? state.ValidVersionMap[dependencyNode.Name].Keys.Last() : null;
+                        // The currently selected version is invalid, try to see if there is another valid version available
+                        if (!await this.InvalidateAndReprocessAsync(state, node, dependencyNode))
+                        {
+                            this.logger.LogWarning(
+                                "Version Resolution for {DependencyName} failed, assuming last valid version is used.",
+                                dependencyNode.Name);
 
-                        AddGraphNode(state, state.NodeReferences[currentNode.Name], dependencyNode.Name, candidateVersion);
-
-                        state.ProcessingQueue.Enqueue((root, dependencyNode));
+                            // there is no valid version available for the node, dependencies are incompatible,
+                        }
                     }
                     else
                     {
-                        this.logger.LogWarning(
-                            "Unable to resolve non-root dependency {PackageName} with version specifiers {PackageVersions} from pypi possibly due to computed version constraints. Skipping package.",
-                            dependencyNode.Name,
-                            JsonConvert.SerializeObject(dependencyNode.DependencySpecifiers));
-                        singleFileComponentRecorder.RegisterPackageParseFailure(dependencyNode.Name);
+                        // We haven't encountered this package before, so let's fetch it and find a candidate
+                        var newProject = await this.simplePypiClient.GetSimplePypiProjectAsync(dependencyNode);
+
+                        if (newProject == null || !newProject.Files.Any())
+                        {
+                            this.logger.LogWarning(
+                                 "Dependency Package {DependencyName} not found in Pypi. Skipping package",
+                                 dependencyNode.Name);
+                            singleFileComponentRecorder.RegisterPackageParseFailure(dependencyNode.Name);
+                        }
+
+                        var result = this.ConvertSimplePypiProjectToSortedDictionary(newProject, dependencyNode);
+                        if (result.Keys.Any())
+                        {
+                            state.ValidVersionMap[dependencyNode.Name] = result;
+                            var candidateVersion = state.ValidVersionMap[dependencyNode.Name].Keys.Any()
+                                ? state.ValidVersionMap[dependencyNode.Name].Keys.Last() : null;
+
+                            AddGraphNode(state, state.NodeReferences[currentNode.Name], dependencyNode.Name, candidateVersion);
+
+                            state.ProcessingQueue.Enqueue((root, dependencyNode));
+                        }
+                        else
+                        {
+                            this.logger.LogWarning(
+                                "Unable to resolve non-root dependency {PackageName} with version specifiers {PackageVersions} from pypi possibly due to computed version constraints. Skipping package.",
+                                dependencyNode.Name,
+                                JsonConvert.SerializeObject(dependencyNode.DependencySpecifiers));
+                            singleFileComponentRecorder.RegisterPackageParseFailure(dependencyNode.Name);
+                        }
                     }
+                }
+                catch (ArgumentException ae)
+                {
+                    // If version specifier parsing fails, don't attempt to reprocess because it would fail also.
+                    // Log a package failure warning and continue.
+                    this.logger.LogWarning("Failure resolving Python package {DependencyName} with message: {ExMessage}.", dependencyNode.Name, ae.Message);
+                    singleFileComponentRecorder.RegisterPackageParseFailure(dependencyNode.Name);
                 }
             }
         }


### PR DESCRIPTION
When an invalid version specification is returned from PyPi (i.e. `Requires-Dist: c (>dev)`) the current implementation of Python resolvers both throw the exception all the way out, leading to a complete failure of Python graph creation. In this case we should log the warning and continue executing to get as many dependencies as possible.