### PR TITLE
Update RustCli Parsing to process pkgId, and introduce manual override

### DIFF
--- a/src/Microsoft.ComponentDetection.Contracts/TypedComponent/CargoComponent.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/TypedComponent/CargoComponent.cs
@@ -10,12 +10,13 @@ public class CargoComponent : TypedComponent
         // reserved for deserialization
     }
 
-    public CargoComponent(string name, string version, string author = null, string license = null)
+    public CargoComponent(string name, string version, string author = null, string license = null, string source = null)
     {
         this.Name = this.ValidateRequiredInput(name, nameof(this.Name), nameof(ComponentType.Cargo));
         this.Version = this.ValidateRequiredInput(version, nameof(this.Version), nameof(ComponentType.Cargo));
         this.Author = author;
         this.License = license;
+        this.Source = source;
     }
 
     public string Name { get; set; }
@@ -28,6 +29,9 @@ public class CargoComponent : TypedComponent
 
     [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
     public string? License { get; set; }
+
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+    public string? Source { get; set; }
 #nullable disable
 
     public override ComponentType Type => ComponentType.Cargo;

--- a/src/Microsoft.ComponentDetection.Detectors/rust/RustCliDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/rust/RustCliDetector.cs
@@ -212,6 +212,16 @@ public class RustCliDetector : FileComponentDetector
         // 4. url#version => https://github.com/rust-lang/cargo#0.33.0
         // 5. url#name => https://github.com/rust-lang/crates.io-index#packageName
         // 6. url#name@version => https://github.com/rust-lang/cargo#crates-io@0.21.0
+
+        // First, try parsing using the old format in cases where a version of rust older than 1.77 is being used.
+        if (ParseDependencyCargoLock(dependency, out packageName, out version, out source))
+        {
+            if (!(string.IsNullOrEmpty(packageName) || string.IsNullOrEmpty(version)))
+            {
+                return true;
+            }
+        }
+
         var match = DependencyFormatRegexPkgId.Match(dependency);
         packageName = null;
         version = null;

--- a/src/Microsoft.ComponentDetection.Detectors/rust/RustCliDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/rust/RustCliDetector.cs
@@ -71,7 +71,7 @@ public class RustCliDetector : FileComponentDetector
     public override IEnumerable<ComponentType> SupportedComponentTypes => new[] { ComponentType.Cargo };
 
     /// <inheritdoc />
-    public override int Version => 3;
+    public override int Version => 4;
 
     /// <inheritdoc />
     public override IList<string> SearchPatterns { get; } = new[] { "Cargo.toml" };

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/RustCliDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/RustCliDetectorTests.cs
@@ -193,6 +193,180 @@ public class RustCliDetectorTests : BaseDetectorTest<RustCliDetector>
     ""metadata"": null
 }";
 
+    private readonly string mockMetadataV1pkgId = @"
+{
+    ""packages"": [
+        {
+            ""name"": ""registry-package-1"",
+            ""version"": ""1.0.1"",
+            ""id"": ""registry+https://test.com/registry-package-1#registry-package-1@1.0.1"",
+            ""license"": null,
+            ""license_file"": null,
+            ""description"": ""test registry package 1"",
+            ""source"": ""registry+https://test.com/registry-package-1"",
+            ""dependencies"": [
+                {
+                    ""name"": ""inner-dependency-1"",
+                    ""source"": ""registry+registry+https://test.com/inner-dependency-1"",
+                    ""req"": ""^0.3.0"",
+                    ""kind"": ""dev"",
+                    ""rename"": null,
+                    ""optional"": false,
+                    ""uses_default_features"": true,
+                    ""features"": [],
+                    ""target"": null,
+                    ""registry"": null
+                }
+            ]
+        },
+        {
+            ""name"": ""rust-test"",
+            ""version"": ""0.1.0"",
+            ""id"": ""path+file:///home/justin/rust-test#rust-test@0.1.0"",
+            ""license"": null,
+            ""license_file"": null,
+            ""description"": null,
+            ""source"": null,
+            ""dependencies"": [
+                {
+                    ""name"": ""registry-package-1"",
+                    ""source"": ""registry+https://test.com/registry-package-1#registry-package-1@1.0.1"",
+                    ""req"": ""^1.0.1"",
+                    ""kind"": null,
+                    ""rename"": null,
+                    ""optional"": false,
+                    ""uses_default_features"": true,
+                    ""features"": [],
+                    ""target"": null,
+                    ""registry"": null
+                },
+                {
+                    ""name"": ""rust-test-inner"",
+                    ""source"": ""(path+file:///C:/test/rust-test-inner)"",
+                    ""req"": ""*"",
+                    ""kind"": null,
+                    ""rename"": null,
+                    ""optional"": false,
+                    ""uses_default_features"": true,
+                    ""features"": [],
+                    ""target"": null,
+                    ""registry"": null,
+                    ""path"": ""C:\\test\\rust-test-inner""
+                },
+                {
+                    ""name"": ""dev-dependency-1"",
+                    ""source"": ""registry+https://test.com/dev-dependency-1"",
+                    ""req"": ""^0.4.0"",
+                    ""kind"": ""dev"",
+                    ""rename"": null,
+                    ""optional"": false,
+                    ""uses_default_features"": true,
+                    ""features"": [],
+                    ""target"": null,
+                    ""registry"": null
+                }
+            ]
+        },
+        {
+            ""name"": ""rust-test-inner"",
+            ""version"": ""0.1.0"",
+            ""id"": ""path+file:///C:/test/rust-test-inner#rust-test-inner@0.1.0"",
+            ""license"": null,
+            ""license_file"": null,
+            ""description"": null,
+            ""source"": null,
+            ""dependencies"": []
+        },
+        {
+            ""name"": ""dev-dependency-1"",
+            ""version"": ""0.4.0"",
+            ""id"": ""registry+https://test.com/dev-dependency-1#dev-dependency-1@0.4.0"",
+            ""license"": null,
+            ""license_file"": null,
+            ""description"": ""test dev dependency"",
+            ""source"": ""registry+https://github.com/rust-lang/crates.io-index"",
+            ""dependencies"": []
+        }
+    ],
+    ""workspace_members"": [
+        ""path+file:///C:/test#rust-test@0.1.0""
+    ],
+    ""workspace_default_members"": [
+        ""path+file:///C:/test#rust-test@0.1.0""
+    ],
+    ""resolve"": {
+        ""nodes"": [
+            {
+                ""id"": ""registry+https://test.com/registry-package-1#registry-package-1@1.0.1"",
+                ""dependencies"": [],
+                ""deps"": [],
+                ""features"": [
+                    ""default"",
+                    ""std""
+                ]
+            },
+            {
+                ""id"": ""path+file:///C:/test#rust-test@0.1.0"",
+                ""dependencies"": [
+                    ""registry+https://test.com/registry-package-1#registry-package-1@1.0.1"",
+                    ""path+file:///C:/test/rust-test-inner#rust-test-inner@0.1.0"",
+                    ""registry+https://test.com/dev-dependency-1#dev-dependency-1@0.4.0""
+                ],
+                ""deps"": [
+                    {
+                        ""name"": ""registry-package-1"",
+                        ""pkg"": ""registry+https://test.com/registry-package-1#registry-package-1@1.0.1"",
+                        ""dep_kinds"": [
+                            {
+                                ""kind"": null,
+                                ""target"": null
+                            }
+                        ]
+                    },
+                    {
+                        ""name"": ""cargo"",
+                        ""pkg"": ""path+file:///C:/test/rust-test-inner#rust-test-inner@0.1.0"",
+                        ""dep_kinds"": [
+                            {
+                                ""kind"": null,
+                                ""target"": null
+                            }
+                        ]
+                    },
+                    {
+                        ""name"": ""dev-dependency-1"",
+                        ""pkg"": ""registry+https://test.com/dev-dependency-1#dev-dependency-1@0.4.0"",
+                        ""dep_kinds"": [
+                            {
+                                ""kind"": ""dev"",
+                                ""target"": null
+                            }
+                        ]
+                    }
+                ],
+                ""features"": []
+            },
+            {
+                ""id"": ""path+file:///C:/test/rust-test-inner#rust-test-inner@0.1.0"",
+                ""dependencies"": [],
+                ""deps"": [],
+                ""features"": []
+            },
+            {
+                ""id"": ""registry+https://test.com/dev-dependency-1#dev-dependency-1@0.4.0"",
+                ""dependencies"": [],
+                ""deps"": [],
+                ""features"": []
+            }
+        ],
+        ""root"": ""path+file:///C:/test#rust-test@0.1.0""
+    },
+    ""target_directory"": ""C:\\test"",
+    ""version"": 1,
+    ""workspace_root"": ""C:\\test"",
+    ""metadata"": null
+}";
+
     private readonly string mockMetadataWithLicenses = @"
 {
     ""packages"": [
@@ -504,15 +678,20 @@ public class RustCliDetectorTests : BaseDetectorTest<RustCliDetector>
 }";
 
     private Mock<ICommandLineInvocationService> mockCliService;
+
+    private Mock<IEnvironmentVariableService> mockEnvVarService;
+
     private Mock<IComponentStreamEnumerableFactory> mockComponentStreamEnumerableFactory;
 
     [TestInitialize]
-    public void InitCliMock()
+    public void InitMocks()
     {
         this.mockCliService = new Mock<ICommandLineInvocationService>();
         this.DetectorTestUtility.AddServiceMock(this.mockCliService);
         this.mockComponentStreamEnumerableFactory = new Mock<IComponentStreamEnumerableFactory>();
         this.DetectorTestUtility.AddServiceMock(this.mockComponentStreamEnumerableFactory);
+        this.mockEnvVarService = new Mock<IEnvironmentVariableService>();
+        this.DetectorTestUtility.AddServiceMock(this.mockEnvVarService);
     }
 
     [TestMethod]
@@ -546,6 +725,80 @@ public class RustCliDetectorTests : BaseDetectorTest<RustCliDetector>
 
         scanResult.ResultCode.Should().Be(ProcessingResultCode.Success);
         componentRecorder.GetDetectedComponents().Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task RustCliDetector_RespectsFallBackVariableAsync()
+    {
+        var testCargoLockString = @"
+[[package]]
+name = ""my_dependency""
+version = ""1.0.0""
+source = ""registry+https://github.com/rust-lang/crates.io-index""
+dependencies = [
+  ""same_package 1.0.0""
+]
+
+[[package]]
+name = ""other_dependency""
+version = ""0.4.0""
+source = ""registry+https://github.com/rust-lang/crates.io-index""
+dependencies = [
+ ""other_dependency_dependency"",
+]
+
+[[package]]
+name = ""other_dependency_dependency""
+version = ""0.1.12-alpha.6""
+source = ""registry+https://github.com/rust-lang/crates.io-index""
+
+[[package]]
+name = ""my_dev_dependency""
+version = ""1.0.0""
+source = ""registry+https://github.com/rust-lang/crates.io-index""
+dependencies = [
+ ""other_dependency_dependency 0.1.12-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)"",
+ ""dev_dependency_dependency 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)"",
+]";
+        this.mockCliService.Setup(x => x.CanCommandBeLocatedAsync("cargo", It.IsAny<IEnumerable<string>>())).ReturnsAsync(true);
+        this.mockCliService.Setup(x => x.ExecuteCommandAsync(It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<string[]>()))
+            .Throws(new InvalidOperationException());
+        this.mockEnvVarService
+                    .Setup(x => x.IsEnvironmentVariableValueTrue("DisableRustCliScan"))
+                    .Returns(true);
+        using var stream = new MemoryStream();
+        using var writer = new StreamWriter(stream);
+        await writer.WriteAsync(testCargoLockString);
+        await writer.FlushAsync();
+        stream.Position = 0;
+        this.mockComponentStreamEnumerableFactory.Setup(x => x.GetComponentStreams(It.IsAny<DirectoryInfo>(), new List<string> { "Cargo.lock" }, It.IsAny<ExcludeDirectoryPredicate>(), false))
+            .Returns(new[] { new ComponentStream() { Location = "Cargo.toml", Stream = stream } });
+
+        var (scanResult, componentRecorder) = await this.DetectorTestUtility
+            .WithFile("Cargo.toml", string.Empty)
+            .ExecuteDetectorAsync();
+
+        scanResult.ResultCode.Should().Be(ProcessingResultCode.Success);
+        componentRecorder.GetDetectedComponents().Should().HaveCount(4);
+
+        componentRecorder
+            .GetDetectedComponents()
+            .Select(x => x.Component.Id)
+            .Should()
+            .BeEquivalentTo("other_dependency_dependency 0.1.12-alpha.6 - Cargo", "my_dev_dependency 1.0.0 - Cargo", "my_dependency 1.0.0 - Cargo", "other_dependency 0.4.0 - Cargo");
+
+        var components = componentRecorder.GetDetectedComponents();
+
+        foreach (var component in components)
+        {
+            if (component.Component is CargoComponent cargoComponent)
+            {
+                cargoComponent.Author.Should().Be(null);
+                cargoComponent.License.Should().Be(null);
+            }
+        }
+
+        return;
     }
 
     [TestMethod]
@@ -587,25 +840,47 @@ public class RustCliDetectorTests : BaseDetectorTest<RustCliDetector>
     }
 
     [TestMethod]
+    public async Task RustCliDetector_RegistersCorrectRootDepsPkgIdAsync()
+    {
+        var cargoMetadata = this.mockMetadataV1pkgId;
+        this.mockCliService.Setup(x => x.CanCommandBeLocatedAsync("cargo", It.IsAny<IEnumerable<string>>())).ReturnsAsync(true);
+        this.mockCliService.Setup(x => x.ExecuteCommandAsync(It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<string[]>()))
+            .ReturnsAsync(new CommandLineExecutionResult { StdOut = cargoMetadata });
+
+        var (scanResult, componentRecorder) = await this.DetectorTestUtility
+            .WithFile("Cargo.toml", string.Empty)
+            .ExecuteDetectorAsync();
+
+        scanResult.ResultCode.Should().Be(ProcessingResultCode.Success);
+        componentRecorder.GetDetectedComponents().Should().HaveCount(2);
+
+        componentRecorder
+            .GetDetectedComponents()
+            .Select(x => x.Component.Id)
+            .Should()
+            .BeEquivalentTo("registry-package-1 1.0.1 - Cargo", "dev-dependency-1 0.4.0 - Cargo");
+    }
+
+    [TestMethod]
     public async Task RustCliDetector_NotInGraphAsync()
     {
         var cargoMetadata = @"
 {
     ""packages"": [],
     ""workspace_members"": [
-        ""rust-test 0.1.0 (path+file:///home/justin/rust-test)""
+        ""path+file:///home/justin/rust-test#rust-test@0.1.0""
     ],
     ""resolve"": {
         ""nodes"": [
             {
-                ""id"": ""rust-test 0.1.0 (path+file:///home/justin/rust-test)"",
+                ""id"": ""path+file:///home/justin/rust-test#rust-test@0.1.0"",
                 ""dependencies"": [
-                    ""libc 0.2.147 (registry+https://github.com/rust-lang/crates.io-index)""
+                    ""registry+https://github.com/rust-lang/crates.io-index#libc@0.2.147""
                 ],
                 ""deps"": [
                     {
                         ""name"": ""libc"",
-                        ""pkg"": ""libc 0.2.147 (registry+https://github.com/rust-lang/crates.io-index)"",
+                        ""pkg"": ""registry+https://github.com/rust-lang/crates.io-index#libc@0.2.147"",
                         ""dep_kinds"": [
                             {
                                 ""kind"": null,
@@ -617,7 +892,7 @@ public class RustCliDetectorTests : BaseDetectorTest<RustCliDetector>
                 ""features"": []
             }
         ],
-        ""root"": ""rust-test 0.1.0 (path+file:///home/justin/rust-test)""
+        ""root"": ""path+file:///home/justin/rust-test#rust-test@0.1.0""
     },
     ""target_directory"": ""/home/justin/rust-test/target"",
     ""version"": 1,
@@ -643,14 +918,14 @@ public class RustCliDetectorTests : BaseDetectorTest<RustCliDetector>
 {
     ""packages"": [],
     ""workspace_members"": [
-        ""rust-test 0.1.0 (path+file:///home/justin/rust-test)""
+        ""path+file:///home/justin/rust-test#rust-test@0.1.0""
     ],
     ""resolve"": {
         ""nodes"": [
             {
-                ""id"": ""rust-test 0.1.0 (path+file:///home/justin/rust-test)"",
+                ""id"": ""path+file:///home/justin/rust-test#rust-test@0.1.0"",
                 ""dependencies"": [
-                    ""libc 0.2.147 (registry+https://github.com/rust-lang/crates.io-index)""
+                    ""registry+https://github.com/rust-lang/crates.io-index#libc@0.2.147""
                 ],
                 ""deps"": [
                     {
@@ -667,7 +942,7 @@ public class RustCliDetectorTests : BaseDetectorTest<RustCliDetector>
                 ""features"": []
             }
         ],
-        ""root"": ""rust-test 0.1.0 (path+file:///home/justin/rust-test)""
+        ""root"": ""path+file:///home/justin/rust-test#rust-test@0.1.0""
     },
     ""target_directory"": ""/home/justin/rust-test/target"",
     ""version"": 1,
@@ -759,12 +1034,12 @@ public class RustCliDetectorTests : BaseDetectorTest<RustCliDetector>
 {
     ""packages"": [],
     ""workspace_members"": [
-        ""rust-test 0.1.0 (path+file:///home/justin/rust-test)""
+        ""path+file:///home/justin/rust-test#rust-test@0.1.0""
     ],
     ""resolve"": {
         ""nodes"": [
             {
-                ""id"": ""libc 0.2.147 (registry+https://github.com/rust-lang/crates.io-index)"",
+                ""id"": ""registry+https://github.com/rust-lang/crates.io-index#libc@0.2.147"",
                 ""dependencies"": [],
                 ""deps"": [],
                 ""features"": [
@@ -773,14 +1048,14 @@ public class RustCliDetectorTests : BaseDetectorTest<RustCliDetector>
                 ]
             },
             {
-                ""id"": ""rust-test 0.1.0 (path+file:///home/justin/rust-test)"",
+                ""id"": ""path+file:///home/justin/rust-test#rust-test@0.1.0"",
                 ""dependencies"": [
-                    ""libc 0.2.147 (registry+https://github.com/rust-lang/crates.io-index)""
+                    ""registry+https://github.com/rust-lang/crates.io-index#libc@0.2.147""
                 ],
                 ""deps"": [
                     {
                         ""name"": ""libc"",
-                        ""pkg"": ""libc 0.2.147 (registry+https://github.com/rust-lang/crates.io-index)"",
+                        ""pkg"": ""registry+https://github.com/rust-lang/crates.io-index#libc@0.2.147"",
                         ""dep_kinds"": [
                             {
                                 ""kind"": null,
@@ -792,13 +1067,13 @@ public class RustCliDetectorTests : BaseDetectorTest<RustCliDetector>
                 ""features"": []
             }
         ],
-        ""root"": ""rust-test 0.1.0 (path+file:///home/justin/rust-test)""
+        ""root"": ""path+file:///home/justin/rust-test#rust-test@0.1.0""
     },
     ""packages"": [
     {
       ""name"": ""libc"",
       ""version"": ""0.2.147"",
-      ""id"": ""libc 0.2.147 (registry+https://github.com/rust-lang/crates.io-index)"",
+      ""id"": ""registry+https://github.com/rust-lang/crates.io-index#libc@0.2.147"",
       ""license"": """",
       ""license_file"": null,
       ""description"": """",
@@ -826,7 +1101,7 @@ public class RustCliDetectorTests : BaseDetectorTest<RustCliDetector>
     {
       ""name"": ""rust-test"",
       ""version"": ""0.1.0"",
-      ""id"": ""rust-test (registry+https://github.com/rust-lang/crates.io-index)"",
+      ""id"": ""registry+https://github.com/rust-lang/crates.io-index#rust-test"",
       ""license"": """",
       ""license_file"": null,
       ""description"": ""A non-cryptographic hash function using AES-NI for high performance"",

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/RustCliDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/RustCliDetectorTests.cs
@@ -193,180 +193,6 @@ public class RustCliDetectorTests : BaseDetectorTest<RustCliDetector>
     ""metadata"": null
 }";
 
-    private readonly string mockMetadataV1pkgId = @"
-{
-    ""packages"": [
-        {
-            ""name"": ""registry-package-1"",
-            ""version"": ""1.0.1"",
-            ""id"": ""registry+https://test.com/registry-package-1#registry-package-1@1.0.1"",
-            ""license"": null,
-            ""license_file"": null,
-            ""description"": ""test registry package 1"",
-            ""source"": ""registry+https://test.com/registry-package-1"",
-            ""dependencies"": [
-                {
-                    ""name"": ""inner-dependency-1"",
-                    ""source"": ""registry+registry+https://test.com/inner-dependency-1"",
-                    ""req"": ""^0.3.0"",
-                    ""kind"": ""dev"",
-                    ""rename"": null,
-                    ""optional"": false,
-                    ""uses_default_features"": true,
-                    ""features"": [],
-                    ""target"": null,
-                    ""registry"": null
-                }
-            ]
-        },
-        {
-            ""name"": ""rust-test"",
-            ""version"": ""0.1.0"",
-            ""id"": ""path+file:///home/justin/rust-test#rust-test@0.1.0"",
-            ""license"": null,
-            ""license_file"": null,
-            ""description"": null,
-            ""source"": null,
-            ""dependencies"": [
-                {
-                    ""name"": ""registry-package-1"",
-                    ""source"": ""registry+https://test.com/registry-package-1#registry-package-1@1.0.1"",
-                    ""req"": ""^1.0.1"",
-                    ""kind"": null,
-                    ""rename"": null,
-                    ""optional"": false,
-                    ""uses_default_features"": true,
-                    ""features"": [],
-                    ""target"": null,
-                    ""registry"": null
-                },
-                {
-                    ""name"": ""rust-test-inner"",
-                    ""source"": ""(path+file:///C:/test/rust-test-inner)"",
-                    ""req"": ""*"",
-                    ""kind"": null,
-                    ""rename"": null,
-                    ""optional"": false,
-                    ""uses_default_features"": true,
-                    ""features"": [],
-                    ""target"": null,
-                    ""registry"": null,
-                    ""path"": ""C:\\test\\rust-test-inner""
-                },
-                {
-                    ""name"": ""dev-dependency-1"",
-                    ""source"": ""registry+https://test.com/dev-dependency-1"",
-                    ""req"": ""^0.4.0"",
-                    ""kind"": ""dev"",
-                    ""rename"": null,
-                    ""optional"": false,
-                    ""uses_default_features"": true,
-                    ""features"": [],
-                    ""target"": null,
-                    ""registry"": null
-                }
-            ]
-        },
-        {
-            ""name"": ""rust-test-inner"",
-            ""version"": ""0.1.0"",
-            ""id"": ""path+file:///C:/test/rust-test-inner#rust-test-inner@0.1.0"",
-            ""license"": null,
-            ""license_file"": null,
-            ""description"": null,
-            ""source"": null,
-            ""dependencies"": []
-        },
-        {
-            ""name"": ""dev-dependency-1"",
-            ""version"": ""0.4.0"",
-            ""id"": ""registry+https://test.com/dev-dependency-1#dev-dependency-1@0.4.0"",
-            ""license"": null,
-            ""license_file"": null,
-            ""description"": ""test dev dependency"",
-            ""source"": ""registry+https://github.com/rust-lang/crates.io-index"",
-            ""dependencies"": []
-        }
-    ],
-    ""workspace_members"": [
-        ""path+file:///C:/test#rust-test@0.1.0""
-    ],
-    ""workspace_default_members"": [
-        ""path+file:///C:/test#rust-test@0.1.0""
-    ],
-    ""resolve"": {
-        ""nodes"": [
-            {
-                ""id"": ""registry+https://test.com/registry-package-1#registry-package-1@1.0.1"",
-                ""dependencies"": [],
-                ""deps"": [],
-                ""features"": [
-                    ""default"",
-                    ""std""
-                ]
-            },
-            {
-                ""id"": ""path+file:///C:/test#rust-test@0.1.0"",
-                ""dependencies"": [
-                    ""registry+https://test.com/registry-package-1#registry-package-1@1.0.1"",
-                    ""path+file:///C:/test/rust-test-inner#rust-test-inner@0.1.0"",
-                    ""registry+https://test.com/dev-dependency-1#dev-dependency-1@0.4.0""
-                ],
-                ""deps"": [
-                    {
-                        ""name"": ""registry-package-1"",
-                        ""pkg"": ""registry+https://test.com/registry-package-1#registry-package-1@1.0.1"",
-                        ""dep_kinds"": [
-                            {
-                                ""kind"": null,
-                                ""target"": null
-                            }
-                        ]
-                    },
-                    {
-                        ""name"": ""cargo"",
-                        ""pkg"": ""path+file:///C:/test/rust-test-inner#rust-test-inner@0.1.0"",
-                        ""dep_kinds"": [
-                            {
-                                ""kind"": null,
-                                ""target"": null
-                            }
-                        ]
-                    },
-                    {
-                        ""name"": ""dev-dependency-1"",
-                        ""pkg"": ""registry+https://test.com/dev-dependency-1#dev-dependency-1@0.4.0"",
-                        ""dep_kinds"": [
-                            {
-                                ""kind"": ""dev"",
-                                ""target"": null
-                            }
-                        ]
-                    }
-                ],
-                ""features"": []
-            },
-            {
-                ""id"": ""path+file:///C:/test/rust-test-inner#rust-test-inner@0.1.0"",
-                ""dependencies"": [],
-                ""deps"": [],
-                ""features"": []
-            },
-            {
-                ""id"": ""registry+https://test.com/dev-dependency-1#dev-dependency-1@0.4.0"",
-                ""dependencies"": [],
-                ""deps"": [],
-                ""features"": []
-            }
-        ],
-        ""root"": ""path+file:///C:/test#rust-test@0.1.0""
-    },
-    ""target_directory"": ""C:\\test"",
-    ""version"": 1,
-    ""workspace_root"": ""C:\\test"",
-    ""metadata"": null
-}";
-
     private readonly string mockMetadataWithLicenses = @"
 {
     ""packages"": [
@@ -840,28 +666,6 @@ dependencies = [
     }
 
     [TestMethod]
-    public async Task RustCliDetector_RegistersCorrectRootDepsPkgIdAsync()
-    {
-        var cargoMetadata = this.mockMetadataV1pkgId;
-        this.mockCliService.Setup(x => x.CanCommandBeLocatedAsync("cargo", It.IsAny<IEnumerable<string>>())).ReturnsAsync(true);
-        this.mockCliService.Setup(x => x.ExecuteCommandAsync(It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<string[]>()))
-            .ReturnsAsync(new CommandLineExecutionResult { StdOut = cargoMetadata });
-
-        var (scanResult, componentRecorder) = await this.DetectorTestUtility
-            .WithFile("Cargo.toml", string.Empty)
-            .ExecuteDetectorAsync();
-
-        scanResult.ResultCode.Should().Be(ProcessingResultCode.Success);
-        componentRecorder.GetDetectedComponents().Should().HaveCount(2);
-
-        componentRecorder
-            .GetDetectedComponents()
-            .Select(x => x.Component.Id)
-            .Should()
-            .BeEquivalentTo("registry-package-1 1.0.1 - Cargo", "dev-dependency-1 0.4.0 - Cargo");
-    }
-
-    [TestMethod]
     public async Task RustCliDetector_NotInGraphAsync()
     {
         var cargoMetadata = @"
@@ -1032,7 +836,6 @@ dependencies = [
     {
         var cargoMetadata = @"
 {
-    ""packages"": [],
     ""workspace_members"": [
         ""path+file:///home/justin/rust-test#rust-test@0.1.0""
     ],
@@ -1101,7 +904,7 @@ dependencies = [
     {
       ""name"": ""rust-test"",
       ""version"": ""0.1.0"",
-      ""id"": ""registry+https://github.com/rust-lang/crates.io-index#rust-test"",
+      ""id"": ""path+file:///home/justin/rust-test#rust-test@0.1.0"",
       ""license"": """",
       ""license_file"": null,
       ""description"": ""A non-cryptographic hash function using AES-NI for high performance"",


### PR DESCRIPTION
Allows users to manually override rustCLI detector by setting an environment variable DisableRustCliScan=True

Updates cargo metadata output processing to adhere to changes introduced that make the output follow the PkgId Spec: https://doc.rust-lang.org/cargo/reference/pkgid-spec.html

Changes to the metadata output were introduced in 1.77: https://github.com/rust-lang/cargo/pull/12914