### PR TITLE
Handle comments gracefully by the go fallback detector.

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/go/GoComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/go/GoComponentDetector.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.ComponentDetection.Detectors.Go;
+namespace Microsoft.ComponentDetection.Detectors.Go;
 
 using System;
 using System.Collections.Generic;
@@ -257,6 +257,12 @@ public class GoComponentDetector : FileComponentDetector
 
     private void TryRegisterDependencyFromModLine(string line, ISingleFileComponentRecorder singleFileComponentRecorder)
     {
+        if (line.Trim().StartsWith("//"))
+        {
+            // this is a comment line, ignore it
+            return;
+        }
+
         if (this.TryToCreateGoComponentFromModLine(line, out var goComponent))
         {
             singleFileComponentRecorder.RegisterUsage(new DetectedComponent(goComponent));

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/GoComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/GoComponentDetectorTests.cs
@@ -61,6 +61,29 @@ require (
     }
 
     [TestMethod]
+    public async Task TestGoModDetector_CommentsOnFile_CommentsAreIgnoredAsync()
+    {
+        var goMod =
+            @"module github.com/Azure/azure-storage-blob-go
+
+require (
+    // comment
+    github.com/kr/pretty v0.1.0 // indirect
+)";
+        var (scanResult, componentRecorder) = await this.DetectorTestUtility
+            .WithFile("go.mod", goMod)
+            .ExecuteDetectorAsync();
+
+        scanResult.ResultCode.Should().Be(ProcessingResultCode.Success);
+
+        var detectedComponents = componentRecorder.GetDetectedComponents();
+        detectedComponents.Should().ContainSingle("there is only one component definition on the file");
+
+        var discoveredComponents = detectedComponents.ToArray();
+        discoveredComponents.Where(component => component.Component.Id == "github.com/kr/pretty v0.1.0 - Go").Should().ContainSingle();
+    }
+
+    [TestMethod]
     public async Task TestGoSumDetectorWithValidFile_ReturnsSuccessfullyAsync()
     {
         var goSum =


### PR DESCRIPTION
This PR fixes issue #645. The parser of go.mod files was recognizing comments as components. The main change in this PR is to skip the lines that are comments before passing it out to the line parser. 

go.mod files do not support multiline comments. Every commented line should start with (//).
go.sum files do not support comments as there are auto-generated files.

Ex:
![image](https://github.com/microsoft/component-detection/assets/5582507/c3f66019-9549-45df-b405-1a24d8228b2b)

![image](https://github.com/microsoft/component-detection/assets/5582507/f9a71e4e-ee98-4c09-bc77-5f30bf33a53d)
