### PR TITLE
Support for release candidate versions python detector

### DIFF
--- a/src/Microsoft.ComponentDetection.Common/FastDirectoryWalkerFactory.cs
+++ b/src/Microsoft.ComponentDetection.Common/FastDirectoryWalkerFactory.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.ComponentDetection.Common;
+namespace Microsoft.ComponentDetection.Common;
 
 using System;
 using System.Collections.Concurrent;

--- a/src/Microsoft.ComponentDetection.Detectors/pip/IPyPiClient.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/IPyPiClient.cs
@@ -209,7 +209,7 @@ public sealed class PyPiClient : IPyPiClient, IDisposable
             {
                 var parsedVersion = PythonVersion.Create(release.Key);
                 if (release.Value != null && release.Value.Count > 0 &&
-                    parsedVersion.Valid && parsedVersion.IsReleasedPackage &&
+                    parsedVersion.Valid &&
                     PythonVersionUtilities.VersionValidForSpec(release.Key, spec.DependencySpecifiers))
                 {
                     versions.Releases[release.Key] = release.Value;

--- a/src/Microsoft.ComponentDetection.Detectors/pip/IPythonCommandService.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/IPythonCommandService.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.ComponentDetection.Detectors.Pip;
+namespace Microsoft.ComponentDetection.Detectors.Pip;
 
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/src/Microsoft.ComponentDetection.Detectors/pip/PipComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/PipComponentDetector.cs
@@ -37,7 +37,7 @@ public class PipComponentDetector : FileComponentDetector
 
     public override IEnumerable<ComponentType> SupportedComponentTypes { get; } = new[] { ComponentType.Pip };
 
-    public override int Version { get; } = 7;
+    public override int Version { get; } = 8;
 
     protected override async Task<IObservable<ProcessRequest>> OnPrepareDetectionAsync(IObservable<ProcessRequest> processRequests, IDictionary<string, string> detectorArgs)
     {

--- a/src/Microsoft.ComponentDetection.Detectors/pip/PythonCommandService.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/PythonCommandService.cs
@@ -82,7 +82,9 @@ public class PythonCommandService : IPythonCommandService
     private IList<(string PackageString, GitComponent Component)> ParseRequirementsTextFile(string path)
     {
         var items = new List<(string, GitComponent)>();
-        foreach (var line in File.ReadAllLines(path).Select(x => x.Trim().TrimEnd('\\')).Where(x => !x.StartsWith("#") && !x.StartsWith("-") && !string.IsNullOrWhiteSpace(x)))
+        foreach (var line in File.ReadAllLines(path)
+                .Select(x => x.Trim().TrimEnd('\\'))
+                .Where(x => !x.StartsWith("#") && !x.StartsWith("-") && !string.IsNullOrWhiteSpace(x)))
         {
             // We technically shouldn't be ignoring information after the ;
             // It's used to indicate environment markers like specific python versions

--- a/src/Microsoft.ComponentDetection.Detectors/pip/SimplePipComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/SimplePipComponentDetector.cs
@@ -37,7 +37,7 @@ public class SimplePipComponentDetector : FileComponentDetector, IDefaultOffComp
 
     public override IEnumerable<ComponentType> SupportedComponentTypes { get; } = new[] { ComponentType.Pip };
 
-    public override int Version { get; } = 2;
+    public override int Version { get; } = 3;
 
     protected override async Task<IObservable<ProcessRequest>> OnPrepareDetectionAsync(IObservable<ProcessRequest> processRequests, IDictionary<string, string> detectorArgs)
     {

--- a/src/Microsoft.ComponentDetection.Detectors/pip/SimplePythonResolver.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/SimplePythonResolver.cs
@@ -253,8 +253,7 @@ public class SimplePythonResolver : PythonResolverBase, ISimplePythonResolver
                 var packageType = GetPackageType(file.FileName);
                 var version = GetVersionFromFileName(file.FileName);
                 var parsedVersion = PythonVersion.Create(version);
-                if (!parsedVersion.Valid || !parsedVersion.IsReleasedPackage ||
-                    !PythonVersionUtilities.VersionValidForSpec(version, spec.DependencySpecifiers))
+                if (!parsedVersion.Valid || !PythonVersionUtilities.VersionValidForSpec(version, spec.DependencySpecifiers))
                 {
                     continue;
                 }

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/PythonCommandServiceTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/PythonCommandServiceTests.cs
@@ -179,13 +179,14 @@ other=2.1";
             using (var writer = File.CreateText(testPath))
             {
                 await writer.WriteLineAsync("knack==0.4.1");
+                await writer.WriteLineAsync("numpy==1.22.0rc3");
                 await writer.WriteLineAsync("vsts-cli-common==0.1.3    \\      ");
                 await writer.WriteLineAsync("    --hash=sha256:856476331f3e26598017290fd65bebe81c960e806776f324093a46b76fb2d1c0");
                 await writer.FlushAsync();
             }
 
             var result = await service.ParseFileAsync(testPath);
-            var expected = new string[] { "knack==0.4.1", "vsts-cli-common==0.1.3" }.Select<string, (string, GitComponent)>(dep => (dep, null)).ToArray();
+            var expected = new string[] { "knack==0.4.1", "numpy==1.22.0rc3", "vsts-cli-common==0.1.3" }.Select<string, (string, GitComponent)>(dep => (dep, null)).ToArray();
 
             result.Should().HaveCount(expected.Length);
 


### PR DESCRIPTION
This PR is to fix issue #32 

Ex of requirement.txt file
```
numpy==1.23.0rc3
xyz01==0.2
```

Dependency graph results

![image](https://github.com/microsoft/component-detection/assets/5582507/4900ffcd-54f0-4cb3-8a4f-d09e2f1a2c5b)
