### PR TITLE
Sanitize Docker environment vars in logs

### DIFF
--- a/src/Microsoft.ComponentDetection.Common/Utilities/StringUtilities.cs
+++ b/src/Microsoft.ComponentDetection.Common/Utilities/StringUtilities.cs
@@ -5,7 +5,8 @@ using System.Text.RegularExpressions;
 
 public static class StringUtilities
 {
-    private static readonly Regex SensitiveInfoRegex = new Regex(@"(?<=https://)(.+)(?=@)", RegexOptions.Compiled, TimeSpan.FromSeconds(5));
+    private static readonly Regex SensitiveInfoRegex = new Regex(@"(?<=https://)(.+)(?=@)", RegexOptions.Compiled | RegexOptions.IgnoreCase, TimeSpan.FromSeconds(5));
+    public const string SensitivePlaceholder = "******";
 
     /// <summary>
     /// Utility method to remove sensitive information from a string, currently focused on removing on the credentials placed within URL which can be part of CLI commands.
@@ -21,7 +22,7 @@ public static class StringUtilities
 
         try
         {
-            return SensitiveInfoRegex.Replace(inputString, "******");
+            return SensitiveInfoRegex.Replace(inputString, SensitivePlaceholder);
         }
         catch (Exception)
         {

--- a/test/Microsoft.ComponentDetection.Common.Tests/DockerServiceTests.cs
+++ b/test/Microsoft.ComponentDetection.Common.Tests/DockerServiceTests.cs
@@ -3,6 +3,7 @@ namespace Microsoft.ComponentDetection.Common.Tests;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Docker.DotNet.Models;
 using FluentAssertions;
 using Microsoft.ComponentDetection.TestsUtilities;
 using Microsoft.Extensions.Logging;
@@ -79,5 +80,143 @@ public class DockerServiceTests
         var (stdout, stderr) = await this.dockerService.CreateAndRunContainerAsync(TestImage, new List<string>());
         stdout.Should().StartWith("\nHello from Docker!");
         stderr.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public void DockerService_SanitizeEnvironmentVariables()
+    {
+        var responseInput = new ImageInspectResponse
+        {
+            Config = new Config
+            {
+                Env = new List<string>
+                {
+                    "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+                    "MARATHON_APP_RESOURCE_CPU=1",
+                    "REGION=local",
+                    "PIP_INDEX_URL=https://user:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@someregistry.localhost.com",
+                },
+            },
+        };
+
+        var expected = new ImageInspectResponse
+        {
+            Config = new Config
+            {
+                Env = new List<string>
+                {
+                    "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+                    "MARATHON_APP_RESOURCE_CPU=1",
+                    "REGION=local",
+                    $"PIP_INDEX_URL=https://{StringUtilities.SensitivePlaceholder}@someregistry.localhost.com",
+                },
+            },
+        };
+
+        this.dockerService.SanitizeEnvironmentVariables(responseInput);
+        responseInput.Should().BeEquivalentTo(expected);
+
+        responseInput = new ImageInspectResponse
+        {
+            Config = new Config
+            {
+                Env = new List<string>
+                {
+                    "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+                    "MARATHON_APP_RESOURCE_CPU=1",
+                    "REGION=local",
+                },
+            },
+        };
+
+        expected = new ImageInspectResponse
+        {
+            Config = new Config
+            {
+                Env = new List<string>
+                {
+                    "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+                    "MARATHON_APP_RESOURCE_CPU=1",
+                    "REGION=local",
+                },
+            },
+        };
+
+        this.dockerService.SanitizeEnvironmentVariables(responseInput);
+        responseInput.Should().BeEquivalentTo(expected);
+
+        responseInput = new ImageInspectResponse
+        {
+            Config = new Config
+            {
+                Env = new List<string>
+                {
+                    "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+                    "MARATHON_APP_RESOURCE_CPU=1",
+                    "REGION=local",
+                    "PIP_INDEX_URL=https://someregistry.localhost.com",
+                },
+            },
+        };
+
+        expected = new ImageInspectResponse
+        {
+            Config = new Config
+            {
+                Env = new List<string>
+                {
+                    "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+                    "MARATHON_APP_RESOURCE_CPU=1",
+                    "REGION=local",
+                    "PIP_INDEX_URL=https://someregistry.localhost.com",
+                },
+            },
+        };
+
+        this.dockerService.SanitizeEnvironmentVariables(responseInput);
+        responseInput.Should().BeEquivalentTo(expected);
+    }
+
+    [TestMethod]
+    public void DockerService_SanitizeEnvironmentVariables_DoesNotThrow()
+    {
+        var responseInput = new ImageInspectResponse
+        {
+            Config = new Config
+            {
+                Env = null,
+            },
+        };
+
+        var action = () => this.dockerService.SanitizeEnvironmentVariables(responseInput);
+        action.Should().NotThrow();
+        responseInput.Should().BeEquivalentTo(responseInput);
+
+        responseInput = new ImageInspectResponse
+        {
+            Config = null,
+        };
+
+        action = () => this.dockerService.SanitizeEnvironmentVariables(responseInput);
+        action.Should().NotThrow();
+        responseInput.Should().BeEquivalentTo(responseInput);
+
+        responseInput = null;
+
+        action = () => this.dockerService.SanitizeEnvironmentVariables(responseInput);
+        action.Should().NotThrow();
+        responseInput.Should().BeNull();
+
+        responseInput = new ImageInspectResponse
+        {
+            Config = new Config
+            {
+                Env = new List<string>(),
+            },
+        };
+
+        action = () => this.dockerService.SanitizeEnvironmentVariables(responseInput);
+        action.Should().NotThrow();
+        responseInput.Should().BeEquivalentTo(responseInput);
     }
 }

--- a/test/Microsoft.ComponentDetection.Common.Tests/Microsoft.ComponentDetection.Common.Tests.csproj
+++ b/test/Microsoft.ComponentDetection.Common.Tests/Microsoft.ComponentDetection.Common.Tests.csproj
@@ -6,6 +6,7 @@
 
     <ItemGroup Label="Package References">
       <PackageReference Include="coverlet.collector" PrivateAssets="all" />
+      <PackageReference Include="Docker.DotNet" />
       <PackageReference Include="FluentAssertions.Analyzers" PrivateAssets="all" />
       <PackageReference Include="Microsoft.Extensions.Logging" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/test/Microsoft.ComponentDetection.Common.Tests/StringUtilitiesTests.cs
+++ b/test/Microsoft.ComponentDetection.Common.Tests/StringUtilitiesTests.cs
@@ -14,12 +14,13 @@ public class StringUtilitiesTests
     [DataRow(null, null)]
     [DataRow("  ", "  ")]
     [DataRow(" https:// ", " https:// ")]
-    [DataRow("https://username:password@domain.me", "https://******@domain.me")]
+    [DataRow("https://username:password@domain.me", $"https://{StringUtilities.SensitivePlaceholder}@domain.me")]
+    [DataRow("HTTPS://username:password@domain.me", $"HTTPS://{StringUtilities.SensitivePlaceholder}@domain.me")]
     [DataRow("https://domain.me", "https://domain.me")]
     [DataRow("https://@domain.me", "https://@domain.me")]
     [DataRow(
         "install -r requirements.txt --dry-run --ignore-installed --quiet --report file.zvn --index-url https://user:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@someregistry.localhost.com",
-        "install -r requirements.txt --dry-run --ignore-installed --quiet --report file.zvn --index-url https://******@someregistry.localhost.com")]
+        $"install -r requirements.txt --dry-run --ignore-installed --quiet --report file.zvn --index-url https://{StringUtilities.SensitivePlaceholder}@someregistry.localhost.com")]
     public void RemoveSensitiveInformation_ReturnsAsExpected(string input, string expected)
     {
         var actual = StringUtilities.RemoveSensitiveInformation(input);


### PR DESCRIPTION
## Context
We spotted some ephemeral credentials in our telemetry due to syft being executed in a container and returning all/most of its environment variables.

## Solution
Sanitize confidential information placed in URLs within env vars passed to Syft.