### PR TITLE
Add support to persist pip reports

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/pip/PipCommandService.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/PipCommandService.cs
@@ -131,7 +131,7 @@ public class PipCommandService : IPipCommandService
         var workingDir = new DirectoryInfo(this.pathUtilityService.GetParentDirectory(formattedPath));
 
         CommandLineExecutionResult command;
-        var reportName = Path.GetRandomFileName();
+        var reportName = Path.GetFileNameWithoutExtension(Path.GetRandomFileName()) + ".component-detection-pip-report.json";
         var reportFile = new FileInfo(Path.Combine(workingDir.FullName, reportName));
 
         string pipReportCommand;

--- a/src/Microsoft.ComponentDetection.Detectors/pip/PipReportComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/PipReportComponentDetector.cs
@@ -22,6 +22,7 @@ public class PipReportComponentDetector : FileComponentDetector
     private const string PipReportOverrideBehaviorEnvVar = "PipReportOverrideBehavior";
     private const string PipReportSkipFallbackOnFailureEnvVar = "PipReportSkipFallbackOnFailure";
     private const string PipReportFileLevelTimeoutSecondsEnvVar = "PipReportFileLevelTimeoutSeconds";
+    private const string PipReportPersistReportsEnvVar = "PipReportPersistReports";
 
     private static readonly IList<string> PipReportPreGeneratedFilePatterns = new List<string> { "*.component-detection-pip-report.json", "component-detection-pip-report.json" };
 
@@ -300,11 +301,14 @@ public class PipReportComponentDetector : FileComponentDetector
         finally
         {
             // Clean up the report output JSON file so it isn't left on the machine.
-            foreach (var reportFile in reportFiles)
+            if (!this.envVarService.IsEnvironmentVariableValueTrue(PipReportPersistReportsEnvVar) && reportFiles.Any())
             {
-                if (reportFile is not null && reportFile.Exists)
+                foreach (var reportFile in reportFiles)
                 {
-                    reportFile.Delete();
+                    if (reportFile is not null && reportFile.Exists)
+                    {
+                        reportFile.Delete();
+                    }
                 }
             }
         }

--- a/src/Microsoft.ComponentDetection.Detectors/pip/PipReportComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/PipReportComponentDetector.cs
@@ -301,7 +301,7 @@ public class PipReportComponentDetector : FileComponentDetector
         finally
         {
             // Clean up the report output JSON file so it isn't left on the machine.
-            if (!this.envVarService.IsEnvironmentVariableValueTrue(PipReportPersistReportsEnvVar) && reportFiles.Any())
+            if (!this.envVarService.IsEnvironmentVariableValueTrue(PipReportPersistReportsEnvVar))
             {
                 foreach (var reportFile in reportFiles)
                 {


### PR DESCRIPTION
The primary use case here is when the same build stage has both Component Detection and SBOM (where CD runs again). This will allow whichever comes second to be able to just use the previous runs' reports, rather than regenerating them.