### PR TITLE
Enable parallelism by detector

### DIFF
--- a/src/Microsoft.ComponentDetection.Common/CommandLineInvocationService.cs
+++ b/src/Microsoft.ComponentDetection.Common/CommandLineInvocationService.cs
@@ -157,6 +157,24 @@ public class CommandLineInvocationService : ICommandLineInvocationService
         t1.Start();
         t2.Start();
 
+<<<<<<< HEAD
+=======
+        cancellationToken.Register(() =>
+        {
+            try
+            {
+                process.Kill();
+            }
+            catch (InvalidOperationException)
+            {
+                // swallow invalid operations, which indicate that there is no process associated with
+                // the process object, and therefore nothing to kill
+                // https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.kill?view=net-8.0#system-diagnostics-process-kill
+                return;
+            }
+        });
+
+>>>>>>> 99639f1 (add parallelism for detection)
         return tcs.Task;
     }
 }

--- a/src/Microsoft.ComponentDetection.Common/CommandLineInvocationService.cs
+++ b/src/Microsoft.ComponentDetection.Common/CommandLineInvocationService.cs
@@ -157,24 +157,6 @@ public class CommandLineInvocationService : ICommandLineInvocationService
         t1.Start();
         t2.Start();
 
-<<<<<<< HEAD
-=======
-        cancellationToken.Register(() =>
-        {
-            try
-            {
-                process.Kill();
-            }
-            catch (InvalidOperationException)
-            {
-                // swallow invalid operations, which indicate that there is no process associated with
-                // the process object, and therefore nothing to kill
-                // https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.kill?view=net-8.0#system-diagnostics-process-kill
-                return;
-            }
-        });
-
->>>>>>> 99639f1 (add parallelism for detection)
         return tcs.Task;
     }
 }

--- a/src/Microsoft.ComponentDetection.Contracts/FileComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/FileComponentDetector.cs
@@ -81,11 +81,7 @@ public abstract class FileComponentDetector : IComponentDetector
         var filteredObservable = this.Scanner.GetFilteredComponentStreamObservable(request.SourceDirectory, this.SearchPatterns, request.ComponentRecorder);
 
         this.Logger.LogDebug("Registered {Detector}", this.GetType().FullName);
-<<<<<<< HEAD
-        return this.ProcessAsync(filteredObservable, request.DetectorArgs);
-=======
-        return this.ProcessAsync(filteredObservable, request.DetectorArgs, request.MaxThreads, cancellationToken);
->>>>>>> 99639f1 (add parallelism for detection)
+        return this.ProcessAsync(filteredObservable, request.DetectorArgs, request.MaxThreads);
     }
 
     /// <summary>

--- a/src/Microsoft.ComponentDetection.Contracts/FileComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/FileComponentDetector.cs
@@ -13,8 +13,6 @@ using Microsoft.Extensions.Logging;
 /// <summary>Specialized base class for file based component detection.</summary>
 public abstract class FileComponentDetector : IComponentDetector
 {
-    private const int DefaultMaxThreads = 10;
-
     /// <summary>
     /// Gets or sets the factory for handing back component streams to File detectors.
     /// </summary>
@@ -107,14 +105,14 @@ public abstract class FileComponentDetector : IComponentDetector
     /// <param name="lockfileVersion">The lockfile version.</param>
     protected void RecordLockfileVersion(string lockfileVersion) => this.Telemetry["LockfileVersion"] = lockfileVersion;
 
-    private async Task<IndividualDetectorScanResult> ProcessAsync(IObservable<ProcessRequest> processRequests, IDictionary<string, string> detectorArgs, int? maxThreads)
+    private async Task<IndividualDetectorScanResult> ProcessAsync(IObservable<ProcessRequest> processRequests, IDictionary<string, string> detectorArgs, int maxThreads)
     {
         var processor = new ActionBlock<ProcessRequest>(
             async processRequest => await this.OnFileFoundAsync(processRequest, detectorArgs),
             new ExecutionDataflowBlockOptions
             {
                 // MaxDegreeOfParallelism is the lower of the processor count and the max threads arg that the customer passed in
-                MaxDegreeOfParallelism = Math.Min(Environment.ProcessorCount, maxThreads ?? DefaultMaxThreads),
+                MaxDegreeOfParallelism = Math.Min(Environment.ProcessorCount, maxThreads),
             });
 
         var preprocessedObserbable = await this.OnPrepareDetectionAsync(processRequests, detectorArgs);

--- a/src/Microsoft.ComponentDetection.Contracts/ScanRequest.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/ScanRequest.cs
@@ -19,7 +19,7 @@ public class ScanRequest
     /// <param name="imagesToScan">Container images to scan.</param>
     /// <param name="componentRecorder">Detector component recorder.</param>
     /// <param name="maxThreads">Max number of threads to use for detection.</param>
-    public ScanRequest(DirectoryInfo sourceDirectory, ExcludeDirectoryPredicate directoryExclusionPredicate, ILogger logger, IDictionary<string, string> detectorArgs, IEnumerable<string> imagesToScan, IComponentRecorder componentRecorder, int maxThreads = 10)
+    public ScanRequest(DirectoryInfo sourceDirectory, ExcludeDirectoryPredicate directoryExclusionPredicate, ILogger logger, IDictionary<string, string> detectorArgs, IEnumerable<string> imagesToScan, IComponentRecorder componentRecorder, int maxThreads = 3)
     {
         this.SourceDirectory = sourceDirectory;
         this.DirectoryExclusionPredicate = directoryExclusionPredicate;

--- a/src/Microsoft.ComponentDetection.Contracts/ScanRequest.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/ScanRequest.cs
@@ -18,13 +18,15 @@ public class ScanRequest
     /// <param name="detectorArgs">A dictionary of custom detector arguments supplied externally.</param>
     /// <param name="imagesToScan">Container images to scan.</param>
     /// <param name="componentRecorder">Detector component recorder.</param>
-    public ScanRequest(DirectoryInfo sourceDirectory, ExcludeDirectoryPredicate directoryExclusionPredicate, ILogger logger, IDictionary<string, string> detectorArgs, IEnumerable<string> imagesToScan, IComponentRecorder componentRecorder)
+    /// <param name="maxThreads">Max number of threads to use for detection.</param>
+    public ScanRequest(DirectoryInfo sourceDirectory, ExcludeDirectoryPredicate directoryExclusionPredicate, ILogger logger, IDictionary<string, string> detectorArgs, IEnumerable<string> imagesToScan, IComponentRecorder componentRecorder, int? maxThreads)
     {
         this.SourceDirectory = sourceDirectory;
         this.DirectoryExclusionPredicate = directoryExclusionPredicate;
         this.DetectorArgs = detectorArgs;
         this.ImagesToScan = imagesToScan;
         this.ComponentRecorder = componentRecorder;
+        this.MaxThreads = maxThreads;
     }
 
     /// <summary>
@@ -51,4 +53,9 @@ public class ScanRequest
     /// Gets the detector component recorder.
     /// </summary>
     public IComponentRecorder ComponentRecorder { get; private set; }
+
+    /// <summary>
+    /// Gets the maximum number of threads to use in parallel for executing the detection.
+    /// </summary>
+    public int? MaxThreads { get; private set; }
 }

--- a/src/Microsoft.ComponentDetection.Contracts/ScanRequest.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/ScanRequest.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.ComponentDetection.Contracts;
+namespace Microsoft.ComponentDetection.Contracts;
 
 using System.Collections.Generic;
 using System.IO;
@@ -19,7 +19,7 @@ public class ScanRequest
     /// <param name="imagesToScan">Container images to scan.</param>
     /// <param name="componentRecorder">Detector component recorder.</param>
     /// <param name="maxThreads">Max number of threads to use for detection.</param>
-    public ScanRequest(DirectoryInfo sourceDirectory, ExcludeDirectoryPredicate directoryExclusionPredicate, ILogger logger, IDictionary<string, string> detectorArgs, IEnumerable<string> imagesToScan, IComponentRecorder componentRecorder, int? maxThreads)
+    public ScanRequest(DirectoryInfo sourceDirectory, ExcludeDirectoryPredicate directoryExclusionPredicate, ILogger logger, IDictionary<string, string> detectorArgs, IEnumerable<string> imagesToScan, IComponentRecorder componentRecorder, int? maxThreads = 10)
     {
         this.SourceDirectory = sourceDirectory;
         this.DirectoryExclusionPredicate = directoryExclusionPredicate;

--- a/src/Microsoft.ComponentDetection.Contracts/ScanRequest.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/ScanRequest.cs
@@ -19,7 +19,7 @@ public class ScanRequest
     /// <param name="imagesToScan">Container images to scan.</param>
     /// <param name="componentRecorder">Detector component recorder.</param>
     /// <param name="maxThreads">Max number of threads to use for detection.</param>
-    public ScanRequest(DirectoryInfo sourceDirectory, ExcludeDirectoryPredicate directoryExclusionPredicate, ILogger logger, IDictionary<string, string> detectorArgs, IEnumerable<string> imagesToScan, IComponentRecorder componentRecorder, int? maxThreads = 10)
+    public ScanRequest(DirectoryInfo sourceDirectory, ExcludeDirectoryPredicate directoryExclusionPredicate, ILogger logger, IDictionary<string, string> detectorArgs, IEnumerable<string> imagesToScan, IComponentRecorder componentRecorder, int maxThreads = 10)
     {
         this.SourceDirectory = sourceDirectory;
         this.DirectoryExclusionPredicate = directoryExclusionPredicate;
@@ -57,5 +57,5 @@ public class ScanRequest
     /// <summary>
     /// Gets the maximum number of threads to use in parallel for executing the detection.
     /// </summary>
-    public int? MaxThreads { get; private set; }
+    public int MaxThreads { get; private set; }
 }

--- a/src/Microsoft.ComponentDetection.Orchestrator/Commands/ScanSettings.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Commands/ScanSettings.cs
@@ -76,12 +76,21 @@ public class ScanSettings : BaseSettings
     [Description("Do not display the detection summary on the standard output nor in the logs.")]
     public bool NoSummary { get; set; }
 
+    [CommandOption("--MaxDetectionThreads")]
+    [Description("Max number of parallel threads used for a single detection process, ex: PipReport, Npm, Nuget.")]
+    public int? MaxDetectionThreads { get; set; }
+
     /// <inheritdoc />
     public override ValidationResult Validate()
     {
         if (this.SourceDirectory is null)
         {
             return ValidationResult.Error($"{nameof(this.SourceDirectory)} is required");
+        }
+
+        if (this.MaxDetectionThreads is <= 0)
+        {
+            return ValidationResult.Error($"{nameof(this.MaxDetectionThreads)} must be a positive integer");
         }
 
         return !this.SourceDirectory.Exists ? ValidationResult.Error($"The {nameof(this.SourceDirectory)} {this.SourceDirectory} does not exist") : base.Validate();

--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/DetectorProcessingService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/DetectorProcessingService.cs
@@ -75,7 +75,7 @@ public class DetectorProcessingService : IDetectorProcessingService
                 using (var record = new DetectorExecutionTelemetryRecord())
                 {
                     result = await this.WithExperimentalScanGuardsAsync(
-                        () => detector.ExecuteDetectorAsync(new ScanRequest(settings.SourceDirectory, exclusionPredicate, this.logger, settings.DetectorArgs, settings.DockerImagesToScan, componentRecorder)),
+                        () => detector.ExecuteDetectorAsync(new ScanRequest(settings.SourceDirectory, exclusionPredicate, this.logger, settings.DetectorArgs, settings.DockerImagesToScan, componentRecorder, settings.MaxDetectionThreads)),
                         isExperimentalDetector,
                         record);
 

--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/DetectorProcessingService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/DetectorProcessingService.cs
@@ -23,7 +23,7 @@ using static System.Environment;
 
 public class DetectorProcessingService : IDetectorProcessingService
 {
-    private const int DefaultMaxDetectionThreads = 10;
+    private const int DefaultMaxDetectionThreads = 3;
 
     private readonly IObservableDirectoryWalkerFactory scanner;
     private readonly ILogger<DetectorProcessingService> logger;

--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/DetectorProcessingService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/DetectorProcessingService.cs
@@ -23,6 +23,8 @@ using static System.Environment;
 
 public class DetectorProcessingService : IDetectorProcessingService
 {
+    private const int DefaultMaxDetectionThreads = 10;
+
     private readonly IObservableDirectoryWalkerFactory scanner;
     private readonly ILogger<DetectorProcessingService> logger;
     private readonly IExperimentService experimentService;
@@ -75,7 +77,7 @@ public class DetectorProcessingService : IDetectorProcessingService
                 using (var record = new DetectorExecutionTelemetryRecord())
                 {
                     result = await this.WithExperimentalScanGuardsAsync(
-                        () => detector.ExecuteDetectorAsync(new ScanRequest(settings.SourceDirectory, exclusionPredicate, this.logger, settings.DetectorArgs, settings.DockerImagesToScan, componentRecorder, settings.MaxDetectionThreads)),
+                        () => detector.ExecuteDetectorAsync(new ScanRequest(settings.SourceDirectory, exclusionPredicate, this.logger, settings.DetectorArgs, settings.DockerImagesToScan, componentRecorder, settings.MaxDetectionThreads ?? DefaultMaxDetectionThreads)),
                         isExperimentalDetector,
                         record);
 

--- a/test/Microsoft.ComponentDetection.Orchestrator.Tests/Commands/ScanSettingsTests.cs
+++ b/test/Microsoft.ComponentDetection.Orchestrator.Tests/Commands/ScanSettingsTests.cs
@@ -62,4 +62,37 @@ public class ScanSettingsTests
 
         action.Should().NotThrow();
     }
+
+    [DataTestMethod]
+    [DataRow(-1)]
+    [DataRow(0)]
+    public void Validate_FailInvalidMaxThreads(int? input)
+    {
+        var settings = new ScanSettings
+        {
+            SourceDirectory = new DirectoryInfo(Path.GetTempPath()),
+            MaxDetectionThreads = input,
+        };
+
+        var result = settings.Validate();
+
+        result.Successful.Should().BeFalse();
+    }
+
+    [DataTestMethod]
+    [DataRow(null)]
+    [DataRow(1)]
+    [DataRow(99)]
+    public void Validate_SuccessMaxThreads(int? input)
+    {
+        var settings = new ScanSettings
+        {
+            SourceDirectory = new DirectoryInfo(Path.GetTempPath()),
+            MaxDetectionThreads = input,
+        };
+
+        var result = settings.Validate();
+
+        result.Successful.Should().BeTrue();
+    }
 }

--- a/test/Microsoft.ComponentDetection.VerificationTests/resources/pip/parallel/parallel-test-1/requirements.txt
+++ b/test/Microsoft.ComponentDetection.VerificationTests/resources/pip/parallel/parallel-test-1/requirements.txt
@@ -1,0 +1,14 @@
+artifacts-keyring==0.3.4
+certifi==2024.6.2
+charset-normalizer==3.3.2
+Cython==3.0.10
+idna==3.7
+jaraco.classes==3.4.0
+jaraco.context==5.3.0
+jaraco.functools==4.0.1
+keyring==25.2.1
+more-itertools==10.2.0
+numpy==1.26.4
+pywin32-ctypes==0.2.2
+requests==2.32.3
+urllib3==2.2.1

--- a/test/Microsoft.ComponentDetection.VerificationTests/resources/pip/parallel/parallel-test-2/requirements.txt
+++ b/test/Microsoft.ComponentDetection.VerificationTests/resources/pip/parallel/parallel-test-2/requirements.txt
@@ -1,0 +1,14 @@
+artifacts-keyring==0.3.4
+certifi==2024.6.2
+charset-normalizer==3.3.2
+Cython==3.0.10
+idna==3.7
+jaraco.classes==3.4.0
+jaraco.context==5.3.0
+jaraco.functools==4.0.1
+keyring==25.2.1
+more-itertools==10.2.0
+numpy==1.26.4
+pywin32-ctypes==0.2.2
+requests==2.32.3
+urllib3==2.2.1

--- a/test/Microsoft.ComponentDetection.VerificationTests/resources/pip/parallel/parallel-test-3/requirements.txt
+++ b/test/Microsoft.ComponentDetection.VerificationTests/resources/pip/parallel/parallel-test-3/requirements.txt
@@ -1,0 +1,14 @@
+artifacts-keyring==0.3.4
+certifi==2024.6.2
+charset-normalizer==3.3.2
+Cython==3.0.10
+idna==3.7
+jaraco.classes==3.4.0
+jaraco.context==5.3.0
+jaraco.functools==4.0.1
+keyring==25.2.1
+more-itertools==10.2.0
+numpy==1.26.4
+pywin32-ctypes==0.2.2
+requests==2.32.3
+urllib3==2.2.1

--- a/test/Microsoft.ComponentDetection.VerificationTests/resources/pip/parallel/parallel-test-4/requirements.txt
+++ b/test/Microsoft.ComponentDetection.VerificationTests/resources/pip/parallel/parallel-test-4/requirements.txt
@@ -1,0 +1,14 @@
+artifacts-keyring==0.3.4
+certifi==2024.6.2
+charset-normalizer==3.3.2
+Cython==3.0.10
+idna==3.7
+jaraco.classes==3.4.0
+jaraco.context==5.3.0
+jaraco.functools==4.0.1
+keyring==25.2.1
+more-itertools==10.2.0
+numpy==1.26.4
+pywin32-ctypes==0.2.2
+requests==2.32.3
+urllib3==2.2.1

--- a/test/Microsoft.ComponentDetection.VerificationTests/resources/pip/parallel/parallel-test-5/requirements.txt
+++ b/test/Microsoft.ComponentDetection.VerificationTests/resources/pip/parallel/parallel-test-5/requirements.txt
@@ -1,0 +1,14 @@
+artifacts-keyring==0.3.4
+certifi==2024.6.2
+charset-normalizer==3.3.2
+Cython==3.0.10
+idna==3.7
+jaraco.classes==3.4.0
+jaraco.context==5.3.0
+jaraco.functools==4.0.1
+keyring==25.2.1
+more-itertools==10.2.0
+numpy==1.26.4
+pywin32-ctypes==0.2.2
+requests==2.32.3
+urllib3==2.2.1


### PR DESCRIPTION
Adds some configurable parallelism to a single detector, e.g. within PipReport. 

Added some simple pip reports that take 3-5 seconds to generate.

Running with the `MaxDetectionThreads` set to 1:
![image](https://github.com/microsoft/component-detection/assets/107068277/0b967e74-8942-452a-ac12-c8d43d9ebd02)


Running without the `MaxDetectionThreads` (default of 10):
![image](https://github.com/microsoft/component-detection/assets/107068277/cb6b1dea-32ca-4d03-b663-7fb1a044e66f)


Finally, with `MaxDetectionThreads` set to 2:
![image](https://github.com/microsoft/component-detection/assets/107068277/b13aaaf3-55b9-4e5c-bb72-2a3379748776)

Scan log from the 2 parallel threads is also interesting since you can see that 2 pip reports are triggered at the same time and the next set is triggered once these finish:
[GovCompDisc_Log_20240612152920140_41928.log](https://github.com/user-attachments/files/15811613/GovCompDisc_Log_20240612152920140_41928.log)

