### PR TITLE
Pauldorsch/fix invalid version bug

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/pip/Contracts/PipDependencySpecification.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/Contracts/PipDependencySpecification.cs
@@ -224,11 +224,11 @@ public class PipDependencySpecification
         try
         {
             var topVersion = versions
-            .Where(x => PythonVersionUtilities.VersionValidForSpec(x, this.DependencySpecifiers))
-            .Select(x => (Version: x, PythonVersion: PythonVersion.Create(x)))
-            .Where(x => x.PythonVersion.Valid)
-            .OrderByDescending(x => x.PythonVersion)
-            .FirstOrDefault((null, null));
+                .Where(x => PythonVersionUtilities.VersionValidForSpec(x, this.DependencySpecifiers))
+                .Select(x => (Version: x, PythonVersion: PythonVersion.Create(x)))
+                .Where(x => x.PythonVersion.Valid)
+                .OrderByDescending(x => x.PythonVersion)
+                .FirstOrDefault((null, null));
 
             return topVersion.Version;
         }

--- a/src/Microsoft.ComponentDetection.Detectors/pip/PipComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/PipComponentDetector.cs
@@ -75,7 +75,8 @@ public class PipComponentDetector : FileComponentDetector, IDefaultOffComponentD
             var initialPackages = await this.pythonCommandService.ParseFileAsync(file.Location, pythonExePath);
             var listedPackage = SharedPipUtilities.ParsedPackagesToPipDependencies(
                     initialPackages,
-                    this.pythonResolver.GetPythonEnvironmentVariables())
+                    this.pythonResolver.GetPythonEnvironmentVariables(),
+                    this.Logger)
                 .ToList();
 
             var roots = await this.pythonResolver.ResolveRootsAsync(singleFileComponentRecorder, listedPackage);

--- a/src/Microsoft.ComponentDetection.Detectors/pip/PipReportComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/PipReportComponentDetector.cs
@@ -294,8 +294,15 @@ public class PipReportComponentDetector : FileComponentDetector
             // if pipreport fails, try to at least list the dependencies that are found in the source files
             if (this.GetPipReportOverrideBehavior() != PipReportOverrideBehavior.SourceCodeScan && !this.PipReportSkipFallbackOnFailure())
             {
-                this.Logger.LogInformation("PipReport: Trying to Manually compile dependency list for '{File}' without reaching out to a remote feed.", file.Location);
-                await this.RegisterExplicitComponentsInFileAsync(singleFileComponentRecorder, file.Location, pythonExePath);
+                try
+                {
+                    this.Logger.LogInformation("PipReport: Trying to Manually compile dependency list for '{File}' without reaching out to a remote feed.", file.Location);
+                    await this.RegisterExplicitComponentsInFileAsync(singleFileComponentRecorder, file.Location, pythonExePath);
+                }
+                catch (Exception ex)
+                {
+                    this.Logger.LogWarning(ex, "PipReport: Failed to manually compile dependency list for '{File}'.", file.Location);
+                }
             }
         }
         finally

--- a/src/Microsoft.ComponentDetection.Detectors/pip/PipReportComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/PipReportComponentDetector.cs
@@ -296,12 +296,15 @@ public class PipReportComponentDetector : FileComponentDetector
             {
                 try
                 {
-                    this.Logger.LogInformation("PipReport: Trying to Manually compile dependency list for '{File}' without reaching out to a remote feed.", file.Location);
+                    this.Logger.LogInformation(
+                        "PipReport: Trying to manually compile package list for '{File}' without reaching out to a remote feed. " +
+                        "This will NOT create a dependency graph, so should be avoided unless absolutely necessary.",
+                        file.Location);
                     await this.RegisterExplicitComponentsInFileAsync(singleFileComponentRecorder, file.Location, pythonExePath);
                 }
                 catch (Exception ex)
                 {
-                    this.Logger.LogWarning(ex, "PipReport: Failed to manually compile dependency list for '{File}'.", file.Location);
+                    this.Logger.LogWarning(ex, "PipReport: Failed to manually compile package list for '{File}'.", file.Location);
                 }
             }
         }
@@ -373,7 +376,7 @@ public class PipReportComponentDetector : FileComponentDetector
                 // cffi (>=1.12)
                 // futures; python_version <= \"2.7\"
                 // sphinx (!=1.8.0,!=3.1.0,!=3.1.1,>=1.6.5) ; extra == 'docs'
-                var dependencySpec = new PipDependencySpecification($"Requires-Dist: {dependency}", requiresDist: true);
+                var dependencySpec = new PipDependencySpecification(this.Logger, $"Requires-Dist: {dependency}", requiresDist: true);
                 if (!dependencySpec.IsValidParentPackage(pythonEnvVars))
                 {
                     continue;
@@ -466,7 +469,8 @@ public class PipReportComponentDetector : FileComponentDetector
 
         var listedPackage = SharedPipUtilities.ParsedPackagesToPipDependencies(
                 initialPackages,
-                this.pythonResolver.GetPythonEnvironmentVariables())
+                this.pythonResolver.GetPythonEnvironmentVariables(),
+                this.Logger)
             .ToList();
 
         listedPackage.Select(x => (x.Name, Version: x.GetHighestExplicitPackageVersion()))
@@ -493,7 +497,8 @@ public class PipReportComponentDetector : FileComponentDetector
             var initialPackages = await this.pythonCommandService.ParseFileAsync(filePath, pythonExePath);
             var listedPackage = SharedPipUtilities.ParsedPackagesToPipDependencies(
                     initialPackages,
-                    this.pythonResolver.GetPythonEnvironmentVariables())
+                    this.pythonResolver.GetPythonEnvironmentVariables(),
+                    this.Logger)
                 .Select(x => x.Name)
                 .ToImmutableSortedSet();
 

--- a/src/Microsoft.ComponentDetection.Detectors/pip/SharedPipUtilities.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/SharedPipUtilities.cs
@@ -3,6 +3,7 @@ namespace Microsoft.ComponentDetection.Detectors.Pip;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
+using Microsoft.Extensions.Logging;
 
 public static class SharedPipUtilities
 {
@@ -12,14 +13,16 @@ public static class SharedPipUtilities
     /// </summary>
     /// <param name="parsedPackages">List of packages and git components.</param>
     /// <param name="pythonEnvironmentVariables">Python environment specifiers.</param>
+    /// <param name="logger">Logger for pip dependency specification.</param>
     /// <returns>Enumerable containing the converted, sanitized Pip dependency specs.</returns>
     public static IEnumerable<PipDependencySpecification> ParsedPackagesToPipDependencies(
         IList<(string PackageString, GitComponent Component)> parsedPackages,
-        Dictionary<string, string> pythonEnvironmentVariables) =>
+        Dictionary<string, string> pythonEnvironmentVariables,
+        ILogger logger) =>
             parsedPackages.Where(tuple => tuple.PackageString != null)
                 .Select(tuple => tuple.PackageString)
                 .Where(x => !string.IsNullOrWhiteSpace(x))
-                .Select(x => new PipDependencySpecification(x))
+                .Select(x => new PipDependencySpecification(logger, x, false))
                 .Where(x => !x.PackageIsUnsafe())
                 .Where(x => x.PackageConditionsMet(pythonEnvironmentVariables));
 }

--- a/src/Microsoft.ComponentDetection.Detectors/pip/SimplePipComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/SimplePipComponentDetector.cs
@@ -68,7 +68,7 @@ public class SimplePipComponentDetector : FileComponentDetector, IDefaultOffComp
             var listedPackage = initialPackages.Where(tuple => tuple.PackageString != null)
                 .Select(tuple => tuple.PackageString)
                 .Where(x => !string.IsNullOrWhiteSpace(x))
-                .Select(x => new PipDependencySpecification(x))
+                .Select(x => new PipDependencySpecification(x, false))
                 .Where(x => !x.PackageIsUnsafe())
                 .ToList();
 

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/PipDependencySpecifierTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/PipDependencySpecifierTests.cs
@@ -161,4 +161,43 @@ public class PipDependencySpecifierTests
 
         VerifyPipConditionalDependencyParsing(specs, pythonEnvironmentVariables, true);
     }
+
+    [TestMethod]
+    public void TestPipDependencyGetHighestExplicitPackageVersion_Valid()
+    {
+        var spec = new PipDependencySpecification
+        {
+            Name = "TestPackage",
+            DependencySpecifiers = new List<string> { ">=1.0", "<=3.0", "!=2.0", "!=4.0" },
+        };
+
+        var highestVersion = spec.GetHighestExplicitPackageVersion();
+        highestVersion.Should().Be("3.0");
+    }
+
+    [TestMethod]
+    public void TestPipDependencyGetHighestExplicitPackageVersion_SingleInvalidSpec()
+    {
+        var spec = new PipDependencySpecification
+        {
+            Name = "TestPackage",
+            DependencySpecifiers = new List<string> { ">=1.0", "info", "!=2.0", "!=4.0" },
+        };
+
+        var highestVersion = spec.GetHighestExplicitPackageVersion();
+        highestVersion.Should().BeNull();
+    }
+
+    [TestMethod]
+    public void TestPipDependencyGetHighestExplicitPackageVersion_AllInvalidSpec()
+    {
+        var spec = new PipDependencySpecification
+        {
+            Name = "TestPackage",
+            DependencySpecifiers = new List<string> { "info" },
+        };
+
+        var highestVersion = spec.GetHighestExplicitPackageVersion();
+        highestVersion.Should().BeNull();
+    }
 }

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/PipReportComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/PipReportComponentDetectorTests.cs
@@ -531,6 +531,55 @@ public class PipReportComponentDetectorTests : BaseDetectorTest<PipReportCompone
     }
 
     [TestMethod]
+    public async Task TestPipReportDetector_FallbackAsync()
+    {
+        this.pythonCommandService.Setup(x => x.PythonExistsAsync(It.IsAny<string>())).ReturnsAsync(true);
+
+        var baseSetupPyDependencies = this.ToGitTuple(new List<string> { "a==1.0", "b>=2.0,!=2.1,<3.0.0", "c!=1.1", "y==invalidversion" });
+        var baseRequirementsTextDependencies = this.ToGitTuple(new List<string> { "d~=1.0", "e<=2.0", "f===1.1", "g<3.0", "h>=1.0,<=3.0,!=2.0,!=4.0", "z==invalidversion" });
+        baseRequirementsTextDependencies.Add((null, new GitComponent(new Uri("https://github.com/example/example"), "deadbee")));
+
+        this.pythonCommandService.Setup(x => x.ParseFileAsync(Path.Join(Path.GetTempPath(), "setup.py"), null)).ReturnsAsync(baseSetupPyDependencies);
+        this.pythonCommandService.Setup(x => x.ParseFileAsync(Path.Join(Path.GetTempPath(), "requirements.txt"), null)).ReturnsAsync(baseRequirementsTextDependencies);
+
+        this.pipCommandService.Setup(x => x.GenerateInstallationReportAsync(
+            It.Is<string>(s => s.Contains("requirements.txt", StringComparison.OrdinalIgnoreCase)),
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Want to fallback, so fail initial report generation"));
+
+        var (result, componentRecorder) = await this.DetectorTestUtility
+            .WithFile("setup.py", string.Empty)
+            .WithFile("requirements.txt", string.Empty)
+            .ExecuteDetectorAsync();
+
+        result.ResultCode.Should().Be(ProcessingResultCode.Success);
+
+        var detectedComponents = componentRecorder.GetDetectedComponents();
+        detectedComponents.Should().HaveCount(7);
+
+        var pipComponents = detectedComponents.Where(detectedComponent => detectedComponent.Component.Id.Contains("pip")).ToList();
+        ((PipComponent)pipComponents.Single(x => ((PipComponent)x.Component).Name == "a").Component).Version.Should().Be("1.0");
+        ((PipComponent)pipComponents.Single(x => ((PipComponent)x.Component).Name == "b").Component).Version.Should().Be("2.0");
+        ((PipComponent)pipComponents.Single(x => ((PipComponent)x.Component).Name == "d").Component).Version.Should().Be("1.0");
+        ((PipComponent)pipComponents.Single(x => ((PipComponent)x.Component).Name == "e").Component).Version.Should().Be("2.0");
+        ((PipComponent)pipComponents.Single(x => ((PipComponent)x.Component).Name == "f").Component).Version.Should().Be("1.1");
+        ((PipComponent)pipComponents.Single(x => ((PipComponent)x.Component).Name == "h").Component).Version.Should().Be("3.0");
+        pipComponents.Should().NotContain(x => ((PipComponent)x.Component).Name == "c");
+        pipComponents.Should().NotContain(x => ((PipComponent)x.Component).Name == "g");
+        pipComponents.Should().NotContain(x => ((PipComponent)x.Component).Name == "y");
+        pipComponents.Should().NotContain(x => ((PipComponent)x.Component).Name == "z");
+
+        var gitComponents = detectedComponents.Where(detectedComponent => detectedComponent.Component.Type == ComponentType.Git);
+        gitComponents.Should().ContainSingle();
+        var gitComponent = (GitComponent)gitComponents.Single().Component;
+
+        gitComponent.RepositoryUrl.Should().Be("https://github.com/example/example");
+        gitComponent.CommitHash.Should().Be("deadbee");
+    }
+
+    [TestMethod]
     public async Task TestPipReportDetector_OverrideSkipAsync()
     {
         this.pythonCommandService.Setup(x => x.PythonExistsAsync(It.IsAny<string>())).ReturnsAsync(true);

--- a/test/Microsoft.ComponentDetection.VerificationTests/resources/pip/fallback/requirements.txt
+++ b/test/Microsoft.ComponentDetection.VerificationTests/resources/pip/fallback/requirements.txt
@@ -1,2 +1,3 @@
 fakepythonpackage==1.2.3
 zipp>=3.2.0,<4.0
+badpackage==info


### PR DESCRIPTION
Fixes a bug seen when using the default env vars. The fallback behavior throws an ArgumentException for invalid versions, e.g. `"info", "notrealversion", ...` and we don't handle it gracefully. This catches all exceptions that might be thrown, but also handles the invalid exceptions as we actually expect it to.