### PR TITLE
PipReport option to fallback and parse roots from source

### DIFF
--- a/docs/detectors/pip.md
+++ b/docs/detectors/pip.md
@@ -54,3 +54,7 @@ The default value is 4096.
 
 The enviroment variable `PIP_INDEX_URL` is used to determine what package feed should be used for `pip install --report` detection.
 The default value will use the PyPi index unless pip defaults have been configured globally.
+
+The environment variable `PipReportOverrideBehavior` is used to override pip report with one of the following detection strategies.
+- `Skip`: Will not run pip detection
+- `SourceCodeScan`: Scan `setup.py` and `requirements.txt` files, and record components explicitly from the package files without hitting a remote feed. Does not compile a dependency graph.

--- a/docs/detectors/pip.md
+++ b/docs/detectors/pip.md
@@ -58,3 +58,5 @@ The default value will use the PyPi index unless pip defaults have been configur
 The environment variable `PipReportOverrideBehavior` is used to override pip report with one of the following detection strategies.
 - `Skip`: Will not run pip detection
 - `SourceCodeScan`: Scan `setup.py` and `requirements.txt` files, and record components explicitly from the package files without hitting a remote feed. Does not compile a dependency graph.
+
+The environment variable `PipReportSkipFallbackOnFailure` is used to skip the default fallback behavior if pip report fails. Default behavior scans `setup.py` and `requirements.txt` files, and record components explicitly from the package files without hitting a remote feed. Does not compile a dependency graph.

--- a/src/Microsoft.ComponentDetection.Detectors/pip/Contracts/PipDependencySpecification.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/Contracts/PipDependencySpecification.cs
@@ -199,7 +199,7 @@ public class PipDependencySpecification
 
     /// <summary>
     /// Iterates through the package versions that are explicitly stated, and returns
-    /// the highest that adheres to the version requirements.
+    /// the highest version that adheres to the version requirements.
     /// </summary>
     /// <example>
     /// DependencySpecifiers: (&gt;=1.2.3, !=1.2.4, &lt;2.0.0)

--- a/src/Microsoft.ComponentDetection.Detectors/pip/PipReportComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/PipReportComponentDetector.cs
@@ -199,13 +199,6 @@ public class PipReportComponentDetector : FileComponentDetector, IExperimentalDe
                 ExceptionMessage = e.Message,
                 StackTrace = e.StackTrace,
             };
-
-            // if pipreport fails, try to at least list the dependencies that are found in the source files
-            if (this.GetPipReportOverrideBehavior() != PipReportOverrideBehavior.SourceCodeScan)
-            {
-                this.Logger.LogInformation("PipReport: Trying to Manually compile dependency list for '{File}' without reaching out to a remote feed.", file.Location);
-                await this.RegisterExplicitComponentsInFileAsync(singleFileComponentRecorder, file.Location, pythonExePath);
-            }
         }
         finally
         {

--- a/src/Microsoft.ComponentDetection.Detectors/pip/PythonVersionUtilities.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/PythonVersionUtilities.cs
@@ -85,6 +85,37 @@ public static class PythonVersionUtilities
 
     private static bool VersionValidForSpec(string version, string spec)
     {
+        (var op, var specVersion) = ParseSpec(spec);
+
+        var targetVer = PythonVersion.Create(version);
+        var specVer = PythonVersion.Create(specVersion);
+
+        if (!targetVer.Valid)
+        {
+            throw new ArgumentException($"{version} is not a valid python version");
+        }
+
+        if (!specVer.Valid)
+        {
+            throw new ArgumentException($"The version specification {specVersion} is not a valid python version");
+        }
+
+        return op switch
+        {
+            "==" => targetVer.CompareTo(specVer) == 0,
+            "===" => targetVer.CompareTo(specVer) == 0,
+            "<" => specVer > targetVer,
+            ">" => targetVer > specVer,
+            "<=" => specVer >= targetVer,
+            ">=" => targetVer >= specVer,
+            "!=" => targetVer.CompareTo(specVer) != 0,
+            "~=" => CheckEquality(version, specVersion, true),
+            _ => false,
+        };
+    }
+
+    public static (string Operator, string Version) ParseSpec(string spec)
+    {
         var opChars = new char[] { '=', '<', '>', '~', '!' };
         var specArray = spec.ToCharArray();
 
@@ -97,30 +128,6 @@ public static class PythonVersionUtilities
         var op = spec[..i];
         var specVerSection = spec[i..].Trim();
 
-        var targetVer = PythonVersion.Create(version);
-        var specVer = PythonVersion.Create(specVerSection);
-
-        if (!targetVer.Valid)
-        {
-            throw new ArgumentException($"{version} is not a valid python version");
-        }
-
-        if (!specVer.Valid)
-        {
-            throw new ArgumentException($"The version specification {specVerSection} is not a valid python version");
-        }
-
-        return op switch
-        {
-            "==" => targetVer.CompareTo(specVer) == 0,
-            "===" => targetVer.CompareTo(specVer) == 0,
-            "<" => specVer > targetVer,
-            ">" => targetVer > specVer,
-            "<=" => specVer >= targetVer,
-            ">=" => targetVer >= specVer,
-            "!=" => targetVer.CompareTo(specVer) != 0,
-            "~=" => CheckEquality(version, spec[i..], true),
-            _ => false,
-        };
+        return (op, specVerSection);
     }
 }

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/PipReportComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/PipReportComponentDetectorTests.cs
@@ -251,31 +251,6 @@ public class PipReportComponentDetectorTests : BaseDetectorTest<PipReportCompone
     }
 
     [TestMethod]
-    public async Task TestPipReportDetector_SkipAsync()
-    {
-        this.mockEnvVarService.Setup(x => x.IsEnvironmentVariableValueTrue("DisablePipReportScan")).Returns(true);
-
-        this.pipCommandService.Setup(x => x.GenerateInstallationReportAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((this.simpleExtrasReport, null));
-
-        var (result, componentRecorder) = await this.DetectorTestUtility
-            .WithFile("requirements.txt", string.Empty)
-            .ExecuteDetectorAsync();
-
-        result.ResultCode.Should().Be(ProcessingResultCode.Success);
-
-        this.mockLogger.Verify(x => x.Log(
-            LogLevel.Warning,
-            It.IsAny<EventId>(),
-            It.Is<It.IsAnyType>((o, t) => o.ToString().StartsWith("PipReport: Found DisablePipReportScan environment variable equal to true")),
-            It.IsAny<Exception>(),
-            (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()));
-
-        var detectedComponents = componentRecorder.GetDetectedComponents();
-        detectedComponents.Should().BeEmpty();
-    }
-
-    [TestMethod]
     public async Task TestPipReportDetector_MultiComponentAsync()
     {
         this.pipCommandService.Setup(x => x.GenerateInstallationReportAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/PipReportComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/PipReportComponentDetectorTests.cs
@@ -2,6 +2,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests;
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -469,5 +470,49 @@ public class PipReportComponentDetectorTests : BaseDetectorTest<PipReportCompone
             componentRecorder,
             "tinycss2 1.3.0 - pip",
             new[] { "jupyterlab 4.2.0 - pip" });
+    }
+
+    [TestMethod]
+    public async Task TestPipReportDetector_NoRemoteFeedAsync()
+    {
+        this.pythonCommandService.Setup(x => x.PythonExistsAsync(It.IsAny<string>())).ReturnsAsync(true);
+        this.mockEnvVarService.Setup(x => x.IsEnvironmentVariableValueTrue("SkipPipReportRemoteDependencyGraphResolution")).Returns(true);
+
+        var baseSetupPyDependencies = this.ToGitTuple(new List<string> { "a==1.0", "b>=2.0,!=2.1,<3.0.0", "c!=1.1" });
+        var baseRequirementsTextDependencies = this.ToGitTuple(new List<string> { "d~=1.0", "e<=2.0", "f===1.1", "g<3.0", "h>=1.0,<=3.0,!=2.0,!=4.0" });
+        baseRequirementsTextDependencies.Add((null, new GitComponent(new Uri("https://github.com/example/example"), "deadbee")));
+
+        this.pythonCommandService.Setup(x => x.ParseFileAsync(Path.Join(Path.GetTempPath(), "setup.py"), null)).ReturnsAsync(baseSetupPyDependencies);
+        this.pythonCommandService.Setup(x => x.ParseFileAsync(Path.Join(Path.GetTempPath(), "requirements.txt"), null)).ReturnsAsync(baseRequirementsTextDependencies);
+
+        var (result, componentRecorder) = await this.DetectorTestUtility
+            .WithFile("setup.py", string.Empty)
+            .WithFile("requirements.txt", string.Empty)
+            .ExecuteDetectorAsync();
+
+        result.ResultCode.Should().Be(ProcessingResultCode.Success);
+
+        var detectedComponents = componentRecorder.GetDetectedComponents();
+        detectedComponents.Should().HaveCount(7);
+
+        var pipComponents = detectedComponents.Where(detectedComponent => detectedComponent.Component.Id.Contains("pip")).ToList();
+        ((PipComponent)pipComponents.Single(x => ((PipComponent)x.Component).Name == "a").Component).Version.Should().Be("1.0");
+        ((PipComponent)pipComponents.Single(x => ((PipComponent)x.Component).Name == "b").Component).Version.Should().Be("2.0");
+        ((PipComponent)pipComponents.Single(x => ((PipComponent)x.Component).Name == "d").Component).Version.Should().Be("1.0");
+        ((PipComponent)pipComponents.Single(x => ((PipComponent)x.Component).Name == "e").Component).Version.Should().Be("2.0");
+        ((PipComponent)pipComponents.Single(x => ((PipComponent)x.Component).Name == "f").Component).Version.Should().Be("1.1");
+        ((PipComponent)pipComponents.Single(x => ((PipComponent)x.Component).Name == "h").Component).Version.Should().Be("3.0");
+
+        var gitComponents = detectedComponents.Where(detectedComponent => detectedComponent.Component.Type == ComponentType.Git);
+        gitComponents.Should().ContainSingle();
+        var gitComponent = (GitComponent)gitComponents.Single().Component;
+
+        gitComponent.RepositoryUrl.Should().Be("https://github.com/example/example");
+        gitComponent.CommitHash.Should().Be("deadbee");
+    }
+
+    private List<(string PackageString, GitComponent Component)> ToGitTuple(IList<string> components)
+    {
+        return components.Select<string, (string, GitComponent)>(dep => (dep, null)).ToList();
     }
 }

--- a/test/Microsoft.ComponentDetection.VerificationTests/resources/pip/fallback/requirements.txt
+++ b/test/Microsoft.ComponentDetection.VerificationTests/resources/pip/fallback/requirements.txt
@@ -1,0 +1,2 @@
+fakepythonpackage==1.2.3
+zipp>=3.2.0,<4.0


### PR DESCRIPTION
PipReportOverrideBehavior that allows us to skip pip report or fallback to scanning source files directly without reaching out to remote package repos for the full dependency graph.