### PR TITLE
Update NormalizePath to handle Windows correctly

### DIFF
--- a/src/Microsoft.ComponentDetection.Common/PathUtilityService.cs
+++ b/src/Microsoft.ComponentDetection.Common/PathUtilityService.cs
@@ -76,6 +76,16 @@ public class PathUtilityService : IPathUtilityService
 
     private string ResolvePathFromInfo(FileSystemInfo info) => info.LinkTarget ?? info.FullName;
 
-    public string NormalizePath(string path) =>
-        path?.Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar);
+    public string NormalizePath(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return path;
+        }
+
+        // Normalize the path directory seperator to / on Unix systems and on Windows.
+        // This is the behavior we want as Windows accepts / as a separator.
+        // AltDirectorySeparatorChar is / on Unix and on Windows.
+        return path.Replace('\\', Path.AltDirectorySeparatorChar);
+    }
 }

--- a/src/Microsoft.ComponentDetection.Contracts/IPathUtilityService.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/IPathUtilityService.cs
@@ -36,7 +36,8 @@ public interface IPathUtilityService
     bool MatchesPattern(string searchPattern, string fileName);
 
     /// <summary>
-    /// Normalizes the path to the system based separator.
+    /// Normalize the path directory seperator to / on Unix systems and on Windows.
+    /// This is the behavior we want as Windows accepts / as a separator.
     /// </summary>
     /// <param name="path">the path.</param>
     /// <returns>normalized path.</returns>

--- a/test/Microsoft.ComponentDetection.Common.Tests/PathUtilityServiceTests.cs
+++ b/test/Microsoft.ComponentDetection.Common.Tests/PathUtilityServiceTests.cs
@@ -1,6 +1,5 @@
 namespace Microsoft.ComponentDetection.Common.Tests;
 
-using System.IO;
 using FluentAssertions;
 using Microsoft.ComponentDetection.Common;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -16,14 +15,20 @@ public class PathUtilityServiceTests
     {
         var service = new PathUtilityService(new NullLogger<PathUtilityService>());
         var path = "Users\\SomeUser\\someDir\\someFile";
+        var expectedPath = "Users/SomeUser/someDir/someFile";
         var normalizedPath = service.NormalizePath(path);
-        if (Path.DirectorySeparatorChar == '\\')
-        {
-            normalizedPath.Should().Be(path);
-        }
-        else
-        {
-            normalizedPath.Should().Be(string.Join(Path.DirectorySeparatorChar, path.Split('\\')));
-        }
+
+        normalizedPath.Should().Be(expectedPath);
+    }
+
+    [TestMethod]
+    public void AbsolutePathShouldBeNormalized()
+    {
+        var service = new PathUtilityService(new NullLogger<PathUtilityService>());
+        var path = "C:\\Users\\SomeUser\\someDir\\someFile";
+        var expectedPath = "C:/Users/SomeUser/someDir/someFile";
+        var normalizedPath = service.NormalizePath(path);
+
+        normalizedPath.Should().Be(expectedPath);
     }
 }


### PR DESCRIPTION
When running the Pip detection for setup.py files, there were extra unicode characters being added to the normalized path strings. This will fix that issue by normalizing to `/` which is valid on both Unix and Windows.