### PR TITLE
Fix bug where pipreport used index-urls from requirements.txt

### DIFF
--- a/docs/detectors/pip.md
+++ b/docs/detectors/pip.md
@@ -67,3 +67,7 @@ The environment variable `PipReportSkipFallbackOnFailure` is used to skip the de
 The environment variable `PipReportFileLevelTimeoutSeconds` is used to control the timeout limit for generating the PipReport for individual files. This defaults to the overall timeout.
 
 The environment variable `PipReportDisableFastDeps` is used to disable the fast deps feature in PipReport.
+
+The enviroment variable `PipReportIgnoreFileLevelIndexUrl` is used to ignore the `--index-url` argument that can be provided in the requirements.txt file: https://pip.pypa.io/en/stable/cli/pip_install/#install-index-url
+
+The enviroment variable `PipReportPersistReports` allows the PipReport detector to persist the reports that it generates, rather than cleaning them up after constructing the dependency graph.

--- a/src/Microsoft.ComponentDetection.Common/FileUtilityService.cs
+++ b/src/Microsoft.ComponentDetection.Common/FileUtilityService.cs
@@ -1,7 +1,7 @@
 namespace Microsoft.ComponentDetection.Common;
 
+using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.ComponentDetection.Contracts;
 
@@ -42,13 +42,22 @@ public class FileUtilityService : IFileUtilityService
     public (string DuplicateFilePath, bool CreatedDuplicate) DuplicateFileWithoutLines(string fileName, string removalIndicator)
     {
         // Read all lines from the file and filter out the lines that start with the removal indicator.
-        var originalLines = File.ReadLines(fileName).ToList();
-        var linesToKeep = originalLines
-            .Where(line => !line.Trim().StartsWith(removalIndicator, System.StringComparison.OrdinalIgnoreCase))
-            .ToList();
+        var removedAnyLines = false;
+        var linesToKeep = new List<string>();
+        foreach (var line in File.ReadLines(fileName))
+        {
+            if (line == null || line.Trim().StartsWith(removalIndicator, System.StringComparison.OrdinalIgnoreCase))
+            {
+                removedAnyLines = true;
+            }
+            else
+            {
+                linesToKeep.Add(line);
+            }
+        }
 
         // If the file did not have any lines to remove, return null.
-        if (originalLines.Count == linesToKeep.Count)
+        if (!removedAnyLines)
         {
             return (null, false);
         }

--- a/src/Microsoft.ComponentDetection.Contracts/IFileUtilityService.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/IFileUtilityService.cs
@@ -42,4 +42,12 @@ public interface IFileUtilityService
     /// <param name="fileName">Path to the file.</param>
     /// <returns>Returns a stream representing the file.</returns>
     Stream MakeFileStream(string fileName);
+
+    /// <summary>
+    /// Duplicates a file, removing any lines that starts with the given string.
+    /// </summary>
+    /// <param name="fileName">Path to the file.</param>
+    /// <param name="removalIndicator">The string that indicates a line should be removed.</param>
+    /// <returns>Returns the path of the new file, and whether or not one was created.</returns>
+    (string DuplicateFilePath, bool CreatedDuplicate) DuplicateFileWithoutLines(string fileName, string removalIndicator);
 }

--- a/src/Microsoft.ComponentDetection.Detectors/pip/PipCommandService.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/PipCommandService.cs
@@ -141,11 +141,11 @@ public class PipCommandService : IPipCommandService
         {
             if (path.EndsWith(".py"))
             {
-                pipReportCommand = $"install -e .";
+                pipReportCommand = "install -e .";
             }
             else if (path.EndsWith(".txt", StringComparison.OrdinalIgnoreCase))
             {
-                pipReportCommand = $"install -r requirements.txt";
+                pipReportCommand = "install -r requirements.txt";
                 if (this.environmentService.IsEnvironmentVariableValueTrue(PipReportIgnoreFileLevelIndexUrlEnvVar))
                 {
                     // check for --index-url in requirements.txt and remove it from the file, since we want to use PIP_INDEX_URL from the environment.
@@ -175,9 +175,9 @@ public class PipCommandService : IPipCommandService
                 pipReportCommand += $" --index-url {this.environmentService.GetEnvironmentVariable("PIP_INDEX_URL")}";
             }
 
-            if (!this.environmentService.DoesEnvironmentVariableExist(PipReportDisableFastDepsEnvVar) || !this.environmentService.IsEnvironmentVariableValueTrue(PipReportDisableFastDepsEnvVar))
+            if (!this.environmentService.IsEnvironmentVariableValueTrue(PipReportDisableFastDepsEnvVar))
             {
-                pipReportCommand += $" --use-feature=fast-deps";
+                pipReportCommand += " --use-feature=fast-deps";
             }
 
             this.logger.LogDebug("PipReport: Generating pip installation report for {Path} with command: {Command}", formattedPath, pipReportCommand.RemoveSensitiveInformation());

--- a/src/Microsoft.ComponentDetection.Detectors/pip/PipCommandService.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/PipCommandService.cs
@@ -169,7 +169,7 @@ public class PipCommandService : IPipCommandService
             // When PIP_INDEX_URL is set, we need to pass it as a parameter to pip install command.
             // This should be done before running detection by the build system, otherwise the detection
             // will default to the public PyPI index if not configured in pip defaults. Note this index URL may have credentials, we need to remove it when logging.
-            pipReportCommand += $" --dry-run --ignore-installed --quiet --report {reportName}";
+            pipReportCommand += $" --dry-run --ignore-installed --quiet --no-input --report {reportName}";
             if (this.environmentService.DoesEnvironmentVariableExist("PIP_INDEX_URL"))
             {
                 pipReportCommand += $" --index-url {this.environmentService.GetEnvironmentVariable("PIP_INDEX_URL")}";

--- a/src/Microsoft.ComponentDetection.Detectors/pip/PipCommandService.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/PipCommandService.cs
@@ -134,71 +134,93 @@ public class PipCommandService : IPipCommandService
         var reportName = Path.GetFileNameWithoutExtension(Path.GetRandomFileName()) + ".component-detection-pip-report.json";
         var reportFile = new FileInfo(Path.Combine(workingDir.FullName, reportName));
 
+        FileInfo duplicateFile = null;
         string pipReportCommand;
-        if (path.EndsWith(".py"))
+        try
         {
-            pipReportCommand = $"install -e .";
-        }
-        else if (path.EndsWith(".txt"))
-        {
-            pipReportCommand = "install -r requirements.txt";
-        }
-        else
-        {
-            // Failure case, but this shouldn't be hit since detection is only running
-            // on setup.py and requirements.txt files.
-            this.logger.LogDebug("PipReport: Unsupported file type for pip installation report: {Path}", path);
-            return (new PipInstallationReport(), null);
-        }
-
-        // When PIP_INDEX_URL is set, we need to pass it as a parameter to pip install command.
-        // This should be done before running detection by the build system, otherwise the detection
-        // will default to the public PyPI index if not configured in pip defaults. Note this index URL may have credentials, we need to remove it when logging.
-        pipReportCommand += $" --dry-run --ignore-installed --quiet --report {reportName}";
-        if (this.environmentService.DoesEnvironmentVariableExist("PIP_INDEX_URL"))
-        {
-            pipReportCommand += $" --index-url {this.environmentService.GetEnvironmentVariable("PIP_INDEX_URL")}";
-        }
-
-        if (!this.environmentService.DoesEnvironmentVariableExist(PipReportDisableFastDepsEnvVar) || !this.environmentService.IsEnvironmentVariableValueTrue(PipReportDisableFastDepsEnvVar))
-        {
-            pipReportCommand += $" --use-feature=fast-deps";
-        }
-
-        this.logger.LogDebug("PipReport: Generating pip installation report for {Path} with command: {Command}", formattedPath, pipReportCommand.RemoveSensitiveInformation());
-        command = await this.ExecuteCommandAsync(
-            pipExecutable,
-            pythonExecutable,
-            null,
-            workingDir,
-            cancellationToken,
-            pipReportCommand);
-
-        if (command.ExitCode == -1 && cancellationToken.IsCancellationRequested)
-        {
-            var errorMessage = $"PipReport: Cancelled for file '{formattedPath}' with command '{pipReportCommand.RemoveSensitiveInformation()}'.";
-            using var failureRecord = new PipReportFailureTelemetryRecord
+            if (path.EndsWith(".py"))
             {
-                ExitCode = command.ExitCode,
-                StdErr = $"{errorMessage} {command.StdErr}",
-            };
-
-            this.logger.LogWarning("{Error}", errorMessage);
-            throw new InvalidOperationException(errorMessage);
-        }
-        else if (command.ExitCode != 0)
-        {
-            using var failureRecord = new PipReportFailureTelemetryRecord
+                pipReportCommand = $"install -e .";
+            }
+            else if (path.EndsWith(".txt"))
             {
-                ExitCode = command.ExitCode,
-                StdErr = command.StdErr,
-            };
+                // check for --index-url in requirements.txt and remove it from the file, since we want to use PIP_INDEX_URL from the environment.
+                var (duplicateFilePath, createdDuplicate) = this.fileUtilityService.DuplicateFileWithoutLines(formattedPath, "--index-url");
+                if (createdDuplicate)
+                {
+                    var duplicateFileName = Path.GetFileName(duplicateFilePath);
+                    duplicateFile = new FileInfo(duplicateFilePath);
+                    pipReportCommand = $"install -r {duplicateFileName}";
+                }
+                else
+                {
+                    pipReportCommand = $"install -r requirements.txt";
+                }
+            }
+            else
+            {
+                // Failure case, but this shouldn't be hit since detection is only running
+                // on setup.py and requirements.txt files.
+                this.logger.LogDebug("PipReport: Unsupported file type for pip installation report: {Path}", path);
+                return (new PipInstallationReport(), null);
+            }
 
-            this.logger.LogDebug("PipReport: Pip installation report error: {StdErr}", command.StdErr);
-            throw new InvalidOperationException($"PipReport: Failed to generate pip installation report for file {path} with exit code {command.ExitCode}");
+            // When PIP_INDEX_URL is set, we need to pass it as a parameter to pip install command.
+            // This should be done before running detection by the build system, otherwise the detection
+            // will default to the public PyPI index if not configured in pip defaults. Note this index URL may have credentials, we need to remove it when logging.
+            pipReportCommand += $" --dry-run --ignore-installed --quiet --report {reportName}";
+            if (this.environmentService.DoesEnvironmentVariableExist("PIP_INDEX_URL"))
+            {
+                pipReportCommand += $" --index-url {this.environmentService.GetEnvironmentVariable("PIP_INDEX_URL")}";
+            }
+
+            if (!this.environmentService.DoesEnvironmentVariableExist(PipReportDisableFastDepsEnvVar) || !this.environmentService.IsEnvironmentVariableValueTrue(PipReportDisableFastDepsEnvVar))
+            {
+                pipReportCommand += $" --use-feature=fast-deps";
+            }
+
+            this.logger.LogDebug("PipReport: Generating pip installation report for {Path} with command: {Command}", formattedPath, pipReportCommand.RemoveSensitiveInformation());
+            command = await this.ExecuteCommandAsync(
+                pipExecutable,
+                pythonExecutable,
+                null,
+                workingDir,
+                cancellationToken,
+                pipReportCommand);
+
+            if (command.ExitCode == -1 && cancellationToken.IsCancellationRequested)
+            {
+                var errorMessage = $"PipReport: Cancelled for file '{formattedPath}' with command '{pipReportCommand.RemoveSensitiveInformation()}'.";
+                using var failureRecord = new PipReportFailureTelemetryRecord
+                {
+                    ExitCode = command.ExitCode,
+                    StdErr = $"{errorMessage} {command.StdErr}",
+                };
+
+                this.logger.LogWarning("{Error}", errorMessage);
+                throw new InvalidOperationException(errorMessage);
+            }
+            else if (command.ExitCode != 0)
+            {
+                using var failureRecord = new PipReportFailureTelemetryRecord
+                {
+                    ExitCode = command.ExitCode,
+                    StdErr = command.StdErr,
+                };
+
+                this.logger.LogDebug("PipReport: Pip installation report error: {StdErr}", command.StdErr);
+                throw new InvalidOperationException($"PipReport: Failed to generate pip installation report for file {path} with exit code {command.ExitCode}");
+            }
+
+            var reportOutput = await this.fileUtilityService.ReadAllTextAsync(reportFile);
+            return (JsonConvert.DeserializeObject<PipInstallationReport>(reportOutput), reportFile);
         }
-
-        var reportOutput = await this.fileUtilityService.ReadAllTextAsync(reportFile);
-        return (JsonConvert.DeserializeObject<PipInstallationReport>(reportOutput), reportFile);
+        finally
+        {
+            if (duplicateFile != null && duplicateFile.Exists)
+            {
+                duplicateFile.Delete();
+            }
+        }
     }
 }

--- a/src/Microsoft.ComponentDetection.Detectors/pip/PipReportComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/PipReportComponentDetector.cs
@@ -77,7 +77,7 @@ public class PipReportComponentDetector : FileComponentDetector
 
     public override IEnumerable<ComponentType> SupportedComponentTypes { get; } = new[] { ComponentType.Pip };
 
-    public override int Version { get; } = 6;
+    public override int Version { get; } = 7;
 
     protected override bool EnableParallelism { get; set; } = true;
 

--- a/test/Microsoft.ComponentDetection.Common.Tests/FileUtilityServiceTests.cs
+++ b/test/Microsoft.ComponentDetection.Common.Tests/FileUtilityServiceTests.cs
@@ -1,0 +1,55 @@
+namespace Microsoft.ComponentDetection.Common.Tests;
+
+using System.IO;
+using FluentAssertions;
+using Microsoft.ComponentDetection.Contracts;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[TestClass]
+[TestCategory("Governance/All")]
+[TestCategory("Governance/ComponentDetection")]
+public class FileUtilityServiceTests
+{
+    private readonly IFileUtilityService fileUtilityService;
+
+    public FileUtilityServiceTests() =>
+        this.fileUtilityService = new FileUtilityService();
+
+    [TestMethod]
+    public void DuplicateFileWithoutLines_WithLinesToRemove_ShouldCreateDuplicateFileWithoutLines()
+    {
+        // Get directory of current executing assembly
+        var directory = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
+
+        // Arrange
+        var fileName = $"{directory}/Resources/test-file-duplicate.txt";
+        var removalIndicator = "//REMOVE";
+        var expectedDuplicateFilePath = Path.Combine(directory, "Resources", "temp.test-file-duplicate.txt");
+
+        // Act
+        var (duplicateFilePath, createdDuplicate) = this.fileUtilityService.DuplicateFileWithoutLines(fileName, removalIndicator);
+
+        // Assert
+        createdDuplicate.Should().BeTrue();
+        duplicateFilePath.Should().Be(expectedDuplicateFilePath);
+        File.Exists(expectedDuplicateFilePath).Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void DuplicateFileWithoutLines_WithoutLinesToRemove_ShouldNotCreateDuplicateFile()
+    {
+        // Get directory of current executing assembly
+        var directory = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
+
+        // Arrange
+        var fileName = $"{directory}/Resources/test-file-duplicate.txt";
+        var removalIndicator = "//NOTEXIST";
+
+        // Act
+        var (duplicateFilePath, createdDuplicate) = this.fileUtilityService.DuplicateFileWithoutLines(fileName, removalIndicator);
+
+        // Assert
+        createdDuplicate.Should().BeFalse();
+        duplicateFilePath.Should().BeNull();
+    }
+}

--- a/test/Microsoft.ComponentDetection.Common.Tests/Microsoft.ComponentDetection.Common.Tests.csproj
+++ b/test/Microsoft.ComponentDetection.Common.Tests/Microsoft.ComponentDetection.Common.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <ItemGroup Label="Project References">
         <ProjectReference Include="..\Microsoft.ComponentDetection.TestsUtilities\Microsoft.ComponentDetection.TestsUtilities.csproj" />
@@ -11,6 +11,12 @@
       <PackageReference Include="Microsoft.Extensions.Logging" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" />
       <PackageReference Include="System.Threading.Tasks.Dataflow" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <None Update="Resources\test-file-duplicate.txt">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </None>
     </ItemGroup>
 
 </Project>

--- a/test/Microsoft.ComponentDetection.Common.Tests/Resources/test-file-duplicate.txt
+++ b/test/Microsoft.ComponentDetection.Common.Tests/Resources/test-file-duplicate.txt
@@ -1,0 +1,3 @@
+hello
+//REMOVE
+world

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/PipCommandServiceTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/PipCommandServiceTests.cs
@@ -497,6 +497,7 @@ public class PipCommandServiceTests
     {
         var testPath = Path.Join(Directory.GetCurrentDirectory(), string.Join(Guid.NewGuid().ToString(), "requirements.txt"));
 
+        this.envVarService.Setup(x => x.IsEnvironmentVariableValueTrue("PipReportIgnoreFileLevelIndexUrl")).Returns(true);
         this.commandLineInvokationService.Setup(x => x.CanCommandBeLocatedAsync("pip", It.IsAny<IEnumerable<string>>(), "--version")).ReturnsAsync(true);
 
         this.fileUtilityService.Setup(x => x.DuplicateFileWithoutLines(It.IsAny<string>(), "--index-url"))
@@ -531,6 +532,7 @@ public class PipCommandServiceTests
     {
         var testPath = Path.Join(Directory.GetCurrentDirectory(), string.Join(Guid.NewGuid().ToString(), "requirements.txt"));
 
+        this.envVarService.Setup(x => x.IsEnvironmentVariableValueTrue("PipReportIgnoreFileLevelIndexUrl")).Returns(true);
         this.commandLineInvokationService.Setup(x => x.CanCommandBeLocatedAsync("pip", It.IsAny<IEnumerable<string>>(), "--version")).ReturnsAsync(true);
 
         this.fileUtilityService.Setup(x => x.DuplicateFileWithoutLines(It.IsAny<string>(), "--index-url"))
@@ -557,6 +559,38 @@ public class PipCommandServiceTests
 
         var (report, reportFile) = await service.GenerateInstallationReportAsync(testPath);
         this.fileUtilityService.Verify();
+        this.commandLineInvokationService.Verify();
+    }
+
+    [TestMethod]
+    public async Task PipCommandService_GeneratesReport_UseFileIndex_Async()
+    {
+        var testPath = Path.Join(Directory.GetCurrentDirectory(), string.Join(Guid.NewGuid().ToString(), "requirements.txt"));
+
+        this.envVarService.Setup(x => x.IsEnvironmentVariableValueTrue("PipReportIgnoreFileLevelIndexUrl")).Returns(false);
+        this.commandLineInvokationService.Setup(x => x.CanCommandBeLocatedAsync("pip", It.IsAny<IEnumerable<string>>(), "--version")).ReturnsAsync(true);
+
+        this.fileUtilityService.Setup(x => x.ReadAllTextAsync(It.IsAny<FileInfo>()))
+            .ReturnsAsync(TestResources.pip_report_multi_pkg);
+
+        this.commandLineInvokationService.Setup(x => x.ExecuteCommandAsync(
+            "pip",
+            It.IsAny<IEnumerable<string>>(),
+            It.Is<DirectoryInfo>(d => d.FullName.Contains(Directory.GetCurrentDirectory(), StringComparison.OrdinalIgnoreCase)),
+            It.IsAny<CancellationToken>(),
+            It.Is<string>(s => !s.Contains("temp.requirements.txt", StringComparison.OrdinalIgnoreCase))))
+            .ReturnsAsync(new CommandLineExecutionResult { ExitCode = 0, StdErr = string.Empty, StdOut = string.Empty })
+            .Verifiable();
+
+        var service = new PipCommandService(
+            this.commandLineInvokationService.Object,
+            this.pathUtilityService,
+            this.fileUtilityService.Object,
+            this.envVarService.Object,
+            this.logger.Object);
+
+        var (report, reportFile) = await service.GenerateInstallationReportAsync(testPath);
+        this.fileUtilityService.Verify(x => x.DuplicateFileWithoutLines(It.IsAny<string>(), "--index-url"), Times.Never);
         this.commandLineInvokationService.Verify();
     }
 

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/PipCommandServiceTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/PipCommandServiceTests.cs
@@ -493,6 +493,74 @@ public class PipCommandServiceTests
     }
 
     [TestMethod]
+    public async Task PipCommandService_GeneratesReport_WithDuplicate_Async()
+    {
+        var testPath = Path.Join(Directory.GetCurrentDirectory(), string.Join(Guid.NewGuid().ToString(), "requirements.txt"));
+
+        this.commandLineInvokationService.Setup(x => x.CanCommandBeLocatedAsync("pip", It.IsAny<IEnumerable<string>>(), "--version")).ReturnsAsync(true);
+
+        this.fileUtilityService.Setup(x => x.DuplicateFileWithoutLines(It.IsAny<string>(), "--index-url"))
+            .Returns(("C:/asdf/temp.requirements.txt", true))
+            .Verifiable();
+        this.fileUtilityService.Setup(x => x.ReadAllTextAsync(It.IsAny<FileInfo>()))
+            .ReturnsAsync(TestResources.pip_report_multi_pkg);
+
+        this.commandLineInvokationService.Setup(x => x.ExecuteCommandAsync(
+            "pip",
+            It.IsAny<IEnumerable<string>>(),
+            It.Is<DirectoryInfo>(d => d.FullName.Contains(Directory.GetCurrentDirectory(), StringComparison.OrdinalIgnoreCase)),
+            It.IsAny<CancellationToken>(),
+            It.Is<string>(s => s.Contains("temp.requirements.txt", StringComparison.OrdinalIgnoreCase))))
+            .ReturnsAsync(new CommandLineExecutionResult { ExitCode = 0, StdErr = string.Empty, StdOut = string.Empty })
+            .Verifiable();
+
+        var service = new PipCommandService(
+            this.commandLineInvokationService.Object,
+            this.pathUtilityService,
+            this.fileUtilityService.Object,
+            this.envVarService.Object,
+            this.logger.Object);
+
+        var (report, reportFile) = await service.GenerateInstallationReportAsync(testPath);
+        this.fileUtilityService.Verify();
+        this.commandLineInvokationService.Verify();
+    }
+
+    [TestMethod]
+    public async Task PipCommandService_GeneratesReport_WithoutDuplicate_Async()
+    {
+        var testPath = Path.Join(Directory.GetCurrentDirectory(), string.Join(Guid.NewGuid().ToString(), "requirements.txt"));
+
+        this.commandLineInvokationService.Setup(x => x.CanCommandBeLocatedAsync("pip", It.IsAny<IEnumerable<string>>(), "--version")).ReturnsAsync(true);
+
+        this.fileUtilityService.Setup(x => x.DuplicateFileWithoutLines(It.IsAny<string>(), "--index-url"))
+            .Returns((null, false))
+            .Verifiable();
+        this.fileUtilityService.Setup(x => x.ReadAllTextAsync(It.IsAny<FileInfo>()))
+            .ReturnsAsync(TestResources.pip_report_multi_pkg);
+
+        this.commandLineInvokationService.Setup(x => x.ExecuteCommandAsync(
+            "pip",
+            It.IsAny<IEnumerable<string>>(),
+            It.Is<DirectoryInfo>(d => d.FullName.Contains(Directory.GetCurrentDirectory(), StringComparison.OrdinalIgnoreCase)),
+            It.IsAny<CancellationToken>(),
+            It.Is<string>(s => !s.Contains("temp.requirements.txt", StringComparison.OrdinalIgnoreCase))))
+            .ReturnsAsync(new CommandLineExecutionResult { ExitCode = 0, StdErr = string.Empty, StdOut = string.Empty })
+            .Verifiable();
+
+        var service = new PipCommandService(
+            this.commandLineInvokationService.Object,
+            this.pathUtilityService,
+            this.fileUtilityService.Object,
+            this.envVarService.Object,
+            this.logger.Object);
+
+        var (report, reportFile) = await service.GenerateInstallationReportAsync(testPath);
+        this.fileUtilityService.Verify();
+        this.commandLineInvokationService.Verify();
+    }
+
+    [TestMethod]
     public async Task PipCommandService_GeneratesReport_BadFile_FailsAsync()
     {
         var testPath = Path.Join(Directory.GetCurrentDirectory(), string.Join(Guid.NewGuid().ToString(), ".randomfile"));

--- a/test/Microsoft.ComponentDetection.VerificationTests/resources/pip/index-removal/requirements.txt
+++ b/test/Microsoft.ComponentDetection.VerificationTests/resources/pip/index-removal/requirements.txt
@@ -1,0 +1,3 @@
+--index-url https://pkgs.dev.azure.com/msazure/_packaging/Avere-internal-python/pypi/simple
+
+adal==1.2.7 ; python_full_version >= "3.8.4" and python_full_version < "4.0.0"


### PR DESCRIPTION
Customers' pipelines are being broken because they are using file level `requirements.txt` index urls. This adds an option to disable those