### PR TITLE
Use a random name for working folder for IvyDetector

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/ivy/IvyDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/ivy/IvyDetector.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.ComponentDetection.Detectors.Ivy;
+namespace Microsoft.ComponentDetection.Detectors.Ivy;
 
 using System;
 using System.Collections.Generic;
@@ -125,7 +125,7 @@ public class IvyDetector : FileComponentDetector, IExperimentalDetector
     {
         try
         {
-            var workingDirectory = Path.Combine(Path.GetTempPath(), "ComponentDetection_Ivy");
+            var workingDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
             this.Logger.LogDebug("Preparing temporary Ivy project in {WorkingDirectory}", workingDirectory);
             if (Directory.Exists(workingDirectory))
             {


### PR DESCRIPTION
IvyDetector creates files in a folder named "ComponentDetection_Ivy" in the temporary folder.
However if multiple detectors run in parallel, it brings a race condition when detectors manipulate files in the same folder.

Solution: Use random name for IvyDetector working folder.