### PR TITLE
Pauldorsch/fix support python m pip

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/pip/Contracts/IPipCommandService.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/Contracts/IPipCommandService.cs
@@ -11,22 +11,25 @@ public interface IPipCommandService
     /// Checks the existence of pip.
     /// </summary>
     /// <param name="pipPath">Optional override of the pip.exe absolute path.</param>
+    /// <param name="pythonPath">Optional override of the python.exe absolute path.</param>
     /// <returns>True if pip is found on the OS PATH.</returns>
-    Task<bool> PipExistsAsync(string pipPath = null);
+    Task<bool> PipExistsAsync(string pipPath = null, string pythonPath = null);
 
     /// <summary>
     /// Retrieves the version of pip from the given path. PythonVersion allows for loose version strings such as "1".
     /// </summary>
     /// <param name="pipPath">Optional override of the pip.exe absolute path.</param>
+    /// <param name="pythonPath">Optional override of the python.exe absolute path.</param>
     /// <returns>Version of pip.</returns>
-    Task<Version> GetPipVersionAsync(string pipPath = null);
+    Task<Version> GetPipVersionAsync(string pipPath = null, string pythonPath = null);
 
     /// <summary>
     /// Generates a pip installation report for a given setup.py or requirements.txt file.
     /// </summary>
     /// <param name="path">Path of the Python requirements file.</param>
     /// <param name="pipExePath">Optional override of the pip.exe absolute path.</param>
+    /// <param name="pythonExePath">Optional override of the python.exe absolute path.</param>
     /// <param name="cancellationToken">Token used for canceling the installation report generation.</param>
     /// <returns>See https://pip.pypa.io/en/stable/reference/installation-report/#specification.</returns>
-    Task<(PipInstallationReport Report, FileInfo ReportFile)> GenerateInstallationReportAsync(string path, string pipExePath = null, CancellationToken cancellationToken = default);
+    Task<(PipInstallationReport Report, FileInfo ReportFile)> GenerateInstallationReportAsync(string path, string pipExePath = null, string pythonExePath = null, CancellationToken cancellationToken = default);
 }

--- a/src/Microsoft.ComponentDetection.Detectors/pip/PipCommandService.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/PipCommandService.cs
@@ -83,7 +83,7 @@ public class PipCommandService : IPipCommandService
         {
             return (pipCommand, null);
         }
-        else if (await this.commandLineInvocationService.CanCommandBeLocatedAsync(pythonCommand, null, ["-m", "pip", "--version"]))
+        else if (await this.commandLineInvocationService.CanCommandBeLocatedAsync(pythonCommand, null, "-m", "pip", "--version"))
         {
             return (null, pythonCommand);
         }
@@ -106,17 +106,20 @@ public class PipCommandService : IPipCommandService
     {
         if (!string.IsNullOrEmpty(pipExecutable))
         {
-            return await this.commandLineInvocationService.ExecuteCommandAsync(pipExecutable, additionalCandidateCommands, workingDirectory, cancellationToken, parameters);
+            return await this.commandLineInvocationService.ExecuteCommandAsync(
+                pipExecutable, additionalCandidateCommands, workingDirectory, cancellationToken, parameters);
         }
         else
         {
             var pythonPipParams = new[] { "-m", "pip" };
             var parametersFull = pythonPipParams.Concat(parameters).ToArray();
-            return await this.commandLineInvocationService.ExecuteCommandAsync(pythonExecutable, additionalCandidateCommands, workingDirectory, cancellationToken, parametersFull);
+            return await this.commandLineInvocationService.ExecuteCommandAsync(
+                pythonExecutable, additionalCandidateCommands, workingDirectory, cancellationToken, parametersFull);
         }
     }
 
-    public async Task<(PipInstallationReport Report, FileInfo ReportFile)> GenerateInstallationReportAsync(string path, string pipExePath = null, string pythonExePath = null, CancellationToken cancellationToken = default)
+    public async Task<(PipInstallationReport Report, FileInfo ReportFile)> GenerateInstallationReportAsync(
+        string path, string pipExePath = null, string pythonExePath = null, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrEmpty(path))
         {

--- a/src/Microsoft.ComponentDetection.Detectors/pip/PipCommandService.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/PipCommandService.cs
@@ -77,17 +77,15 @@ public class PipCommandService : IPipCommandService
     private async Task<(string PipExectuable, string PythonExecutable)> ResolvePipAsync(string pipPath = null, string pythonPath = null)
     {
         var pipCommand = string.IsNullOrEmpty(pipPath) ? "pip" : pipPath;
-        var pythonCommand = string.IsNullOrEmpty(pythonPath) ? "python" : $"{pythonPath}";
-        var pythonPipCommand = $"{pythonCommand} -m pip";
+        var pythonCommand = string.IsNullOrEmpty(pythonPath) ? "python" : pythonPath;
 
-        if (await this.commandLineInvocationService.CanCommandBeLocatedAsync(pythonCommand, null, ["-m", "pip", "--version"]))
-        {
-            this.logger.LogDebug("Python Command succeeded: {PythonCmd}", pythonPipCommand);
-            return (null, pythonCommand);
-        }
-        else if (await this.CanCommandBeLocatedAsync(pipCommand))
+        if (await this.CanCommandBeLocatedAsync(pipCommand))
         {
             return (pipCommand, null);
+        }
+        else if (await this.commandLineInvocationService.CanCommandBeLocatedAsync(pythonCommand, null, ["-m", "pip", "--version"]))
+        {
+            return (null, pythonCommand);
         }
 
         return (null, null);

--- a/src/Microsoft.ComponentDetection.Detectors/pip/PipCommandService.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/PipCommandService.cs
@@ -71,13 +71,19 @@ public class PipCommandService : IPipCommandService
         }
     }
 
-    private async Task<string> ResolvePipAsync(string pipPath = null)
+    private async Task<string> ResolvePipAsync(string pipPath = null, string pythonPath = null)
     {
         var pipCommand = string.IsNullOrEmpty(pipPath) ? "pip" : pipPath;
+        var pythonCommand = string.IsNullOrEmpty(pythonPath) ? "python" : $"{pythonPath}";
+        var pythonPipCommand = $"{pythonCommand} -m pip";
 
         if (await this.CanCommandBeLocatedAsync(pipCommand))
         {
             return pipCommand;
+        }
+        else if (await this.commandLineInvocationService.CanCommandBeLocatedAsync(pythonPipCommand, null, parameters: "--version"))
+        {
+            return pythonPipCommand;
         }
 
         return null;

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/PipCommandServiceTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/PipCommandServiceTests.cs
@@ -3,6 +3,7 @@ namespace Microsoft.ComponentDetection.Detectors.Tests;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -100,14 +101,16 @@ public class PipCommandServiceTests
     public async Task PipCommandService_BadVersion_ReturnsNullAsync()
     {
         this.commandLineInvokationService.Setup(x => x.CanCommandBeLocatedAsync(
-            "pip",
+            It.Is<string>(x => x == "pip" || x == "python"),
             It.IsAny<IEnumerable<string>>(),
-            "--version"))
+            It.Is<string[]>(x => x.Last() == "--version")))
             .ReturnsAsync(true);
         this.commandLineInvokationService.Setup(x => x.ExecuteCommandAsync(
-            "pip",
+            It.Is<string>(x => x == "pip" || x == "python"),
             It.IsAny<IEnumerable<string>>(),
-            "--version"))
+            It.IsAny<DirectoryInfo>(),
+            It.IsAny<CancellationToken>(),
+            It.Is<string[]>(x => x.Last() == "--version")))
             .ReturnsAsync(new CommandLineExecutionResult { ExitCode = 0, StdOut = string.Empty });
 
         var service = new PipCommandService(
@@ -125,14 +128,16 @@ public class PipCommandServiceTests
     public async Task PipCommandService_BadVersionString_ReturnsNullAsync()
     {
         this.commandLineInvokationService.Setup(x => x.CanCommandBeLocatedAsync(
-            "pip",
+            It.Is<string>(x => x == "pip" || x == "python"),
             It.IsAny<IEnumerable<string>>(),
-            "--version"))
+            It.Is<string[]>(x => x.Last() == "--version")))
             .ReturnsAsync(true);
         this.commandLineInvokationService.Setup(x => x.ExecuteCommandAsync(
-            "pip",
+            It.Is<string>(x => x == "pip" || x == "python"),
             It.IsAny<IEnumerable<string>>(),
-            "--version"))
+            It.IsAny<DirectoryInfo>(),
+            It.IsAny<CancellationToken>(),
+            It.Is<string[]>(x => x.Last() == "--version")))
             .ReturnsAsync(new CommandLineExecutionResult { ExitCode = 0, StdOut = "this is not a valid output" });
 
         var service = new PipCommandService(
@@ -150,14 +155,16 @@ public class PipCommandServiceTests
     public async Task PipCommandService_ReturnsVersionAsync()
     {
         this.commandLineInvokationService.Setup(x => x.CanCommandBeLocatedAsync(
-            "pip",
+            It.Is<string>(x => x == "pip" || x == "python"),
             It.IsAny<IEnumerable<string>>(),
-            "--version"))
+            It.Is<string[]>(x => x.Last() == "--version")))
             .ReturnsAsync(true);
         this.commandLineInvokationService.Setup(x => x.ExecuteCommandAsync(
-            "pip",
+            It.Is<string>(x => x == "pip" || x == "python"),
             It.IsAny<IEnumerable<string>>(),
-            "--version"))
+            It.IsAny<DirectoryInfo>(),
+            It.IsAny<CancellationToken>(),
+            It.Is<string[]>(x => x.Last() == "--version")))
             .ReturnsAsync(new CommandLineExecutionResult { ExitCode = 0, StdOut = "pip 20.0.2 from c:\\python\\lib\\site-packages\\pip (python 3.8)" });
 
         var service = new PipCommandService(
@@ -177,14 +184,16 @@ public class PipCommandServiceTests
     public async Task PipCommandService_ReturnsVersion_SimpleAsync()
     {
         this.commandLineInvokationService.Setup(x => x.CanCommandBeLocatedAsync(
-            "pip",
+            It.Is<string>(x => x == "pip" || x == "python"),
             It.IsAny<IEnumerable<string>>(),
-            "--version"))
+            It.Is<string[]>(x => x.Last() == "--version")))
             .ReturnsAsync(true);
         this.commandLineInvokationService.Setup(x => x.ExecuteCommandAsync(
-            "pip",
+            It.Is<string>(x => x == "pip" || x == "python"),
             It.IsAny<IEnumerable<string>>(),
-            "--version"))
+            It.IsAny<DirectoryInfo>(),
+            It.IsAny<CancellationToken>(),
+            It.Is<string[]>(x => x.Last() == "--version")))
             .ReturnsAsync(new CommandLineExecutionResult { ExitCode = 0, StdOut = "pip 24.0 from c:\\python\\lib\\site-packages\\pip (python 3.8)" });
 
         var service = new PipCommandService(
@@ -203,14 +212,16 @@ public class PipCommandServiceTests
     public async Task PipCommandService_ReturnsVersionForAPathAsync()
     {
         this.commandLineInvokationService.Setup(x => x.CanCommandBeLocatedAsync(
-            "testPath",
+            It.Is<string>(x => x == "pip" || x == "python"),
             It.IsAny<IEnumerable<string>>(),
-            "--version"))
+            It.Is<string[]>(x => x.Last() == "--version")))
             .ReturnsAsync(true);
         this.commandLineInvokationService.Setup(x => x.ExecuteCommandAsync(
-            "testPath",
+            It.Is<string>(x => x == "pip" || x == "python"),
             It.IsAny<IEnumerable<string>>(),
-            "--version"))
+            It.IsAny<DirectoryInfo>(),
+            It.IsAny<CancellationToken>(),
+            It.Is<string[]>(x => x.Last() == "--version")))
             .ReturnsAsync(new CommandLineExecutionResult { ExitCode = 0, StdOut = "pip 20.0.2 from c:\\python\\lib\\site-packages\\pip (python 3.8)" });
 
         var service = new PipCommandService(

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/PipReportComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/PipReportComponentDetectorTests.cs
@@ -58,8 +58,8 @@ public class PipReportComponentDetectorTests : BaseDetectorTest<PipReportCompone
         this.fileUtilityService = new FileUtilityService();
         this.DetectorTestUtility.AddService(this.fileUtilityService);
 
-        this.pipCommandService.Setup(x => x.PipExistsAsync(It.IsAny<string>())).ReturnsAsync(true);
-        this.pipCommandService.Setup(x => x.GetPipVersionAsync(It.IsAny<string>()))
+        this.pipCommandService.Setup(x => x.PipExistsAsync(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(true);
+        this.pipCommandService.Setup(x => x.GetPipVersionAsync(It.IsAny<string>(), It.IsAny<string>()))
             .ReturnsAsync(new Version(23, 0, 0));
 
         this.singlePackageReport = JsonConvert.DeserializeObject<PipInstallationReport>(TestResources.pip_report_single_pkg);
@@ -81,7 +81,7 @@ public class PipReportComponentDetectorTests : BaseDetectorTest<PipReportCompone
 
         this.DetectorTestUtility.AddServiceMock(this.mockLogger);
 
-        this.pipCommandService.Setup(x => x.PipExistsAsync(It.IsAny<string>())).ReturnsAsync(false);
+        this.pipCommandService.Setup(x => x.PipExistsAsync(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(false);
 
         var (result, componentRecorder) = await this.DetectorTestUtility
             .WithFile("setup.py", string.Empty)
@@ -94,7 +94,7 @@ public class PipReportComponentDetectorTests : BaseDetectorTest<PipReportCompone
     [TestMethod]
     public async Task TestPipReportDetector_PipBadVersion_Null_Async()
     {
-        this.pipCommandService.Setup(x => x.GetPipVersionAsync(It.IsAny<string>()))
+        this.pipCommandService.Setup(x => x.GetPipVersionAsync(It.IsAny<string>(), It.IsAny<string>()))
             .ReturnsAsync((Version)null);
 
         var (result, componentRecorder) = await this.DetectorTestUtility
@@ -114,7 +114,7 @@ public class PipReportComponentDetectorTests : BaseDetectorTest<PipReportCompone
     [TestMethod]
     public async Task TestPipReportDetector_PipBadVersion_Low_Async()
     {
-        this.pipCommandService.Setup(x => x.GetPipVersionAsync(It.IsAny<string>()))
+        this.pipCommandService.Setup(x => x.GetPipVersionAsync(It.IsAny<string>(), It.IsAny<string>()))
             .ReturnsAsync(new Version(22, 1, 0));
 
         var (result, componentRecorder) = await this.DetectorTestUtility
@@ -142,7 +142,7 @@ public class PipReportComponentDetectorTests : BaseDetectorTest<PipReportCompone
     [TestMethod]
     public async Task TestPipReportDetector_BadReportVersionAsync()
     {
-        this.pipCommandService.Setup(x => x.GenerateInstallationReportAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        this.pipCommandService.Setup(x => x.GenerateInstallationReportAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((this.singlePackageReportBadVersion, null));
 
         var (result, componentRecorder) = await this.DetectorTestUtility
@@ -164,7 +164,7 @@ public class PipReportComponentDetectorTests : BaseDetectorTest<PipReportCompone
     {
         this.singlePackageReportBadVersion.Version = "2.5";
 
-        this.pipCommandService.Setup(x => x.GenerateInstallationReportAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        this.pipCommandService.Setup(x => x.GenerateInstallationReportAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((this.singlePackageReportBadVersion, null));
 
         var (result, componentRecorder) = await this.DetectorTestUtility
@@ -184,7 +184,7 @@ public class PipReportComponentDetectorTests : BaseDetectorTest<PipReportCompone
     [TestMethod]
     public async Task TestPipReportDetector_CatchesExceptionAsync()
     {
-        this.pipCommandService.Setup(x => x.GenerateInstallationReportAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        this.pipCommandService.Setup(x => x.GenerateInstallationReportAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidCastException());
 
         var (result, componentRecorder) = await this.DetectorTestUtility
@@ -204,7 +204,7 @@ public class PipReportComponentDetectorTests : BaseDetectorTest<PipReportCompone
     [TestMethod]
     public async Task TestPipReportDetector_SingleComponentAsync()
     {
-        this.pipCommandService.Setup(x => x.GenerateInstallationReportAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        this.pipCommandService.Setup(x => x.GenerateInstallationReportAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((this.singlePackageReport, null));
 
         var (result, componentRecorder) = await this.DetectorTestUtility
@@ -234,7 +234,7 @@ public class PipReportComponentDetectorTests : BaseDetectorTest<PipReportCompone
     [TestMethod]
     public async Task TestPipReportDetector_SimpleExtrasAsync()
     {
-        this.pipCommandService.Setup(x => x.GenerateInstallationReportAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        this.pipCommandService.Setup(x => x.GenerateInstallationReportAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((this.simpleExtrasReport, null));
 
         var (result, componentRecorder) = await this.DetectorTestUtility
@@ -259,7 +259,7 @@ public class PipReportComponentDetectorTests : BaseDetectorTest<PipReportCompone
     [TestMethod]
     public async Task TestPipReportDetector_MultiComponentAsync()
     {
-        this.pipCommandService.Setup(x => x.GenerateInstallationReportAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        this.pipCommandService.Setup(x => x.GenerateInstallationReportAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((this.multiPackageReport, null));
 
         var (result, componentRecorder) = await this.DetectorTestUtility
@@ -290,10 +290,12 @@ public class PipReportComponentDetectorTests : BaseDetectorTest<PipReportCompone
         this.pipCommandService.Setup(x => x.GenerateInstallationReportAsync(
             It.Is<string>(s => s.Contains("setup.py", StringComparison.OrdinalIgnoreCase)),
             It.IsAny<string>(),
+            It.IsAny<string>(),
             It.IsAny<CancellationToken>()))
             .ReturnsAsync((this.multiPackageReport, null));
         this.pipCommandService.Setup(x => x.GenerateInstallationReportAsync(
             It.Is<string>(s => s.Contains("requirements.txt", StringComparison.OrdinalIgnoreCase)),
+            It.IsAny<string>(),
             It.IsAny<string>(),
             It.IsAny<CancellationToken>()))
             .ReturnsAsync((this.singlePackageReport, null));
@@ -330,10 +332,12 @@ public class PipReportComponentDetectorTests : BaseDetectorTest<PipReportCompone
         this.pipCommandService.Setup(x => x.GenerateInstallationReportAsync(
             It.Is<string>(s => s.Contains("setup.py", StringComparison.OrdinalIgnoreCase)),
             It.IsAny<string>(),
+            It.IsAny<string>(),
             It.IsAny<CancellationToken>()))
             .ReturnsAsync((this.multiPackageReport, null));
         this.pipCommandService.Setup(x => x.GenerateInstallationReportAsync(
             It.Is<string>(s => s.Contains("requirements.txt", StringComparison.OrdinalIgnoreCase)),
+            It.IsAny<string>(),
             It.IsAny<string>(),
             It.IsAny<CancellationToken>()))
             .ReturnsAsync((this.singlePackageReport, null));
@@ -395,6 +399,7 @@ public class PipReportComponentDetectorTests : BaseDetectorTest<PipReportCompone
 
         this.pipCommandService.Setup(x => x.GenerateInstallationReportAsync(
             It.Is<string>(s => s.Contains("requirements.txt", StringComparison.OrdinalIgnoreCase)),
+            It.IsAny<string>(),
             It.IsAny<string>(),
             It.IsAny<CancellationToken>()))
             .ReturnsAsync((this.jupyterPackageReport, null));
@@ -568,7 +573,7 @@ public class PipReportComponentDetectorTests : BaseDetectorTest<PipReportCompone
     [TestMethod]
     public async Task TestPipReportDetector_InvalidPregeneratedFile_Async()
     {
-        this.pipCommandService.Setup(x => x.GenerateInstallationReportAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        this.pipCommandService.Setup(x => x.GenerateInstallationReportAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((this.simpleExtrasReport, null));
 
         this.pythonCommandService
@@ -602,7 +607,7 @@ public class PipReportComponentDetectorTests : BaseDetectorTest<PipReportCompone
             (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()));
 
         this.pipCommandService.Verify(
-            x => x.GenerateInstallationReportAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            x => x.GenerateInstallationReportAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Once);
 
         // verify results


### PR DESCRIPTION
When `pip` is not found, we should fall back to use `python -m pip`, which is supported when customers install the https://www.nuget.org/packages/python package