### PR TITLE
Add CancellationToken support to CD processes

### DIFF
--- a/src/Microsoft.ComponentDetection.Common/CommandLineInvocationService.cs
+++ b/src/Microsoft.ComponentDetection.Common/CommandLineInvocationService.cs
@@ -175,7 +175,7 @@ public class CommandLineInvocationService : ICommandLineInvocationService
 
         process.Exited += (sender, args) =>
         {
-            Task.WaitAll([t1, t2]);
+            Task.WaitAll(t1, t2);
             tcs.TrySetResult(new CommandLineExecutionResult { ExitCode = process.ExitCode, StdErr = errorText, StdOut = stdOutText });
             process.Dispose();
         };

--- a/src/Microsoft.ComponentDetection.Common/CommandLineInvocationService.cs
+++ b/src/Microsoft.ComponentDetection.Common/CommandLineInvocationService.cs
@@ -15,7 +15,6 @@ using Microsoft.ComponentDetection.Contracts;
 /// <inheritdoc/>
 public class CommandLineInvocationService : ICommandLineInvocationService
 {
-    private const int WriteStdOutErrTimeoutSeconds = 10;
     private readonly IDictionary<string, string> commandLocatableCache = new ConcurrentDictionary<string, string>();
 
     /// <inheritdoc/>
@@ -176,7 +175,7 @@ public class CommandLineInvocationService : ICommandLineInvocationService
 
         process.Exited += (sender, args) =>
         {
-            Task.WaitAll([t1, t2], TimeSpan.FromSeconds(WriteStdOutErrTimeoutSeconds));
+            Task.WaitAll([t1, t2]);
             tcs.TrySetResult(new CommandLineExecutionResult { ExitCode = process.ExitCode, StdErr = errorText, StdOut = stdOutText });
             process.Dispose();
         };

--- a/src/Microsoft.ComponentDetection.Common/CommandLineInvocationService.cs
+++ b/src/Microsoft.ComponentDetection.Common/CommandLineInvocationService.cs
@@ -184,7 +184,20 @@ public class CommandLineInvocationService : ICommandLineInvocationService
         t1.Start();
         t2.Start();
 
-        cancellationToken.Register(process.Kill);
+        cancellationToken.Register(() =>
+        {
+            try
+            {
+                process.Kill();
+            }
+            catch (InvalidOperationException)
+            {
+                // swallow invalid operations, which indicate that there is no process associated with
+                // the process object, and therefore nothing to kill
+                // https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.kill?view=net-8.0#system-diagnostics-process-kill
+                return;
+            }
+        });
 
         return tcs.Task;
     }

--- a/src/Microsoft.ComponentDetection.Common/CommandLineInvocationService.cs
+++ b/src/Microsoft.ComponentDetection.Common/CommandLineInvocationService.cs
@@ -173,6 +173,7 @@ public class CommandLineInvocationService : ICommandLineInvocationService
         {
             stdOutText = process.StandardOutput.ReadToEnd();
         });
+
         process.Exited += (sender, args) =>
         {
             Task.WaitAll([t1, t2], TimeSpan.FromSeconds(WriteStdOutErrTimeoutSeconds));
@@ -184,7 +185,7 @@ public class CommandLineInvocationService : ICommandLineInvocationService
         t1.Start();
         t2.Start();
 
-        var processKillRegistration = cancellationToken.Register(process.Kill);
+        cancellationToken.Register(process.Kill);
 
         return tcs.Task;
     }

--- a/src/Microsoft.ComponentDetection.Common/FileWritingService.cs
+++ b/src/Microsoft.ComponentDetection.Common/FileWritingService.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Globalization;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.ComponentDetection.Common.Exceptions;
 using Newtonsoft.Json;
@@ -67,11 +68,11 @@ public sealed class FileWritingService : IFileWritingService
     }
 
     /// <inheritdoc />
-    public async Task WriteFileAsync(string relativeFilePath, string text)
+    public async Task WriteFileAsync(string relativeFilePath, string text, CancellationToken cancellationToken = default)
     {
         relativeFilePath = this.ResolveFilePath(relativeFilePath);
 
-        await File.WriteAllTextAsync(relativeFilePath, text);
+        await File.WriteAllTextAsync(relativeFilePath, text, cancellationToken);
     }
 
     /// <inheritdoc />

--- a/src/Microsoft.ComponentDetection.Common/IFileWritingService.cs
+++ b/src/Microsoft.ComponentDetection.Common/IFileWritingService.cs
@@ -1,7 +1,8 @@
-﻿namespace Microsoft.ComponentDetection.Common;
+namespace Microsoft.ComponentDetection.Common;
 
 using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 /// <summary>
@@ -35,8 +36,9 @@ public interface IFileWritingService : IDisposable, IAsyncDisposable
     /// </summary>
     /// <param name="relativeFilePath">The relative path to the file.</param>
     /// <param name="text">The text to write.</param>
+    /// <param name="cancellationToken">Token to cancel the file write operation.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
-    Task WriteFileAsync(string relativeFilePath, string text);
+    Task WriteFileAsync(string relativeFilePath, string text, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Writes the object to the file as JSON.

--- a/src/Microsoft.ComponentDetection.Contracts/ICommandLineInvocationService.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/ICommandLineInvocationService.cs
@@ -1,7 +1,8 @@
-﻿namespace Microsoft.ComponentDetection.Contracts;
+namespace Microsoft.ComponentDetection.Contracts;
 
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 /// <summary>
@@ -41,9 +42,10 @@ public interface ICommandLineInvocationService
     /// <param name="command">The command name to execute. Environment variables like PATH on windows will also be considered if the command is not an absolute path. </param>
     /// <param name="additionalCandidateCommands">Other commands that could satisfy the need for the first command. Assumption is that they all share similar calling patterns.</param>
     /// <param name="workingDirectory">The directory under which to run the command.</param>
+    /// <param name="cancellationToken">Token used for cancelling the command.</param>
     /// <param name="parameters">The parameters that should be passed to the command. The parameters will be space-joined.</param>
     /// <returns>Awaitable task with the result of executing the command, including exit code.</returns>
-    Task<CommandLineExecutionResult> ExecuteCommandAsync(string command, IEnumerable<string> additionalCandidateCommands = null, DirectoryInfo workingDirectory = null, params string[] parameters);
+    Task<CommandLineExecutionResult> ExecuteCommandAsync(string command, IEnumerable<string> additionalCandidateCommands = null, DirectoryInfo workingDirectory = null, CancellationToken cancellationToken = default, params string[] parameters);
 
     /// <summary>
     /// Executes a command line command. If the command has not been located yet, CanCommandBeLocated will be invoked without the submitted parameters.
@@ -53,6 +55,26 @@ public interface ICommandLineInvocationService
     /// <param name="parameters">The parameters that should be passed to the command. The parameters will be space-joined.</param>
     /// <returns>Awaitable task with the result of executing the command, including exit code.</returns>
     Task<CommandLineExecutionResult> ExecuteCommandAsync(string command, IEnumerable<string> additionalCandidateCommands = null, params string[] parameters);
+
+    /// <summary>
+    /// Executes a command line command. If the command has not been located yet, CanCommandBeLocated will be invoked without the submitted parameters.
+    /// </summary>
+    /// <param name="command">The command name to execute. Environment variables like PATH on windows will also be considered if the command is not an absolute path. </param>
+    /// <param name="additionalCandidateCommands">Other commands that could satisfy the need for the first command. Assumption is that they all share similar calling patterns.</param>
+    /// <param name="workingDirectory">The directory under which to run the command.</param>
+    /// <param name="parameters">The parameters that should be passed to the command. The parameters will be space-joined.</param>
+    /// <returns>Awaitable task with the result of executing the command, including exit code.</returns>
+    Task<CommandLineExecutionResult> ExecuteCommandAsync(string command, IEnumerable<string> additionalCandidateCommands = null, DirectoryInfo workingDirectory = null, params string[] parameters);
+
+    /// <summary>
+    /// Executes a command line command. If the command has not been located yet, CanCommandBeLocated will be invoked without the submitted parameters.
+    /// </summary>
+    /// <param name="command">The command name to execute. Environment variables like PATH on windows will also be considered if the command is not an absolute path. </param>
+    /// <param name="additionalCandidateCommands">Other commands that could satisfy the need for the first command. Assumption is that they all share similar calling patterns.</param>
+    /// <param name="cancellationToken">Token used for cancelling the command.</param>
+    /// <param name="parameters">The parameters that should be passed to the command. The parameters will be space-joined.</param>
+    /// <returns>Awaitable task with the result of executing the command, including exit code.</returns>
+    Task<CommandLineExecutionResult> ExecuteCommandAsync(string command, IEnumerable<string> additionalCandidateCommands = null, CancellationToken cancellationToken = default, params string[] parameters);
 }
 
 /// <summary>

--- a/src/Microsoft.ComponentDetection.Contracts/ICommandLineInvocationService.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/ICommandLineInvocationService.cs
@@ -1,5 +1,6 @@
 namespace Microsoft.ComponentDetection.Contracts;
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
@@ -54,6 +55,7 @@ public interface ICommandLineInvocationService
     /// <param name="additionalCandidateCommands">Other commands that could satisfy the need for the first command. Assumption is that they all share similar calling patterns.</param>
     /// <param name="parameters">The parameters that should be passed to the command. The parameters will be space-joined.</param>
     /// <returns>Awaitable task with the result of executing the command, including exit code.</returns>
+    [Obsolete($"This implementation of {nameof(ExecuteCommandAsync)} is deprecated. Please use a version with CancellationTokens.")]
     Task<CommandLineExecutionResult> ExecuteCommandAsync(string command, IEnumerable<string> additionalCandidateCommands = null, params string[] parameters);
 
     /// <summary>
@@ -64,6 +66,7 @@ public interface ICommandLineInvocationService
     /// <param name="workingDirectory">The directory under which to run the command.</param>
     /// <param name="parameters">The parameters that should be passed to the command. The parameters will be space-joined.</param>
     /// <returns>Awaitable task with the result of executing the command, including exit code.</returns>
+    [Obsolete($"This implementation of {nameof(ExecuteCommandAsync)} is deprecated. Please use a version with CancellationTokens.")]
     Task<CommandLineExecutionResult> ExecuteCommandAsync(string command, IEnumerable<string> additionalCandidateCommands = null, DirectoryInfo workingDirectory = null, params string[] parameters);
 
     /// <summary>

--- a/src/Microsoft.ComponentDetection.Contracts/IComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/IComponentDetector.cs
@@ -1,6 +1,7 @@
-﻿namespace Microsoft.ComponentDetection.Contracts;
+namespace Microsoft.ComponentDetection.Contracts;
 
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 
@@ -39,7 +40,7 @@ public interface IComponentDetector
     ///  Run the detector and return the result set of components found.
     /// </summary>
     /// <returns> Awaitable task with result of components found. </returns>
-    Task<IndividualDetectorScanResult> ExecuteDetectorAsync(ScanRequest request);
+    Task<IndividualDetectorScanResult> ExecuteDetectorAsync(ScanRequest request, CancellationToken cancellationToken = default);
 }
 
 /// <summary>

--- a/src/Microsoft.ComponentDetection.Contracts/ScanRequest.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/ScanRequest.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.ComponentDetection.Contracts;
+namespace Microsoft.ComponentDetection.Contracts;
 
 using System.Collections.Generic;
 using System.IO;

--- a/src/Microsoft.ComponentDetection.Detectors/cocoapods/PodComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/cocoapods/PodComponentDetector.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.ComponentDetection.Common;
 using Microsoft.ComponentDetection.Contracts;
@@ -36,7 +37,7 @@ public class PodComponentDetector : FileComponentDetector
 
     public override int Version { get; } = 2;
 
-    protected override async Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs)
+    protected override async Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs, CancellationToken cancellationToken = default)
     {
         var singleFileComponentRecorder = processRequest.SingleFileComponentRecorder;
         var file = processRequest.ComponentStream;

--- a/src/Microsoft.ComponentDetection.Detectors/conan/ConanLockComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/conan/ConanLockComponentDetector.cs
@@ -1,9 +1,10 @@
-﻿namespace Microsoft.ComponentDetection.Detectors.Conan;
+namespace Microsoft.ComponentDetection.Detectors.Conan;
 
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Contracts.Internal;
@@ -33,14 +34,14 @@ public class ConanLockComponentDetector : FileComponentDetector, IDefaultOffComp
 
     public override IEnumerable<string> Categories => new List<string> { "Conan" };
 
-    protected override async Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs)
+    protected override async Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs, CancellationToken cancellationToken = default)
     {
         var singleFileComponentRecorder = processRequest.SingleFileComponentRecorder;
         var conanLockFile = processRequest.ComponentStream;
 
         try
         {
-            var conanLock = await JsonSerializer.DeserializeAsync<ConanLock>(conanLockFile.Stream);
+            var conanLock = await JsonSerializer.DeserializeAsync<ConanLock>(conanLockFile.Stream, cancellationToken: cancellationToken);
             this.RecordLockfileVersion(conanLock.Version);
 
             if (!conanLock.HasNodes())

--- a/src/Microsoft.ComponentDetection.Detectors/conda/CondaLockComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/conda/CondaLockComponentDetector.cs
@@ -3,6 +3,7 @@ namespace Microsoft.ComponentDetection.Detectors.Poetry;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Contracts.Internal;
@@ -35,7 +36,7 @@ public class CondaLockComponentDetector : FileComponentDetector, IDefaultOffComp
     public override IEnumerable<string> Categories => new List<string> { "Python" };
 
     /// <inheritdoc/>
-    protected override Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs)
+    protected override Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs, CancellationToken cancellationToken = default)
     {
         var singleFileComponentRecorder = processRequest.SingleFileComponentRecorder;
 

--- a/src/Microsoft.ComponentDetection.Detectors/dockerfile/DockerfileComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/dockerfile/DockerfileComponentDetector.cs
@@ -1,10 +1,11 @@
-﻿namespace Microsoft.ComponentDetection.Detectors.Dockerfile;
+namespace Microsoft.ComponentDetection.Detectors.Dockerfile;
 
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.ComponentDetection.Common;
 using Microsoft.ComponentDetection.Contracts;
@@ -42,7 +43,7 @@ public class DockerfileComponentDetector : FileComponentDetector, IDefaultOffCom
 
     public override int Version => 1;
 
-    protected override async Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs)
+    protected override async Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs, CancellationToken cancellationToken = default)
     {
         var singleFileComponentRecorder = processRequest.SingleFileComponentRecorder;
         var file = processRequest.ComponentStream;

--- a/src/Microsoft.ComponentDetection.Detectors/go/GoComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/go/GoComponentDetector.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.ComponentDetection.Common;
 using Microsoft.ComponentDetection.Common.Telemetry.Records;
@@ -145,7 +146,7 @@ public class GoComponentDetector : FileComponentDetector
         return true;
     }
 
-    protected override async Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs)
+    protected override async Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs, CancellationToken cancellationToken = default)
     {
         var singleFileComponentRecorder = processRequest.SingleFileComponentRecorder;
         var file = processRequest.ComponentStream;

--- a/src/Microsoft.ComponentDetection.Detectors/go/GoComponentWithReplaceDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/go/GoComponentWithReplaceDetector.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.ComponentDetection.Common;
 using Microsoft.ComponentDetection.Common.Telemetry.Records;
@@ -148,7 +149,7 @@ public class GoComponentWithReplaceDetector : FileComponentDetector, IExperiment
         return true;
     }
 
-    protected override async Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs)
+    protected override async Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs, CancellationToken cancellationToken = default)
     {
         var singleFileComponentRecorder = processRequest.SingleFileComponentRecorder;
         var file = processRequest.ComponentStream;

--- a/src/Microsoft.ComponentDetection.Detectors/gradle/GradleComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/gradle/GradleComponentDetector.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Contracts.Internal;
@@ -46,7 +47,7 @@ public class GradleComponentDetector : FileComponentDetector, IComponentDetector
 
     public override int Version { get; } = 3;
 
-    protected override Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs)
+    protected override Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs, CancellationToken cancellationToken = default)
     {
         var singleFileComponentRecorder = processRequest.SingleFileComponentRecorder;
         var file = processRequest.ComponentStream;

--- a/src/Microsoft.ComponentDetection.Detectors/ivy/IvyDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/ivy/IvyDetector.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Contracts.BcdeModels;
@@ -79,7 +80,7 @@ public class IvyDetector : FileComponentDetector, IExperimentalDetector
         return Enumerable.Empty<ProcessRequest>().ToObservable();
     }
 
-    protected override async Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs)
+    protected override async Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs, CancellationToken cancellationToken = default)
     {
         var singleFileComponentRecorder = processRequest.SingleFileComponentRecorder;
         var ivyXmlFile = processRequest.ComponentStream;

--- a/src/Microsoft.ComponentDetection.Detectors/linux/LinuxContainerDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/linux/LinuxContainerDetector.cs
@@ -39,7 +39,7 @@ public class LinuxContainerDetector : IComponentDetector
 
     public bool NeedsAutomaticRootDependencyCalculation => false;
 
-    public async Task<IndividualDetectorScanResult> ExecuteDetectorAsync(ScanRequest request)
+    public async Task<IndividualDetectorScanResult> ExecuteDetectorAsync(ScanRequest request, CancellationToken cancellationToken = default)
     {
 #pragma warning disable CA1308
         var imagesToProcess = request.ImagesToScan?.Where(image => !string.IsNullOrWhiteSpace(image))

--- a/src/Microsoft.ComponentDetection.Detectors/maven/MvnCliComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/maven/MvnCliComponentDetector.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
 using Microsoft.ComponentDetection.Common;
@@ -81,7 +82,7 @@ public class MvnCliComponentDetector : FileComponentDetector
             .ToObservable();
     }
 
-    protected override async Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs)
+    protected override async Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs, CancellationToken cancellationToken = default)
     {
         this.mavenCommandService.ParseDependenciesFile(processRequest);
 

--- a/src/Microsoft.ComponentDetection.Detectors/npm/NpmComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/npm/NpmComponentDetector.cs
@@ -1,9 +1,10 @@
-﻿namespace Microsoft.ComponentDetection.Detectors.Npm;
+namespace Microsoft.ComponentDetection.Detectors.Npm;
 
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using global::NuGet.Versioning;
 using Microsoft.ComponentDetection.Contracts;
@@ -39,7 +40,7 @@ public class NpmComponentDetector : FileComponentDetector
 
     public override int Version { get; } = 2;
 
-    protected override async Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs)
+    protected override async Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs, CancellationToken cancellationToken = default)
     {
         var singleFileComponentRecorder = processRequest.SingleFileComponentRecorder;
         var file = processRequest.ComponentStream;

--- a/src/Microsoft.ComponentDetection.Detectors/npm/NpmLockfileDetectorBase.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/npm/NpmLockfileDetectorBase.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reactive.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.ComponentDetection.Common;
 using Microsoft.ComponentDetection.Contracts;
@@ -92,7 +93,7 @@ public abstract class NpmLockfileDetectorBase : FileComponentDetector
                 }
             }));
 
-    protected override async Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs)
+    protected override async Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs, CancellationToken cancellationToken = default)
     {
         IEnumerable<string> packageJsonPattern = new List<string> { "package.json" };
         var singleFileComponentRecorder = processRequest.SingleFileComponentRecorder;

--- a/src/Microsoft.ComponentDetection.Detectors/nuget/NuGetComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/nuget/NuGetComponentDetector.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Linq;
@@ -43,7 +44,7 @@ public class NuGetComponentDetector : FileComponentDetector
 
     public override int Version { get; } = 2;
 
-    protected override async Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs)
+    protected override async Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs, CancellationToken cancellationToken = default)
     {
         var stream = processRequest.ComponentStream;
         var ignoreNugetConfig = detectorArgs.TryGetValue("NuGet.IncludeRepositoryPaths", out var includeRepositoryPathsValue) && includeRepositoryPathsValue.Equals(bool.FalseString, StringComparison.OrdinalIgnoreCase);

--- a/src/Microsoft.ComponentDetection.Detectors/nuget/NuGetPackagesConfigDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/nuget/NuGetPackagesConfigDetector.cs
@@ -2,6 +2,7 @@ namespace Microsoft.ComponentDetection.Detectors.NuGet;
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 using global::NuGet.Packaging;
@@ -48,7 +49,7 @@ public sealed class NuGetPackagesConfigDetector : FileComponentDetector
     public override int Version => 1;
 
     /// <inheritdoc />
-    protected override Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs)
+    protected override Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs, CancellationToken cancellationToken = default)
     {
         try
         {

--- a/src/Microsoft.ComponentDetection.Detectors/nuget/NuGetProjectModelProjectCentricComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/nuget/NuGetProjectModelProjectCentricComponentDetector.cs
@@ -5,6 +5,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using global::NuGet.Packaging.Core;
 using global::NuGet.ProjectModel;
@@ -208,7 +209,7 @@ public class NuGetProjectModelProjectCentricComponentDetector : FileComponentDet
 
     public override int Version { get; } = 1;
 
-    protected override Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs)
+    protected override Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs, CancellationToken cancellationToken = default)
     {
         try
         {

--- a/src/Microsoft.ComponentDetection.Detectors/pip/Contracts/IPipCommandService.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/Contracts/IPipCommandService.cs
@@ -2,6 +2,7 @@ namespace Microsoft.ComponentDetection.Detectors.Pip;
 
 using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 public interface IPipCommandService
@@ -25,6 +26,7 @@ public interface IPipCommandService
     /// </summary>
     /// <param name="path">Path of the Python requirements file.</param>
     /// <param name="pipExePath">Optional override of the pip.exe absolute path.</param>
+    /// <param name="cancellationToken">Token used for canceling the installation report generation.</param>
     /// <returns>See https://pip.pypa.io/en/stable/reference/installation-report/#specification.</returns>
-    Task<(PipInstallationReport Report, FileInfo ReportFile)> GenerateInstallationReportAsync(string path, string pipExePath = null);
+    Task<(PipInstallationReport Report, FileInfo ReportFile)> GenerateInstallationReportAsync(string path, string pipExePath = null, CancellationToken cancellationToken = default);
 }

--- a/src/Microsoft.ComponentDetection.Detectors/pip/PipCommandService.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/PipCommandService.cs
@@ -144,7 +144,7 @@ public class PipCommandService : IPipCommandService
                 StdErr = $"{errorMessage} {command.StdErr}",
             };
 
-            this.logger.LogDebug("{Error}", errorMessage);
+            this.logger.LogWarning("{Error}", errorMessage);
             throw new InvalidOperationException(errorMessage);
         }
         else if (command.ExitCode != 0)

--- a/src/Microsoft.ComponentDetection.Detectors/pip/PipCommandService.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/PipCommandService.cs
@@ -3,6 +3,7 @@ namespace Microsoft.ComponentDetection.Detectors.Pip;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.ComponentDetection.Common;
 using Microsoft.ComponentDetection.Common.Telemetry.Records;
@@ -85,7 +86,7 @@ public class PipCommandService : IPipCommandService
         return await this.commandLineInvocationService.CanCommandBeLocatedAsync(pipPath, new List<string> { "pip3" }, "--version");
     }
 
-    public async Task<(PipInstallationReport Report, FileInfo ReportFile)> GenerateInstallationReportAsync(string path, string pipExePath = null)
+    public async Task<(PipInstallationReport Report, FileInfo ReportFile)> GenerateInstallationReportAsync(string path, string pipExePath = null, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrEmpty(path))
         {
@@ -131,9 +132,22 @@ public class PipCommandService : IPipCommandService
             pipExecutable,
             null,
             workingDir,
+            cancellationToken,
             pipReportCommand);
 
-        if (command.ExitCode != 0)
+        if (command.ExitCode == -1 && cancellationToken.IsCancellationRequested)
+        {
+            var errorMessage = $"PipReport: Cancelled for file '{formattedPath}' with command '{pipReportCommand.RemoveSensitiveInformation()}'.";
+            using var failureRecord = new PipReportFailureTelemetryRecord
+            {
+                ExitCode = command.ExitCode,
+                StdErr = $"{errorMessage} {command.StdErr}",
+            };
+
+            this.logger.LogDebug("{Error}", errorMessage);
+            throw new InvalidOperationException(errorMessage);
+        }
+        else if (command.ExitCode != 0)
         {
             using var failureRecord = new PipReportFailureTelemetryRecord
             {

--- a/src/Microsoft.ComponentDetection.Detectors/pip/PipComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/PipComponentDetector.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reactive.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Contracts.Internal;
@@ -52,7 +53,7 @@ public class PipComponentDetector : FileComponentDetector
         return processRequests;
     }
 
-    protected override async Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs)
+    protected override async Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs, CancellationToken cancellationToken = default)
     {
         this.CurrentScanRequest.DetectorArgs.TryGetValue("Pip.PythonExePath", out var pythonExePath);
         var singleFileComponentRecorder = processRequest.SingleFileComponentRecorder;

--- a/src/Microsoft.ComponentDetection.Detectors/pip/PipReportComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/PipReportComponentDetector.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reactive.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.ComponentDetection.Common.Telemetry.Records;
 using Microsoft.ComponentDetection.Contracts;
@@ -77,7 +78,7 @@ public class PipReportComponentDetector : FileComponentDetector, IExperimentalDe
         return processRequests;
     }
 
-    protected override async Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs)
+    protected override async Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs, CancellationToken cancellationToken = default)
     {
         this.CurrentScanRequest.DetectorArgs.TryGetValue("Pip.PipExePath", out var pipExePath);
         var singleFileComponentRecorder = processRequest.SingleFileComponentRecorder;
@@ -103,7 +104,7 @@ public class PipReportComponentDetector : FileComponentDetector, IExperimentalDe
             this.Logger.LogInformation("PipReport: Generating pip installation report for {File}", file.Location);
 
             // Call pip executable to generate the installation report of a given project file.
-            (var report, reportFile) = await this.pipCommandService.GenerateInstallationReportAsync(file.Location, pipExePath);
+            (var report, reportFile) = await this.pipCommandService.GenerateInstallationReportAsync(file.Location, pipExePath, cancellationToken);
 
             // The report version is used to determine how to parse the report. If it is greater
             // than the maximum supported version, there may be new fields and the parsing will fail.

--- a/src/Microsoft.ComponentDetection.Detectors/pip/SimplePipComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/SimplePipComponentDetector.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reactive.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Contracts.Internal;
@@ -52,7 +53,7 @@ public class SimplePipComponentDetector : FileComponentDetector, IDefaultOffComp
         return processRequests;
     }
 
-    protected override async Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs)
+    protected override async Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs, CancellationToken cancellationToken = default)
     {
         this.CurrentScanRequest.DetectorArgs.TryGetValue("Pip.PythonExePath", out var pythonExePath);
         var singleFileComponentRecorder = processRequest.SingleFileComponentRecorder;

--- a/src/Microsoft.ComponentDetection.Detectors/pnpm/PnpmComponentDetectorFactory.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pnpm/PnpmComponentDetectorFactory.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.ComponentDetection.Common.Telemetry.Records;
 using Microsoft.ComponentDetection.Contracts;
@@ -44,7 +45,7 @@ public class PnpmComponentDetectorFactory : FileComponentDetector
 
     public override bool NeedsAutomaticRootDependencyCalculation => true;
 
-    protected override async Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs)
+    protected override async Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs, CancellationToken cancellationToken = default)
     {
         var singleFileComponentRecorder = processRequest.SingleFileComponentRecorder;
         var file = processRequest.ComponentStream;

--- a/src/Microsoft.ComponentDetection.Detectors/poetry/PoetryComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/poetry/PoetryComponentDetector.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Contracts.Internal;
@@ -34,7 +35,7 @@ public class PoetryComponentDetector : FileComponentDetector, IExperimentalDetec
 
     public override IEnumerable<string> Categories => new List<string> { "Python" };
 
-    protected override async Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs)
+    protected override async Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs, CancellationToken cancellationToken = default)
     {
         var singleFileComponentRecorder = processRequest.SingleFileComponentRecorder;
         var poetryLockFile = processRequest.ComponentStream;

--- a/src/Microsoft.ComponentDetection.Detectors/ruby/RubyComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/ruby/RubyComponentDetector.cs
@@ -31,6 +31,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Contracts.Internal;
@@ -72,7 +73,7 @@ public class RubyComponentDetector : FileComponentDetector
 
     public override bool NeedsAutomaticRootDependencyCalculation => true;
 
-    protected override Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs)
+    protected override Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs, CancellationToken cancellationToken = default)
     {
         var singleFileComponentRecorder = processRequest.SingleFileComponentRecorder;
         var file = processRequest.ComponentStream;

--- a/src/Microsoft.ComponentDetection.Detectors/rust/RustCliDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/rust/RustCliDetector.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.ComponentDetection.Common;
 using Microsoft.ComponentDetection.Common.Telemetry.Records;
@@ -73,7 +74,7 @@ public class RustCliDetector : FileComponentDetector
     public override IList<string> SearchPatterns { get; } = new[] { "Cargo.toml" };
 
     /// <inheritdoc />
-    protected override async Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs)
+    protected override async Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs, CancellationToken cancellationToken = default)
     {
         var componentStream = processRequest.ComponentStream;
         this.Logger.LogInformation("Discovered Cargo.toml: {Location}", componentStream.Location);

--- a/src/Microsoft.ComponentDetection.Detectors/rust/RustCrateDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/rust/RustCrateDetector.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.ComponentDetection.Common.Telemetry.Records;
 using Microsoft.ComponentDetection.Contracts;
@@ -64,7 +65,7 @@ public class RustCrateDetector : FileComponentDetector
 
     private static bool IsLocalPackage(CargoPackage package) => package.Source == null;
 
-    protected override async Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs)
+    protected override async Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs, CancellationToken cancellationToken = default)
     {
         var singleFileComponentRecorder = processRequest.SingleFileComponentRecorder;
         var cargoLockFile = processRequest.ComponentStream;

--- a/src/Microsoft.ComponentDetection.Detectors/spdx/Spdx22ComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/spdx/Spdx22ComponentDetector.cs
@@ -1,10 +1,11 @@
-﻿namespace Microsoft.ComponentDetection.Detectors.Spdx;
+namespace Microsoft.ComponentDetection.Detectors.Spdx;
 
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Contracts.Internal;
@@ -42,7 +43,7 @@ public class Spdx22ComponentDetector : FileComponentDetector, IDefaultOffCompone
 
     public override IList<string> SearchPatterns => new List<string> { "*.spdx.json" };
 
-    protected override Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs)
+    protected override Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs, CancellationToken cancellationToken = default)
     {
         this.Logger.LogDebug("Discovered SPDX2.2 manifest file at: {ManifestLocation}", processRequest.ComponentStream.Location);
         var file = processRequest.ComponentStream;

--- a/src/Microsoft.ComponentDetection.Detectors/vcpkg/VcpkgComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/vcpkg/VcpkgComponentDetector.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Contracts.Internal;
@@ -43,7 +44,7 @@ public class VcpkgComponentDetector : FileComponentDetector, IExperimentalDetect
 
     public override int Version => 2;
 
-    protected override async Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs)
+    protected override async Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs, CancellationToken cancellationToken = default)
     {
         var singleFileComponentRecorder = processRequest.SingleFileComponentRecorder;
         var file = processRequest.ComponentStream;

--- a/src/Microsoft.ComponentDetection.Detectors/yarn/YarnLockComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/yarn/YarnLockComponentDetector.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Threading;
 using System.Threading.Tasks;
 using DotNet.Globbing;
 using Microsoft.ComponentDetection.Contracts;
@@ -43,7 +44,7 @@ public class YarnLockComponentDetector : FileComponentDetector
     /// <remarks>"Package" is a more common substring, enclose it with \ to verify it is a folder.</remarks>
     protected override IList<string> SkippedFolders => new List<string> { "node_modules", "pnpm-store", "\\package\\" };
 
-    protected override async Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs)
+    protected override async Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs, CancellationToken cancellationToken = default)
     {
         var singleFileComponentRecorder = processRequest.SingleFileComponentRecorder;
         var file = processRequest.ComponentStream;

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/PipCommandServiceTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/PipCommandServiceTests.cs
@@ -3,6 +3,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.ComponentDetection.Common;
@@ -243,6 +244,7 @@ public class PipCommandServiceTests
             "pip",
             It.IsAny<IEnumerable<string>>(),
             It.Is<DirectoryInfo>(d => d.FullName.Contains(Directory.GetCurrentDirectory(), StringComparison.OrdinalIgnoreCase)),
+            It.IsAny<CancellationToken>(),
             It.Is<string>(s => s.Contains("requirements.txt", StringComparison.OrdinalIgnoreCase))))
             .ReturnsAsync(new CommandLineExecutionResult { ExitCode = 0, StdErr = string.Empty, StdOut = string.Empty })
             .Verifiable();
@@ -293,6 +295,7 @@ public class PipCommandServiceTests
             "pip",
             It.IsAny<IEnumerable<string>>(),
             It.Is<DirectoryInfo>(d => d.FullName.Contains(Directory.GetCurrentDirectory(), StringComparison.OrdinalIgnoreCase)),
+            It.IsAny<CancellationToken>(),
             It.Is<string>(s => s.Contains("-e .", StringComparison.OrdinalIgnoreCase))))
             .ReturnsAsync(new CommandLineExecutionResult { ExitCode = 0, StdErr = string.Empty, StdOut = string.Empty })
             .Verifiable();
@@ -343,6 +346,7 @@ public class PipCommandServiceTests
             "pip",
             It.IsAny<IEnumerable<string>>(),
             It.Is<DirectoryInfo>(d => d.FullName.Contains(Directory.GetCurrentDirectory(), StringComparison.OrdinalIgnoreCase)),
+            It.IsAny<CancellationToken>(),
             It.Is<string>(s => s.Contains("requirements.txt", StringComparison.OrdinalIgnoreCase))))
             .ReturnsAsync(new CommandLineExecutionResult { ExitCode = 0, StdErr = string.Empty, StdOut = string.Empty })
             .Verifiable();
@@ -450,11 +454,12 @@ public class PipCommandServiceTests
             "pip",
             It.IsAny<IEnumerable<string>>(),
             It.Is<DirectoryInfo>(d => d.FullName.Contains(Directory.GetCurrentDirectory(), StringComparison.OrdinalIgnoreCase)),
+            It.IsAny<CancellationToken>(),
             It.Is<string>(s => s.Contains("requirements.txt", StringComparison.OrdinalIgnoreCase))))
             .ReturnsAsync(new CommandLineExecutionResult { ExitCode = 1, StdErr = "TestFail", StdOut = string.Empty })
             .Verifiable();
 
-        var action = async () => await service.GenerateInstallationReportAsync(testPath);
+        var action = async () => await service.GenerateInstallationReportAsync(testPath, cancellationToken: CancellationToken.None);
         await action.Should().ThrowAsync<InvalidOperationException>();
 
         this.commandLineInvokationService.Verify();

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/PipReportComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/PipReportComponentDetectorTests.cs
@@ -3,6 +3,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.ComponentDetection.Contracts;
@@ -124,7 +125,7 @@ public class PipReportComponentDetectorTests : BaseDetectorTest<PipReportCompone
     [TestMethod]
     public async Task TestPipReportDetector_BadReportVersionAsync()
     {
-        this.pipCommandService.Setup(x => x.GenerateInstallationReportAsync(It.IsAny<string>(), It.IsAny<string>()))
+        this.pipCommandService.Setup(x => x.GenerateInstallationReportAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((this.singlePackageReportBadVersion, null));
 
         var (result, componentRecorder) = await this.DetectorTestUtility
@@ -146,7 +147,7 @@ public class PipReportComponentDetectorTests : BaseDetectorTest<PipReportCompone
     {
         this.singlePackageReportBadVersion.Version = "2.5";
 
-        this.pipCommandService.Setup(x => x.GenerateInstallationReportAsync(It.IsAny<string>(), It.IsAny<string>()))
+        this.pipCommandService.Setup(x => x.GenerateInstallationReportAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((this.singlePackageReportBadVersion, null));
 
         var (result, componentRecorder) = await this.DetectorTestUtility
@@ -166,7 +167,7 @@ public class PipReportComponentDetectorTests : BaseDetectorTest<PipReportCompone
     [TestMethod]
     public async Task TestPipReportDetector_CatchesExceptionAsync()
     {
-        this.pipCommandService.Setup(x => x.GenerateInstallationReportAsync(It.IsAny<string>(), It.IsAny<string>()))
+        this.pipCommandService.Setup(x => x.GenerateInstallationReportAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidCastException());
 
         var (result, componentRecorder) = await this.DetectorTestUtility
@@ -186,7 +187,7 @@ public class PipReportComponentDetectorTests : BaseDetectorTest<PipReportCompone
     [TestMethod]
     public async Task TestPipReportDetector_SingleComponentAsync()
     {
-        this.pipCommandService.Setup(x => x.GenerateInstallationReportAsync(It.IsAny<string>(), It.IsAny<string>()))
+        this.pipCommandService.Setup(x => x.GenerateInstallationReportAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((this.singlePackageReport, null));
 
         var (result, componentRecorder) = await this.DetectorTestUtility
@@ -216,7 +217,7 @@ public class PipReportComponentDetectorTests : BaseDetectorTest<PipReportCompone
     [TestMethod]
     public async Task TestPipReportDetector_SimpleExtrasAsync()
     {
-        this.pipCommandService.Setup(x => x.GenerateInstallationReportAsync(It.IsAny<string>(), It.IsAny<string>()))
+        this.pipCommandService.Setup(x => x.GenerateInstallationReportAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((this.simpleExtrasReport, null));
 
         var (result, componentRecorder) = await this.DetectorTestUtility
@@ -243,7 +244,7 @@ public class PipReportComponentDetectorTests : BaseDetectorTest<PipReportCompone
     {
         this.mockEnvVarService.Setup(x => x.IsEnvironmentVariableValueTrue("DisablePipReportScan")).Returns(true);
 
-        this.pipCommandService.Setup(x => x.GenerateInstallationReportAsync(It.IsAny<string>(), It.IsAny<string>()))
+        this.pipCommandService.Setup(x => x.GenerateInstallationReportAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((this.simpleExtrasReport, null));
 
         var (result, componentRecorder) = await this.DetectorTestUtility
@@ -266,7 +267,7 @@ public class PipReportComponentDetectorTests : BaseDetectorTest<PipReportCompone
     [TestMethod]
     public async Task TestPipReportDetector_MultiComponentAsync()
     {
-        this.pipCommandService.Setup(x => x.GenerateInstallationReportAsync(It.IsAny<string>(), It.IsAny<string>()))
+        this.pipCommandService.Setup(x => x.GenerateInstallationReportAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((this.multiPackageReport, null));
 
         var (result, componentRecorder) = await this.DetectorTestUtility
@@ -296,11 +297,13 @@ public class PipReportComponentDetectorTests : BaseDetectorTest<PipReportCompone
     {
         this.pipCommandService.Setup(x => x.GenerateInstallationReportAsync(
             It.Is<string>(s => s.Contains("setup.py", StringComparison.OrdinalIgnoreCase)),
-            It.IsAny<string>()))
+            It.IsAny<string>(),
+            It.IsAny<CancellationToken>()))
             .ReturnsAsync((this.multiPackageReport, null));
         this.pipCommandService.Setup(x => x.GenerateInstallationReportAsync(
             It.Is<string>(s => s.Contains("requirements.txt", StringComparison.OrdinalIgnoreCase)),
-            It.IsAny<string>()))
+            It.IsAny<string>(),
+            It.IsAny<CancellationToken>()))
             .ReturnsAsync((this.singlePackageReport, null));
 
         var (result, componentRecorder) = await this.DetectorTestUtility
@@ -334,11 +337,13 @@ public class PipReportComponentDetectorTests : BaseDetectorTest<PipReportCompone
 
         this.pipCommandService.Setup(x => x.GenerateInstallationReportAsync(
             It.Is<string>(s => s.Contains("setup.py", StringComparison.OrdinalIgnoreCase)),
-            It.IsAny<string>()))
+            It.IsAny<string>(),
+            It.IsAny<CancellationToken>()))
             .ReturnsAsync((this.multiPackageReport, null));
         this.pipCommandService.Setup(x => x.GenerateInstallationReportAsync(
             It.Is<string>(s => s.Contains("requirements.txt", StringComparison.OrdinalIgnoreCase)),
-            It.IsAny<string>()))
+            It.IsAny<string>(),
+            It.IsAny<CancellationToken>()))
             .ReturnsAsync((this.singlePackageReport, null));
 
         var (result, componentRecorder) = await this.DetectorTestUtility
@@ -398,7 +403,8 @@ public class PipReportComponentDetectorTests : BaseDetectorTest<PipReportCompone
 
         this.pipCommandService.Setup(x => x.GenerateInstallationReportAsync(
             It.Is<string>(s => s.Contains("requirements.txt", StringComparison.OrdinalIgnoreCase)),
-            It.IsAny<string>()))
+            It.IsAny<string>(),
+            It.IsAny<CancellationToken>()))
             .ReturnsAsync((this.jupyterPackageReport, null));
 
         var (result, componentRecorder) = await this.DetectorTestUtility

--- a/test/Microsoft.ComponentDetection.Orchestrator.Tests/Experiments/DefaultExperimentProcessorTests.cs
+++ b/test/Microsoft.ComponentDetection.Orchestrator.Tests/Experiments/DefaultExperimentProcessorTests.cs
@@ -1,6 +1,7 @@
-﻿namespace Microsoft.ComponentDetection.Orchestrator.Tests.Experiments;
+namespace Microsoft.ComponentDetection.Orchestrator.Tests.Experiments;
 
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.ComponentDetection.Common;
 using Microsoft.ComponentDetection.Orchestrator.Experiments;
@@ -42,7 +43,8 @@ public class DefaultExperimentProcessorTests
         this.fileWritingServiceMock.Verify(
             f => f.WriteFileAsync(
                 It.Is<string>(s => s.StartsWith($"Experiment_{config.Object.Name}_")),
-                serializedDiff),
+                serializedDiff,
+                It.IsAny<CancellationToken>()),
             Times.Once);
     }
 }

--- a/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/BcdeScanExecutionServiceTests.cs
+++ b/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/BcdeScanExecutionServiceTests.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.ComponentDetection.Common.DependencyGraph;

--- a/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/DetectorProcessingServiceTests.cs
+++ b/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/DetectorProcessingServiceTests.cs
@@ -288,7 +288,7 @@ public class DetectorProcessingServiceTests
         ScanRequest capturedRequest = null;
         this.firstFileComponentDetectorMock.Setup(x => x.ExecuteDetectorAsync(It.IsAny<ScanRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(this.ExpectedResultForDetector(this.firstFileComponentDetectorMock.Object.Id))
-            .Callback<ScanRequest>(request => capturedRequest = request);
+            .Callback<ScanRequest, CancellationToken>((request, token) => capturedRequest = request);
 
         await this.serviceUnderTest.ProcessDetectorsAsync(DefaultArgs, this.detectorsToUse, new DetectorRestrictions());
 
@@ -404,7 +404,7 @@ public class DetectorProcessingServiceTests
         ScanRequest capturedRequest = null;
         this.firstFileComponentDetectorMock.Setup(x => x.ExecuteDetectorAsync(It.IsAny<ScanRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(this.ExpectedResultForDetector(this.firstFileComponentDetectorMock.Object.Id))
-            .Callback<ScanRequest>(request => capturedRequest = request);
+            .Callback<ScanRequest, CancellationToken>((request, token) => capturedRequest = request);
 
         await this.serviceUnderTest.ProcessDetectorsAsync(args, this.detectorsToUse, new DetectorRestrictions());
 
@@ -562,12 +562,10 @@ public class DetectorProcessingServiceTests
         var expectedResult = this.ExpectedResultForDetector(id);
 
         mockFileDetector.Setup(x => x.ExecuteDetectorAsync(It.Is<ScanRequest>(request => request.SourceDirectory == DefaultArgs.SourceDirectory && request.ComponentRecorder != null), It.IsAny<CancellationToken>())).Returns(
-            (ScanRequest request) =>
-            {
-                return mockFileDetector.Object.ExecuteDetectorAsync(request);
-            }).Verifiable();
+            (ScanRequest request, CancellationToken cancellationToken) => mockFileDetector.Object.ExecuteDetectorAsync(request, cancellationToken)).Verifiable();
+
         mockFileDetector.Setup(x => x.ExecuteDetectorAsync(It.Is<ScanRequest>(request => request.SourceDirectory == DefaultArgs.SourceDirectory && request.ComponentRecorder != null), It.IsAny<CancellationToken>())).ReturnsAsync(
-            (ScanRequest request) =>
+            (ScanRequest request, CancellationToken cancellationToken) =>
             {
                 this.FillComponentRecorder(request.ComponentRecorder, id);
                 return expectedResult;
@@ -611,7 +609,7 @@ public class DetectorProcessingServiceTests
         this.componentDictionary.Should().ContainKey(id, $"MockDetector id:{id}, should be in mock dictionary");
 
         mockCommandDetector.Setup(x => x.ExecuteDetectorAsync(It.Is<ScanRequest>(request => request.SourceDirectory == DefaultArgs.SourceDirectory && !request.DetectorArgs.Any()), It.IsAny<CancellationToken>())).ReturnsAsync(
-            (ScanRequest request) =>
+            (ScanRequest request, CancellationToken cancellationToken) =>
             {
                 this.FillComponentRecorder(request.ComponentRecorder, id);
                 return this.ExpectedResultForDetector(id);

--- a/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/DetectorProcessingServiceTests.cs
+++ b/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/DetectorProcessingServiceTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.ComponentDetection.Common.DependencyGraph;
@@ -89,8 +90,8 @@ public class DetectorProcessingServiceTests
 
         var results = await this.serviceUnderTest.ProcessDetectorsAsync(DefaultArgs, this.detectorsToUse, new DetectorRestrictions());
 
-        this.firstFileComponentDetectorMock.Verify(x => x.ExecuteDetectorAsync(It.Is<ScanRequest>(request => request.SourceDirectory == DefaultArgs.SourceDirectory)));
-        this.secondFileComponentDetectorMock.Verify(x => x.ExecuteDetectorAsync(It.Is<ScanRequest>(request => request.SourceDirectory == DefaultArgs.SourceDirectory)));
+        this.firstFileComponentDetectorMock.Verify(x => x.ExecuteDetectorAsync(It.Is<ScanRequest>(request => request.SourceDirectory == DefaultArgs.SourceDirectory), It.IsAny<CancellationToken>()));
+        this.secondFileComponentDetectorMock.Verify(x => x.ExecuteDetectorAsync(It.Is<ScanRequest>(request => request.SourceDirectory == DefaultArgs.SourceDirectory), It.IsAny<CancellationToken>()));
 
         this.ValidateExpectedComponents(results, this.detectorsToUse);
         this.GetDiscoveredComponentsFromDetectorProcessingResult(results).FirstOrDefault(x => x.Component?.Type == ComponentType.Npm).Component
@@ -107,7 +108,7 @@ public class DetectorProcessingServiceTests
         var mockComponentDetector = new Mock<IComponentDetector>();
         mockComponentDetector.Setup(d => d.Id).Returns("test");
 
-        mockComponentDetector.Setup(x => x.ExecuteDetectorAsync(It.IsAny<ScanRequest>()))
+        mockComponentDetector.Setup(x => x.ExecuteDetectorAsync(It.IsAny<ScanRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(() =>
             {
                 return new IndividualDetectorScanResult
@@ -134,8 +135,8 @@ public class DetectorProcessingServiceTests
 
         var results = await this.serviceUnderTest.ProcessDetectorsAsync(DefaultArgs, this.detectorsToUse, new DetectorRestrictions());
 
-        this.firstFileComponentDetectorMock.Verify(x => x.ExecuteDetectorAsync(It.Is<ScanRequest>(request => request.SourceDirectory == DefaultArgs.SourceDirectory)));
-        this.secondFileComponentDetectorMock.Verify(x => x.ExecuteDetectorAsync(It.Is<ScanRequest>(request => request.SourceDirectory == DefaultArgs.SourceDirectory)));
+        this.firstFileComponentDetectorMock.Verify(x => x.ExecuteDetectorAsync(It.Is<ScanRequest>(request => request.SourceDirectory == DefaultArgs.SourceDirectory), It.IsAny<CancellationToken>()));
+        this.secondFileComponentDetectorMock.Verify(x => x.ExecuteDetectorAsync(It.Is<ScanRequest>(request => request.SourceDirectory == DefaultArgs.SourceDirectory), It.IsAny<CancellationToken>()));
 
         foreach (var discoveredComponent in this.GetDiscoveredComponentsFromDetectorProcessingResult(results))
         {
@@ -202,9 +203,9 @@ public class DetectorProcessingServiceTests
             .Should().BeTrue("Experimental component should not be in component list");
         results.ResultCode.Should().Be(ProcessingResultCode.Success);
 
-        this.firstFileComponentDetectorMock.Verify(x => x.ExecuteDetectorAsync(It.Is<ScanRequest>(request => request.SourceDirectory == DefaultArgs.SourceDirectory)));
-        this.secondFileComponentDetectorMock.Verify(x => x.ExecuteDetectorAsync(It.Is<ScanRequest>(request => request.SourceDirectory == DefaultArgs.SourceDirectory)));
-        this.experimentalFileComponentDetectorMock.Verify(x => x.ExecuteDetectorAsync(It.Is<ScanRequest>(request => request.SourceDirectory == DefaultArgs.SourceDirectory)));
+        this.firstFileComponentDetectorMock.Verify(x => x.ExecuteDetectorAsync(It.Is<ScanRequest>(request => request.SourceDirectory == DefaultArgs.SourceDirectory), It.IsAny<CancellationToken>()));
+        this.secondFileComponentDetectorMock.Verify(x => x.ExecuteDetectorAsync(It.Is<ScanRequest>(request => request.SourceDirectory == DefaultArgs.SourceDirectory), It.IsAny<CancellationToken>()));
+        this.experimentalFileComponentDetectorMock.Verify(x => x.ExecuteDetectorAsync(It.Is<ScanRequest>(request => request.SourceDirectory == DefaultArgs.SourceDirectory), It.IsAny<CancellationToken>()));
     }
 
     [TestMethod]
@@ -230,9 +231,9 @@ public class DetectorProcessingServiceTests
             .Should().NotBeNull();
         results.ResultCode.Should().Be(ProcessingResultCode.Success);
 
-        this.firstFileComponentDetectorMock.Verify(x => x.ExecuteDetectorAsync(It.Is<ScanRequest>(request => request.SourceDirectory == DefaultArgs.SourceDirectory)));
-        this.secondFileComponentDetectorMock.Verify(x => x.ExecuteDetectorAsync(It.Is<ScanRequest>(request => request.SourceDirectory == DefaultArgs.SourceDirectory)));
-        this.experimentalFileComponentDetectorMock.Verify(x => x.ExecuteDetectorAsync(It.Is<ScanRequest>(request => request.SourceDirectory == DefaultArgs.SourceDirectory)));
+        this.firstFileComponentDetectorMock.Verify(x => x.ExecuteDetectorAsync(It.Is<ScanRequest>(request => request.SourceDirectory == DefaultArgs.SourceDirectory), It.IsAny<CancellationToken>()));
+        this.secondFileComponentDetectorMock.Verify(x => x.ExecuteDetectorAsync(It.Is<ScanRequest>(request => request.SourceDirectory == DefaultArgs.SourceDirectory), It.IsAny<CancellationToken>()));
+        this.experimentalFileComponentDetectorMock.Verify(x => x.ExecuteDetectorAsync(It.Is<ScanRequest>(request => request.SourceDirectory == DefaultArgs.SourceDirectory), It.IsAny<CancellationToken>()));
     }
 
     [TestMethod]
@@ -244,7 +245,7 @@ public class DetectorProcessingServiceTests
             this.experimentalFileComponentDetectorMock.Object,
         };
 
-        this.experimentalFileComponentDetectorMock.Setup(x => x.ExecuteDetectorAsync(It.Is<ScanRequest>(request => request.SourceDirectory == DefaultArgs.SourceDirectory)))
+        this.experimentalFileComponentDetectorMock.Setup(x => x.ExecuteDetectorAsync(It.Is<ScanRequest>(request => request.SourceDirectory == DefaultArgs.SourceDirectory), It.IsAny<CancellationToken>()))
             .Throws(new InvalidOperationException("Simulated experimental failure"));
 
         DetectorProcessingResult results = null;
@@ -264,8 +265,8 @@ public class DetectorProcessingServiceTests
         this.GetDiscoveredComponentsFromDetectorProcessingResult(results).Should().HaveCount(records.Sum(x => x.DetectedComponentCount ?? 0));
         results.ResultCode.Should().Be(ProcessingResultCode.Success);
 
-        this.firstFileComponentDetectorMock.Verify(x => x.ExecuteDetectorAsync(It.Is<ScanRequest>(request => request.SourceDirectory == DefaultArgs.SourceDirectory)));
-        this.secondFileComponentDetectorMock.Verify(x => x.ExecuteDetectorAsync(It.Is<ScanRequest>(request => request.SourceDirectory == DefaultArgs.SourceDirectory)));
+        this.firstFileComponentDetectorMock.Verify(x => x.ExecuteDetectorAsync(It.Is<ScanRequest>(request => request.SourceDirectory == DefaultArgs.SourceDirectory), It.IsAny<CancellationToken>()));
+        this.secondFileComponentDetectorMock.Verify(x => x.ExecuteDetectorAsync(It.Is<ScanRequest>(request => request.SourceDirectory == DefaultArgs.SourceDirectory), It.IsAny<CancellationToken>()));
     }
 
     [TestMethod]
@@ -285,7 +286,7 @@ public class DetectorProcessingServiceTests
         var d2 = new DirectoryInfo(Path.Combine(Environment.CurrentDirectory, "shouldNotExclude", "stuff"));
 
         ScanRequest capturedRequest = null;
-        this.firstFileComponentDetectorMock.Setup(x => x.ExecuteDetectorAsync(It.IsAny<ScanRequest>()))
+        this.firstFileComponentDetectorMock.Setup(x => x.ExecuteDetectorAsync(It.IsAny<ScanRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(this.ExpectedResultForDetector(this.firstFileComponentDetectorMock.Object.Id))
             .Callback<ScanRequest>(request => capturedRequest = request);
 
@@ -401,7 +402,7 @@ public class DetectorProcessingServiceTests
         Environment.CurrentDirectory = sourceDirectory.FullName;
 
         ScanRequest capturedRequest = null;
-        this.firstFileComponentDetectorMock.Setup(x => x.ExecuteDetectorAsync(It.IsAny<ScanRequest>()))
+        this.firstFileComponentDetectorMock.Setup(x => x.ExecuteDetectorAsync(It.IsAny<ScanRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(this.ExpectedResultForDetector(this.firstFileComponentDetectorMock.Object.Id))
             .Callback<ScanRequest>(request => capturedRequest = request);
 
@@ -455,8 +456,8 @@ public class DetectorProcessingServiceTests
         var secondDetectorRecord = records.FirstOrDefault(x => x.DetectorId == this.secondFileComponentDetectorMock.Object.Id);
         secondDetectorRecord.Should().NotBeNull();
 
-        this.firstFileComponentDetectorMock.Verify(x => x.ExecuteDetectorAsync(It.Is<ScanRequest>(request => request.SourceDirectory == DefaultArgs.SourceDirectory)));
-        this.secondFileComponentDetectorMock.Verify(x => x.ExecuteDetectorAsync(It.Is<ScanRequest>(request => request.SourceDirectory == DefaultArgs.SourceDirectory)));
+        this.firstFileComponentDetectorMock.Verify(x => x.ExecuteDetectorAsync(It.Is<ScanRequest>(request => request.SourceDirectory == DefaultArgs.SourceDirectory), It.IsAny<CancellationToken>()));
+        this.secondFileComponentDetectorMock.Verify(x => x.ExecuteDetectorAsync(It.Is<ScanRequest>(request => request.SourceDirectory == DefaultArgs.SourceDirectory), It.IsAny<CancellationToken>()));
     }
 
     [TestMethod]
@@ -485,10 +486,10 @@ public class DetectorProcessingServiceTests
 
         this.ValidateExpectedComponents(results, this.detectorsToUse);
 
-        this.firstFileComponentDetectorMock.Verify(x => x.ExecuteDetectorAsync(It.Is<ScanRequest>(request => request.SourceDirectory == DefaultArgs.SourceDirectory)));
-        this.secondFileComponentDetectorMock.Verify(x => x.ExecuteDetectorAsync(It.Is<ScanRequest>(request => request.SourceDirectory == DefaultArgs.SourceDirectory)));
-        this.firstCommandComponentDetectorMock.Verify(x => x.ExecuteDetectorAsync(It.Is<ScanRequest>(request => request.SourceDirectory == DefaultArgs.SourceDirectory)));
-        this.secondCommandComponentDetectorMock.Verify(x => x.ExecuteDetectorAsync(It.Is<ScanRequest>(request => request.SourceDirectory == DefaultArgs.SourceDirectory)));
+        this.firstFileComponentDetectorMock.Verify(x => x.ExecuteDetectorAsync(It.Is<ScanRequest>(request => request.SourceDirectory == DefaultArgs.SourceDirectory), It.IsAny<CancellationToken>()));
+        this.secondFileComponentDetectorMock.Verify(x => x.ExecuteDetectorAsync(It.Is<ScanRequest>(request => request.SourceDirectory == DefaultArgs.SourceDirectory), It.IsAny<CancellationToken>()));
+        this.firstCommandComponentDetectorMock.Verify(x => x.ExecuteDetectorAsync(It.Is<ScanRequest>(request => request.SourceDirectory == DefaultArgs.SourceDirectory), It.IsAny<CancellationToken>()));
+        this.secondCommandComponentDetectorMock.Verify(x => x.ExecuteDetectorAsync(It.Is<ScanRequest>(request => request.SourceDirectory == DefaultArgs.SourceDirectory), It.IsAny<CancellationToken>()));
     }
 
     [TestMethod]
@@ -560,12 +561,12 @@ public class DetectorProcessingServiceTests
 
         var expectedResult = this.ExpectedResultForDetector(id);
 
-        mockFileDetector.Setup(x => x.ExecuteDetectorAsync(It.Is<ScanRequest>(request => request.SourceDirectory == DefaultArgs.SourceDirectory && request.ComponentRecorder != null))).Returns(
+        mockFileDetector.Setup(x => x.ExecuteDetectorAsync(It.Is<ScanRequest>(request => request.SourceDirectory == DefaultArgs.SourceDirectory && request.ComponentRecorder != null), It.IsAny<CancellationToken>())).Returns(
             (ScanRequest request) =>
             {
                 return mockFileDetector.Object.ExecuteDetectorAsync(request);
             }).Verifiable();
-        mockFileDetector.Setup(x => x.ExecuteDetectorAsync(It.Is<ScanRequest>(request => request.SourceDirectory == DefaultArgs.SourceDirectory && request.ComponentRecorder != null))).ReturnsAsync(
+        mockFileDetector.Setup(x => x.ExecuteDetectorAsync(It.Is<ScanRequest>(request => request.SourceDirectory == DefaultArgs.SourceDirectory && request.ComponentRecorder != null), It.IsAny<CancellationToken>())).ReturnsAsync(
             (ScanRequest request) =>
             {
                 this.FillComponentRecorder(request.ComponentRecorder, id);
@@ -609,7 +610,7 @@ public class DetectorProcessingServiceTests
 
         this.componentDictionary.Should().ContainKey(id, $"MockDetector id:{id}, should be in mock dictionary");
 
-        mockCommandDetector.Setup(x => x.ExecuteDetectorAsync(It.Is<ScanRequest>(request => request.SourceDirectory == DefaultArgs.SourceDirectory && !request.DetectorArgs.Any()))).ReturnsAsync(
+        mockCommandDetector.Setup(x => x.ExecuteDetectorAsync(It.Is<ScanRequest>(request => request.SourceDirectory == DefaultArgs.SourceDirectory && !request.DetectorArgs.Any()), It.IsAny<CancellationToken>())).ReturnsAsync(
             (ScanRequest request) =>
             {
                 this.FillComponentRecorder(request.ComponentRecorder, id);


### PR DESCRIPTION
Adds cancellation support for pip report, and sets up the ability for other processes to be cancelled if we choose to do so.

Tested by running locally, here is an example with timeout set to 3:
![image](https://github.com/microsoft/component-detection/assets/107068277/d01a1e38-1b9d-4159-b8dd-2fc583f9babb)

And here with it set to 10:
![image](https://github.com/microsoft/component-detection/assets/107068277/46c191d2-e23e-4979-bfbe-2a60260a316a)

Snippet from the logs for these runs:
```
[13:52:58 DBG] PipReport: Cancelled for file 'C:/src/component-detection/test/Microsoft.ComponentDetection.VerificationTests/resources/pip/simple-extras/requirements.txt' with command 'install -r requirements.txt --dry-run --ignore-installed --quiet --report uqz3ardl.l4r'.
[13:52:58 INF] Telemetry record: {
  "RecordName": "PipReportFailure",
  "ExitCode": -1,
  "StdErr": "PipReport: Cancelled for file \u0027C:/src/component-detection/test/Microsoft.ComponentDetection.VerificationTests/resources/pip/simple-extras/requirements.txt\u0027 with command \u0027install -r requirements.txt --dry-run --ignore-installed --quiet --report uqz3ardl.l4r\u0027. ",
  "ExecutionTime": "00:00:00.0192389",
  "Timestamp": "2024-06-12T20:52:58.1639892Z",
  "CorrelationId": "e942f400-f78d-4f33-baba-ae41cbb283ef"
}
[13:52:58 WRN] PipReport: Failure while parsing pip installation report for C:\src\component-detection\test\Microsoft.ComponentDetection.VerificationTests\resources\pip\simple-extras\requirements.txt
System.InvalidOperationException: PipReport: Cancelled for file 'C:/src/component-detection/test/Microsoft.ComponentDetection.VerificationTests/resources/pip/simple-extras/requirements.txt' with command 'install -r requirements.txt --dry-run --ignore-installed --quiet --report uqz3ardl.l4r'.
   at Microsoft.ComponentDetection.Detectors.Pip.PipCommandService.GenerateInstallationReportAsync(String path, String pipExePath, CancellationToken cancellationToken) in C:\src\component-detection\src\Microsoft.ComponentDetection.Detectors\pip\PipCommandService.cs:line 148
   at Microsoft.ComponentDetection.Detectors.Pip.PipReportComponentDetector.OnFileFoundAsync(ProcessRequest processRequest, IDictionary`2 detectorArgs, CancellationToken cancellationToken) in C:\src\component-detection\src\Microsoft.ComponentDetection.Detectors\pip\PipReportComponentDetector.cs:line 107
[13:52:58 INF] Telemetry record: {
  "RecordName": "FailedParsingFile",
  "DetectorId": "PipReport",
  "FilePath": "C:\\src\\component-detection\\test\\Microsoft.ComponentDetection.VerificationTests\\resources\\pip\\simple-extras\\requirements.txt",
  "ExceptionMessage": "PipReport: Cancelled for file \u0027C:/src/component-detection/test/Microsoft.ComponentDetection.VerificationTests/resources/pip/simple-extras/requirements.txt\u0027 with command \u0027install -r requirements.txt --dry-run --ignore-installed --quiet --report uqz3ardl.l4r\u0027.",
  "StackTrace": "   at Microsoft.ComponentDetection.Detectors.Pip.PipCommandService.GenerateInstallationReportAsync(String path, String pipExePath, CancellationToken cancellationToken) in C:\\src\\component-detection\\src\\Microsoft.ComponentDetection.Detectors\\pip\\PipCommandService.cs:line 148\r\n   at Microsoft.ComponentDetection.Detectors.Pip.PipReportComponentDetector.OnFileFoundAsync(ProcessRequest processRequest, IDictionary\u00602 detectorArgs, CancellationToken cancellationToken) in C:\\src\\component-detection\\src\\Microsoft.ComponentDetection.Detectors\\pip\\PipReportComponentDetector.cs:line 107",
  "ExecutionTime": "00:00:00.0001008",
  "Timestamp": "2024-06-12T20:52:58.190925Z",
  "CorrelationId": "e942f400-f78d-4f33-baba-ae41cbb283ef"
}
[13:52:58 INF] Telemetry record: {
  "RecordName": "DetectorExecution",
  "DetectorId": "PipReport",
  "DetectedComponentCount": 0,
  "ExplicitlyReferencedComponentCount": 0,
  "ReturnCode": 0,
  "IsExperimental": true,
  "ExperimentalInformation": null,
  "AdditionalTelemetryDetails": "{}",
  "ExecutionTime": "00:00:10.2052562",
  "Timestamp": "2024-06-12T20:52:58.1927965Z",
  "CorrelationId": "e942f400-f78d-4f33-baba-ae41cbb283ef"
}
```
