### PR TITLE
Ignore leading and trailing spaces on versions

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/pip/PythonVersionUtilities.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/PythonVersionUtilities.cs
@@ -95,9 +95,10 @@ public static class PythonVersionUtilities
         }
 
         var op = spec[..i];
+        var specVerSection = spec[i..].Trim();
 
         var targetVer = PythonVersion.Create(version);
-        var specVer = PythonVersion.Create(spec[i..]);
+        var specVer = PythonVersion.Create(specVerSection);
 
         if (!targetVer.Valid)
         {
@@ -106,7 +107,7 @@ public static class PythonVersionUtilities
 
         if (!specVer.Valid)
         {
-            throw new ArgumentException($"The version specification {spec[i..]} is not a valid python version");
+            throw new ArgumentException($"The version specification {specVerSection} is not a valid python version");
         }
 
         return op switch

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/PythonVersionTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/PythonVersionTests.cs
@@ -86,6 +86,7 @@ public class PythonVersionTests
         IList<(IList<string>, IList<string>, IList<string>)> testCases = new List<(IList<string>, IList<string>, IList<string>)>
         {
             (new List<string> { "==1.0" }, new List<string> { "1.0" }, new List<string> { "1.0.1", "2.0", "0.1" }),
+            (new List<string> { "== 1.0 " }, new List<string> { "1.0" }, new List<string> { "1.0.1", "2.0", "0.1" }),
             (new List<string> { "==1.4.*" }, new List<string> { "1.4", "1.4.1", "1.4.2", "1.4.3" }, new List<string> { "1.0.1", "2.0", "0.1", "1.5", "1.5.0" }),
             (new List<string> { ">=1.0" }, new List<string> { "1.0", "1.1", "1.5" }, new List<string> { "0.9" }),
             (new List<string> { ">=1.0", "<=1.4" }, new List<string> { "1.0", "1.1", "1.4" }, new List<string> { "0.9", "1.5" }),


### PR DESCRIPTION
This PR addresses issue #833 . The root cause of the problem was our handling of versions, which included spaces. When creating a Python version from a string, we encountered an issue: the version passed as a parameter (including spaces) did not align with the value extracted from the regular expression (regex). The PR rectified this inconsistency, ensuring consistent version handling.
