### PR TITLE
Add env var that allows customers to skip pip report

### DIFF
--- a/src/Microsoft.ComponentDetection.Common/Telemetry/Records/PipReportSkipTelemetryRecord.cs
+++ b/src/Microsoft.ComponentDetection.Common/Telemetry/Records/PipReportSkipTelemetryRecord.cs
@@ -1,0 +1,12 @@
+namespace Microsoft.ComponentDetection.Common.Telemetry.Records;
+
+public class PipReportSkipTelemetryRecord : BaseDetectionTelemetryRecord
+{
+    public override string RecordName => "PipReportSkip";
+
+    public string SkipReason { get; set; }
+
+    public string DetectorId { get; set; }
+
+    public int DetectorVersion { get; set; }
+}

--- a/src/Microsoft.ComponentDetection.Detectors/pip/PipReportComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/PipReportComponentDetector.cs
@@ -88,10 +88,10 @@ public class PipReportComponentDetector : FileComponentDetector, IExperimentalDe
         {
             if (this.IsPipReportManuallyDisabled())
             {
-                this.Logger.LogWarning("PipReport: The pip report has been manually disabled, fallback strategy performed.");
+                this.Logger.LogWarning("PipReport: Found {DisablePipReportScanEnvVar} environment variable equal to true. Skipping pip report.", DisablePipReportScanEnvVar);
                 using var skipReportRecord = new PipReportSkipTelemetryRecord
                 {
-                    SkipReason = $"Found {DisablePipReportScanEnvVar} equal to true. Skipping pip report.",
+                    SkipReason = $"PipReport: Found {DisablePipReportScanEnvVar} environment variable equal to true. Skipping pip report.",
                     DetectorId = this.Id,
                     DetectorVersion = this.Version,
                 };

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/PipReportComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/PipReportComponentDetectorTests.cs
@@ -20,6 +20,7 @@ using Newtonsoft.Json;
 public class PipReportComponentDetectorTests : BaseDetectorTest<PipReportComponentDetector>
 {
     private readonly Mock<IPipCommandService> pipCommandService;
+    private readonly Mock<IEnvironmentVariableService> mockEnvVarService;
     private readonly Mock<ILogger<PipReportComponentDetector>> mockLogger;
 
     private readonly PipInstallationReport singlePackageReport;
@@ -35,6 +36,9 @@ public class PipReportComponentDetectorTests : BaseDetectorTest<PipReportCompone
 
         this.mockLogger = new Mock<ILogger<PipReportComponentDetector>>();
         this.DetectorTestUtility.AddServiceMock(this.mockLogger);
+
+        this.mockEnvVarService = new Mock<IEnvironmentVariableService>();
+        this.DetectorTestUtility.AddServiceMock(this.mockEnvVarService);
 
         this.pipCommandService.Setup(x => x.PipExistsAsync(It.IsAny<string>())).ReturnsAsync(true);
         this.pipCommandService.Setup(x => x.GetPipVersionAsync(It.IsAny<string>()))
@@ -232,6 +236,31 @@ public class PipReportComponentDetectorTests : BaseDetectorTest<PipReportCompone
         var pipComponents = detectedComponents.Where(detectedComponent => detectedComponent.Component.Id.Contains("pip")).ToList();
         var requestsComponent = pipComponents.Single(x => ((PipComponent)x.Component).Name.Equals("requests")).Component as PipComponent;
         requestsComponent.Version.Should().Be("2.32.3");
+    }
+
+    [TestMethod]
+    public async Task TestPipReportDetector_SkipAsync()
+    {
+        this.mockEnvVarService.Setup(x => x.IsEnvironmentVariableValueTrue("DisablePipReportScan")).Returns(true);
+
+        this.pipCommandService.Setup(x => x.GenerateInstallationReportAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync((this.simpleExtrasReport, null));
+
+        var (result, componentRecorder) = await this.DetectorTestUtility
+            .WithFile("requirements.txt", string.Empty)
+            .ExecuteDetectorAsync();
+
+        result.ResultCode.Should().Be(ProcessingResultCode.Success);
+
+        this.mockLogger.Verify(x => x.Log(
+            LogLevel.Warning,
+            It.IsAny<EventId>(),
+            It.Is<It.IsAnyType>((o, t) => o.ToString().StartsWith("PipReport: The pip report has been manually disabled")),
+            It.IsAny<Exception>(),
+            (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()));
+
+        var detectedComponents = componentRecorder.GetDetectedComponents();
+        detectedComponents.Should().BeEmpty();
     }
 
     [TestMethod]

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/PipReportComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/PipReportComponentDetectorTests.cs
@@ -255,7 +255,7 @@ public class PipReportComponentDetectorTests : BaseDetectorTest<PipReportCompone
         this.mockLogger.Verify(x => x.Log(
             LogLevel.Warning,
             It.IsAny<EventId>(),
-            It.Is<It.IsAnyType>((o, t) => o.ToString().StartsWith("PipReport: The pip report has been manually disabled")),
+            It.Is<It.IsAnyType>((o, t) => o.ToString().StartsWith("PipReport: Found DisablePipReportScan environment variable equal to true")),
             It.IsAny<Exception>(),
             (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()));
 


### PR DESCRIPTION
Pip report causes customers to have their runs timeout. To immediately unblock customers, this adds the ability to not run pipreport detection. Investigating root cause in meantime