### PR TITLE
Increase Python cache window

### DIFF
--- a/docs/detectors/pip.md
+++ b/docs/detectors/pip.md
@@ -50,7 +50,7 @@ If no internet connection or a component cannot be found in PyPi, said component
 ## Environment Variables
 
 The environment variable `PyPiMaxCacheEntries` is used to control the size of the in-memory LRU cache that caches responses from PyPi.
-The default value is 128.
+The default value is 4096.
 
 The enviroment variable `PIP_INDEX_URL` is used to determine what package feed should be used for `pip install --report` detection.
 The default value will use the PyPi index unless pip defaults have been configured globally.

--- a/src/Microsoft.ComponentDetection.Detectors/pip/IPyPiClient.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/IPyPiClient.cs
@@ -30,7 +30,7 @@ public interface IPyPiClient
 public sealed class PyPiClient : IPyPiClient, IDisposable
 {
     // Values used for cache creation
-    private const long CACHEINTERVALSECONDS = 60;
+    private const long CACHEINTERVALSECONDS = 180;
 
     private const long DEFAULTCACHEENTRIES = 4096;
 

--- a/src/Microsoft.ComponentDetection.Detectors/pip/SimplePypiClient.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/SimplePypiClient.cs
@@ -18,7 +18,7 @@ using Polly;
 public sealed class SimplePyPiClient : ISimplePyPiClient, IDisposable
 {
     // Values used for cache creation
-    private const long CACHEINTERVALSECONDS = 60;
+    private const long CACHEINTERVALSECONDS = 180;
     private const long DEFAULTCACHEENTRIES = 4096;
 
     // max number of retries allowed, to cap the total delay period


### PR DESCRIPTION
Increase Python cache window used for sliding expiration of PyPi responses so cache hits are more likely.