### PR TITLE
feat(rust): allow specifying features to `cargo metadata`

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -5,7 +5,7 @@ Environment variables are sometimes used to control experimental features or adv
 ## `DisableGoCliScan`
 
 If the environment variable `DisableGoCliScan` is set to "true", we fall back to parsing `go.mod` and `go.sum` ourselves. 
-Otherwise, the Go detector uses go-cli command: `go list -m all` to discover Go dependencies.
+Otherwise, the Go detector uses go-cli command: `go list -m all` to discover Go dependencies. [^1]
 
 ## `PyPiMaxCacheEntries`
 
@@ -18,4 +18,11 @@ When set to any value, enables detector experiments, a feature to compare the re
 same ecosystem. The available experiments are found in the [`Experiments\Config`](../src/Microsoft.ComponentDetection.Orchestrator/Experiments/Configs)
 folder.
 
-[1]: https://go.dev/ref/mod#go-mod-graph
+## `CD_RUST_CLI_FEATURES`
+
+Specifies the features (comma seperated) to be passed into `cargo metadata`, which tells cargo to build the project with
+the features for the workspace/project. By default, `cargo metadata` will run with `--all-features`, instructing `cargo`
+to determine the build graph if all features should be built in the project/workspace. [^2]
+
+[^1]: https://go.dev/ref/mod#go-mod-graph
+[^2]: https://doc.rust-lang.org/cargo/commands/cargo-metadata.html#feature-selection


### PR DESCRIPTION
Closes #1001 

This uses a new environment variable to configure the Rust CLI detector, `CD_RUST_CLI_FEATURES`. Open to any other ideas on how to pass this into the detector.