### PR TITLE
Fix MSTest Packages for test utilities

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,7 +21,10 @@
     <PackageVersion Include="MinVer" Version="5.0.0" />
     <PackageVersion Include="Moq" Version="4.18.4" />
     <PackageVersion Include="morelinq" Version="4.2.0" />
-    <PackageVersion Include="MSTest" Version="3.5.1" />
+    <PackageVersion Include="MSTest.TestFramework" Version="3.5.1" />
+    <PackageVersion Include="MSTest.Analyzers" Version="3.5.1" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="3.5.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="Newtonsoft.Json.Schema" Version="3.0.16" />
     <PackageVersion Include="NuGet.ProjectModel" Version="6.10.0" />

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -3,7 +3,8 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"/>
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="MSTest"/>
+    <PackageReference Include="MSTest.TestFramework"/>
+    <PackageReference Include="MSTest.Analyzers "/>
     <PackageReference Include="Moq"/>
     <PackageReference Include="FluentAssertions"/>
     <PackageReference Include="Faker.net"/>

--- a/test/Microsoft.ComponentDetection.Common.Tests/Microsoft.ComponentDetection.Common.Tests.csproj
+++ b/test/Microsoft.ComponentDetection.Common.Tests/Microsoft.ComponentDetection.Common.Tests.csproj
@@ -9,6 +9,8 @@
       <PackageReference Include="FluentAssertions.Analyzers" PrivateAssets="all" />
       <PackageReference Include="Microsoft.Extensions.Logging" />
       <PackageReference Include="System.Threading.Tasks.Dataflow" />
+      <PackageReference Include="MSTest.TestAdapter "/>
+      <PackageReference Include="Microsoft.NET.Test.Sdk "/>
     </ItemGroup>
 
     <ItemGroup>

--- a/test/Microsoft.ComponentDetection.Contracts.Tests/Microsoft.ComponentDetection.Contracts.Tests.csproj
+++ b/test/Microsoft.ComponentDetection.Contracts.Tests/Microsoft.ComponentDetection.Contracts.Tests.csproj
@@ -9,6 +9,8 @@
         <PackageReference Include="System.Reactive" />
         <PackageReference Include="System.Threading.Tasks.Dataflow" />
         <PackageReference Include="packageurl-dotnet" />
+        <PackageReference Include="MSTest.TestAdapter " />
+        <PackageReference Include="Microsoft.NET.Test.Sdk " />
         <PackageReference Include="FluentAssertions.Analyzers" PrivateAssets="all" />
     </ItemGroup>
 

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/Microsoft.ComponentDetection.Detectors.Tests.csproj
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/Microsoft.ComponentDetection.Detectors.Tests.csproj
@@ -14,6 +14,8 @@
         <PackageReference Include="System.Threading.Tasks.Dataflow" />
         <PackageReference Include="packageurl-dotnet" />
         <PackageReference Include="YamlDotNet" />
+        <PackageReference Include="MSTest.TestAdapter "/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk "/>
     </ItemGroup>
 
     <ItemGroup>

--- a/test/Microsoft.ComponentDetection.Orchestrator.Tests/Microsoft.ComponentDetection.Orchestrator.Tests.csproj
+++ b/test/Microsoft.ComponentDetection.Orchestrator.Tests/Microsoft.ComponentDetection.Orchestrator.Tests.csproj
@@ -11,7 +11,9 @@
         <PackageReference Include="Spectre.Console.Cli" />
         <PackageReference Include="Spectre.Console.Testing" />
         <PackageReference Include="System.Threading.Tasks.Dataflow" />
-      <PackageReference Include="FluentAssertions.Analyzers" PrivateAssets="all" />
+        <PackageReference Include="MSTest.TestAdapter "/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk "/>
+        <PackageReference Include="FluentAssertions.Analyzers" PrivateAssets="all" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Dotnet pack is failing, since `testhost.dll` is mistakenly in the TestUtilities Nuget package.
```
The assembly 'content\testhost.dll' is not inside the 'lib' folder and hence it won't be added as a reference when the package is installed into a project. Move it into the 'lib' folder if it needs to be referenced.
```

https://learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-mstest-getting-started mentions 
```
If you are creating a test infrastructure project that is intended to be used as a helper by multiple test projects, you should install the MSTest.TestFramework and MSTest.Analyzers packages directly into that project.
```