### PR TITLE
Small updates to PipReport detector

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -35,6 +35,7 @@ jobs:
             { name: "Yarn", repo: "gatsbyjs/gatsby" },
           ]
       fail-fast: false
+      max-parallel: 4 # limit the total number of running jobs to avoid rate limiting
     name: ${{ matrix.language.name }}
     steps:
       - name: Checkout Component Detection

--- a/docs/detectors/pip.md
+++ b/docs/detectors/pip.md
@@ -10,6 +10,17 @@ Pip detection depends on the following to successfully run:
 
 ## Detection strategy
 
+### Installation Report (PipReportDetector)
+The `--report` option of the `pip install` command produces a detailed JSON report of what it did install (or what it would have installed). 
+See https://pip.pypa.io/en/stable/reference/installation-report/#specification for more details.
+
+Serialization specifications:
+- https://packaging.python.org/en/latest/specifications/core-metadata/
+- https://peps.python.org/pep-0508/
+- https://peps.python.org/pep-0301/
+
+### Legacy Detection (PipDetector, SimplePipDetector)
+
 Pip detection is performed by running the following code snippet on every *setup.py*:
 
 ```python
@@ -34,9 +45,12 @@ Pip detection will not run if `python` is unavailable.
 
 If no `bdist_wheel` or `bdist_egg` are available for a given component, dependencies will not be fetched.
 
-If no internet connection or a component cannot be found in Pypi, said component and its dependencies will be skipped.
+If no internet connection or a component cannot be found in PyPi, said component and its dependencies will be skipped.
 
 ## Environment Variables
 
 The environment variable `PyPiMaxCacheEntries` is used to control the size of the in-memory LRU cache that caches responses from PyPi.
 The default value is 128.
+
+The enviroment variable `PIP_INDEX_URL` is used to determine what package feed should be used for `pip install --report` detection.
+The default value will use the PyPi index unless pip defaults have been configured globally.

--- a/src/Microsoft.ComponentDetection.Detectors/pip/PipCommandService.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/PipCommandService.cs
@@ -134,16 +134,14 @@ public class PipCommandService : IPipCommandService
 
         if (command.ExitCode != 0)
         {
-            this.logger.LogWarning("PipReport: Failed to generate pip installation report for file {Path} with exit code {ExitCode}", path, command.ExitCode);
-            this.logger.LogDebug("PipReport: Pip installation report error: {StdErr}", command.StdErr);
-
             using var failureRecord = new PipReportFailureTelemetryRecord
             {
                 ExitCode = command.ExitCode,
                 StdErr = command.StdErr,
             };
 
-            return (new PipInstallationReport(), null);
+            this.logger.LogDebug("PipReport: Pip installation report error: {StdErr}", command.StdErr);
+            throw new InvalidOperationException($"PipReport: Failed to generate pip installation report for file {path} with exit code {command.ExitCode}");
         }
 
         var reportOutput = await this.fileUtilityService.ReadAllTextAsync(reportFile);

--- a/src/Microsoft.ComponentDetection.Detectors/pip/PipReportComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/PipReportComponentDetector.cs
@@ -121,7 +121,7 @@ public class PipReportComponentDetector : FileComponentDetector, IExperimentalDe
         }
         catch (Exception e)
         {
-            this.Logger.LogError(e, "PipReport: Failure while parsing pip installation report for {File}", file.Location);
+            this.Logger.LogWarning(e, "PipReport: Failure while parsing pip installation report for {File}", file.Location);
 
             using var parseFailedRecord = new FailedParsingFileRecord
             {

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/PipCommandServiceTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/PipCommandServiceTests.cs
@@ -454,15 +454,8 @@ public class PipCommandServiceTests
             .ReturnsAsync(new CommandLineExecutionResult { ExitCode = 1, StdErr = "TestFail", StdOut = string.Empty })
             .Verifiable();
 
-        var (report, reportFile) = await service.GenerateInstallationReportAsync(testPath);
-
-        // the file shouldn't exist since we're not writing to it in the test
-        reportFile.Should().BeNull();
-
-        // validate report parameters
-        report.Should().NotBeNull();
-        report.Version.Should().BeNull();
-        report.InstallItems.Should().BeNull();
+        var action = async () => await service.GenerateInstallationReportAsync(testPath);
+        await action.Should().ThrowAsync<InvalidOperationException>();
 
         this.commandLineInvokationService.Verify();
     }

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/PipReportComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/PipReportComponentDetectorTests.cs
@@ -169,7 +169,7 @@ public class PipReportComponentDetectorTests : BaseDetectorTest<PipReportCompone
         await action.Should().ThrowAsync<InvalidCastException>();
 
         this.mockLogger.Verify(x => x.Log(
-            LogLevel.Error,
+            LogLevel.Warning,
             It.IsAny<EventId>(),
             It.Is<It.IsAnyType>((o, t) => o.ToString().StartsWith("PipReport: Failure while parsing pip")),
             It.IsAny<Exception>(),


### PR DESCRIPTION
Slightly change error handling in the pip report detector to avoid attempting to parse failed reports. Add some new docs and update smoke tests to avoid rate limiting failures.