### PR TITLE
Pauldorsch/remove pip report throw

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/pip/PipReportComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/PipReportComponentDetector.cs
@@ -132,8 +132,6 @@ public class PipReportComponentDetector : FileComponentDetector, IExperimentalDe
                 ExceptionMessage = e.Message,
                 StackTrace = e.StackTrace,
             };
-
-            throw;
         }
         finally
         {

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/PipReportComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/PipReportComponentDetectorTests.cs
@@ -163,10 +163,11 @@ public class PipReportComponentDetectorTests : BaseDetectorTest<PipReportCompone
         this.pipCommandService.Setup(x => x.GenerateInstallationReportAsync(It.IsAny<string>(), It.IsAny<string>()))
             .ThrowsAsync(new InvalidCastException());
 
-        var action = async () => await this.DetectorTestUtility
+        var (result, componentRecorder) = await this.DetectorTestUtility
             .WithFile("setup.py", string.Empty)
             .ExecuteDetectorAsync();
-        await action.Should().ThrowAsync<InvalidCastException>();
+
+        result.ResultCode.Should().Be(ProcessingResultCode.Success);
 
         this.mockLogger.Verify(x => x.Log(
             LogLevel.Warning,


### PR DESCRIPTION
PipReport throws when file detector fails, which causes other files to not have the pipreport run on them. We want to just log / output telemetry instead of throwing.