### PR TITLE
Update Gradle parsing to reduce logging calls

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/gradle/GradleComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/gradle/GradleComponentDetector.cs
@@ -66,6 +66,7 @@ public class GradleComponentDetector : FileComponentDetector, IComponentDetector
         }
 
         var lines = new List<string>(text.Split("\n"));
+        var devDepLockFile = this.IsDevDependencyByLockfile(file);
 
         while (lines.Count > 0)
         {
@@ -80,7 +81,7 @@ public class GradleComponentDetector : FileComponentDetector, IComponentDetector
             if (line.Split(":").Length == 3)
             {
                 var detectedMavenComponent = new DetectedComponent(this.CreateMavenComponentFromFileLine(line));
-                var devDependency = this.IsDevDependencyByLockfile(file) || this.IsDevDependencyByConfigurations(line);
+                var devDependency = devDepLockFile || this.IsDevDependencyByConfigurations(line);
                 singleFileComponentRecorder.RegisterUsage(detectedMavenComponent, isDevelopmentDependency: devDependency);
             }
         }


### PR DESCRIPTION
Update Gradle parsing to reduce logging calls to IsDevDependencyByLockfile since it only needs to be calculated once per file.