### PR TITLE
Fix security alert

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -53,5 +53,8 @@
     <PackageVersion Include="yamldotnet" Version="15.1.6" />
     <PackageVersion Include="Faker.net" Version="2.0.163" />
     <PackageVersion Include="Valleysoft.DockerfileModel" Version="1.1.1" />
+
+    <!-- Fix security alerts -->
+    <PackageVersion Include="System.Formats.Asn1" Version="6.0.1" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.ComponentDetection.Detectors/Microsoft.ComponentDetection.Detectors.csproj
+++ b/src/Microsoft.ComponentDetection.Detectors/Microsoft.ComponentDetection.Detectors.csproj
@@ -15,6 +15,9 @@
         <PackageReference Include="System.Threading.Tasks.Dataflow" />
         <PackageReference Include="Tomlyn.Signed" />
         <PackageReference Include="Valleysoft.DockerfileModel " />
+
+        <!-- Fix alerts -->
+        <PackageVersion Include="System.Formats.Asn1" />
     </ItemGroup>
 
     <ItemGroup Label="Package References">

--- a/src/Microsoft.ComponentDetection.Detectors/Microsoft.ComponentDetection.Detectors.csproj
+++ b/src/Microsoft.ComponentDetection.Detectors/Microsoft.ComponentDetection.Detectors.csproj
@@ -17,7 +17,7 @@
         <PackageReference Include="Valleysoft.DockerfileModel " />
 
         <!-- Fix alerts -->
-        <PackageVersion Include="System.Formats.Asn1" />
+        <PackageReference Include="System.Formats.Asn1" />
     </ItemGroup>
 
     <ItemGroup Label="Package References">


### PR DESCRIPTION
## Context
Technically DoS doesn't impact the tool, but still, bumping `System.Formats.Asn1` to address CVE-2024-38095

## Root
`NuGet.ProjectModel 6.10.0` is the root dependency that brings the vulnerable package transitively.