### PR TITLE
Evaluating invalid maven scope as "Compile"

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/maven/IMavenStyleDependencyGraphParserService.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/maven/IMavenStyleDependencyGraphParserService.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.ComponentDetection.Detectors.Maven;
+namespace Microsoft.ComponentDetection.Detectors.Maven;
 
 using Microsoft.ComponentDetection.Contracts;
 

--- a/src/Microsoft.ComponentDetection.Detectors/maven/MavenCommandService.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/maven/MavenCommandService.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.ComponentDetection.Detectors.Maven;
+namespace Microsoft.ComponentDetection.Detectors.Maven;
 
 using System;
 using System.IO;

--- a/src/Microsoft.ComponentDetection.Detectors/maven/MavenStyleDependencyGraphParserService.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/maven/MavenStyleDependencyGraphParserService.cs
@@ -1,12 +1,17 @@
 namespace Microsoft.ComponentDetection.Detectors.Maven;
 
 using Microsoft.ComponentDetection.Contracts;
+using Microsoft.Extensions.Logging;
 
 public class MavenStyleDependencyGraphParserService : IMavenStyleDependencyGraphParserService
 {
+    private readonly ILogger logger;
+
+    public MavenStyleDependencyGraphParserService(ILogger<MavenStyleDependencyGraphParserService> logger) => this.logger = logger;
+
     public void Parse(string[] lines, ISingleFileComponentRecorder singleFileComponentRecorder)
     {
         var parser = new MavenStyleDependencyGraphParser();
-        parser.Parse(lines, singleFileComponentRecorder);
+        parser.Parse(lines, singleFileComponentRecorder, this.logger);
     }
 }

--- a/src/Microsoft.ComponentDetection.Detectors/maven/MvnCliComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/maven/MvnCliComponentDetector.cs
@@ -36,7 +36,7 @@ public class MvnCliComponentDetector : FileComponentDetector
 
     public override IEnumerable<ComponentType> SupportedComponentTypes => new[] { ComponentType.Maven };
 
-    public override int Version => 2;
+    public override int Version => 3;
 
     public override IEnumerable<string> Categories => new[] { Enum.GetName(typeof(DetectorClass), DetectorClass.Maven) };
 

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/MavenParsingUtilitiesTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/MavenParsingUtilitiesTests.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.ComponentDetection.Detectors.Tests;
+namespace Microsoft.ComponentDetection.Detectors.Tests;
 
 using System;
 using FluentAssertions;
@@ -79,10 +79,16 @@ public class MavenParsingUtilitiesTests
     }
 
     [TestMethod]
-    public void GenerateDetectedComponentAndIsDeveDependencyAndDependencyScope_InvalidScope()
+    public void GenerateDetectedComponentAndIsDeveDependencyAndDependencyScope_InvalidScopeIsEvaluatedAsCompile()
     {
-        var ex = Assert.ThrowsException<InvalidOperationException>(
-            () => GenerateDetectedComponentAndMetadataFromMavenString("org.apache.maven:maven-artifact:jar:3.6.1-SNAPSHOT:invalidScope"));
-        ex.Message.Contains("invalid scope", StringComparison.OrdinalIgnoreCase).Should().BeTrue();
+        var componentAndMetaData =
+           GenerateDetectedComponentAndMetadataFromMavenString("org.apache.maven:maven-artifact:jar:3.6.1-SNAPSHOT:invalidScope");
+
+        componentAndMetaData.Should().NotBeNull();
+        componentAndMetaData.DependencyScope.Should().NotBeNull();
+
+        var actualComponent = (MavenComponent)componentAndMetaData.Component.Component;
+        actualComponent.Should().BeOfType<MavenComponent>();
+        componentAndMetaData.DependencyScope.Should().Be(DependencyScope.MavenCompile);
     }
 }

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/MavenParsingUtilitiesTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/MavenParsingUtilitiesTests.cs
@@ -13,7 +13,7 @@ using static Microsoft.ComponentDetection.Detectors.Maven.MavenParsingUtilities;
 public class MavenParsingUtilitiesTests
 {
     [TestMethod]
-    public void GenerateDetectedComponentAndIsDeveDependencyAndDependencyScope_HappyPath()
+    public void GenerateDetectedComponentAndIsDevDependencyAndDependencyScope_HappyPath()
     {
         var componentAndMetaData =
             GenerateDetectedComponentAndMetadataFromMavenString("org.apache.maven:maven-artifact:jar:3.6.1-SNAPSHOT:provided");
@@ -37,7 +37,7 @@ public class MavenParsingUtilitiesTests
     }
 
     [TestMethod]
-    public void GenerateDetectedComponentAndIsDeveDependencyAndDependencyScope_DefaultScopeCompile()
+    public void GenerateDetectedComponentAndIsDevDependencyAndDependencyScope_DefaultScopeCompile()
     {
         var componentAndMetaData =
             GenerateDetectedComponentAndMetadataFromMavenString("org.apache.maven:maven-artifact:jar:3.6.1-SNAPSHOT");
@@ -51,7 +51,7 @@ public class MavenParsingUtilitiesTests
     }
 
     [TestMethod]
-    public void GenerateDetectedComponentAndIsDeveDependencyAndDependencyScope_DiscardLeftoverStringWhileParsingScope()
+    public void GenerateDetectedComponentAndIsDevDependencyAndDependencyScope_DiscardLeftoverStringWhileParsingScope()
     {
         var componentAndMetaData =
             GenerateDetectedComponentAndMetadataFromMavenString("org.apache.maven:maven-artifact:jar:3.6.1-SNAPSHOT:provided (optional)");
@@ -65,7 +65,7 @@ public class MavenParsingUtilitiesTests
     }
 
     [TestMethod]
-    public void GenerateDetectedComponentAndIsDeveDependencyAndDependencyScope_DevelopmentDependencyTrue()
+    public void GenerateDetectedComponentAndIsDevDependencyAndDependencyScope_DevelopmentDependencyTrue()
     {
         var componentAndMetaData =
             GenerateDetectedComponentAndMetadataFromMavenString("org.apache.maven:maven-artifact:jar:3.6.1-SNAPSHOT:test");
@@ -79,7 +79,7 @@ public class MavenParsingUtilitiesTests
     }
 
     [TestMethod]
-    public void GenerateDetectedComponentAndIsDeveDependencyAndDependencyScope_InvalidScopeIsEvaluatedAsCompile()
+    public void GenerateDetectedComponentAndIsDevDependencyAndDependencyScope_InvalidScopeIsEvaluatedAsCompile()
     {
         var componentAndMetaData =
            GenerateDetectedComponentAndMetadataFromMavenString("org.apache.maven:maven-artifact:jar:3.6.1-SNAPSHOT:invalidScope");


### PR DESCRIPTION
### Summary: 
Currently maven detector is failing for invalid `<scope>` in maven dependency file. However, these dependencies are valid as per maven cli and evaluated as "Compile". Component Detector matches the maven's behavior to evaluate these "invalid" scope as "Compile"

#858 

### Testing:
- local testing
- updated unit test for invalid dependency 