### PR TITLE
add MSBuild binary log (.binlog) component detector

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,9 +21,12 @@
     <PackageVersion Include="MinVer" Version="5.0.0" />
     <PackageVersion Include="Moq" Version="4.18.4" />
     <PackageVersion Include="morelinq" Version="4.2.0" />
+    <PackageVersion Include="MSBuild.StructuredLogger" Version="2.2.317" />
     <PackageVersion Include="MSTest.TestFramework" Version="3.5.1" />
     <PackageVersion Include="MSTest.Analyzers" Version="3.5.1" />
     <PackageVersion Include="MSTest.TestAdapter" Version="3.5.1" />
+    <PackageVersion Include="Microsoft.Build.Framework" Version="17.5.0" />
+    <PackageVersion Include="Microsoft.Build.Locator" Version="1.6.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="Newtonsoft.Json.Schema" Version="3.0.16" />

--- a/src/Microsoft.ComponentDetection.Detectors/Microsoft.ComponentDetection.Detectors.csproj
+++ b/src/Microsoft.ComponentDetection.Detectors/Microsoft.ComponentDetection.Detectors.csproj
@@ -36,4 +36,8 @@
         </EmbeddedResource>
     </ItemGroup>
 
+    <ItemGroup>
+        <InternalsVisibleTo Include="Microsoft.ComponentDetection.Detectors.Tests" />
+    </ItemGroup>
+
 </Project>

--- a/src/Microsoft.ComponentDetection.Detectors/Microsoft.ComponentDetection.Detectors.csproj
+++ b/src/Microsoft.ComponentDetection.Detectors/Microsoft.ComponentDetection.Detectors.csproj
@@ -9,7 +9,10 @@
         <PackageReference Include="Polly" />
         <PackageReference Include="SemanticVersioning" />
         <PackageReference Include="yamldotnet" />
+        <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="Runtime" PrivateAssets="All" />
+        <PackageReference Include="Microsoft.Build.Locator" />
         <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
+        <PackageReference Include="MSBuild.StructuredLogger" />
         <PackageReference Include="Newtonsoft.Json" />
         <PackageReference Include="System.Reactive" />
         <PackageReference Include="System.Threading.Tasks.Dataflow" />

--- a/src/Microsoft.ComponentDetection.Detectors/nuget/NuGetMSBuildBinaryLogComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/nuget/NuGetMSBuildBinaryLogComponentDetector.cs
@@ -1,0 +1,212 @@
+﻿namespace Microsoft.ComponentDetection.Detectors.NuGet;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Microsoft.Build.Locator;
+using Microsoft.Build.Logging.StructuredLogger;
+using Microsoft.ComponentDetection.Contracts;
+using Microsoft.ComponentDetection.Contracts.Internal;
+using Microsoft.ComponentDetection.Contracts.TypedComponent;
+using Microsoft.Extensions.Logging;
+
+using Task = System.Threading.Tasks.Task;
+
+public class NuGetMSBuildBinaryLogComponentDetector : FileComponentDetector
+{
+    private static readonly HashSet<string> TopLevelPackageItemNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    {
+        "PackageReference",
+    };
+
+    // the items listed below represent collection names that NuGet will resolve a package into, along with the metadata value names to get the package name and version
+    private static readonly Dictionary<string, (string NameMetadata, string VersionMetadata)> ResolvedPackageItemNames = new Dictionary<string, (string, string)>(StringComparer.OrdinalIgnoreCase)
+    {
+        ["NativeCopyLocalItems"] = ("NuGetPackageId", "NuGetPackageVersion"),
+        ["ResourceCopyLocalItems"] = ("NuGetPackageId", "NuGetPackageVersion"),
+        ["RuntimeCopyLocalItems"] = ("NuGetPackageId", "NuGetPackageVersion"),
+        ["ResolvedAnalyzers"] = ("NuGetPackageId", "NuGetPackageVersion"),
+        ["_PackageDependenciesDesignTime"] = ("Name", "Version"),
+    };
+
+    private static bool isMSBuildRegistered;
+
+    public NuGetMSBuildBinaryLogComponentDetector(
+        IObservableDirectoryWalkerFactory walkerFactory,
+        ILogger<NuGetMSBuildBinaryLogComponentDetector> logger)
+    {
+        this.Scanner = walkerFactory;
+        this.Logger = logger;
+    }
+
+    public override string Id { get; } = "NuGetMSBuildBinaryLog";
+
+    public override IEnumerable<string> Categories => new[] { Enum.GetName(typeof(DetectorClass), DetectorClass.NuGet) };
+
+    public override IList<string> SearchPatterns { get; } = new List<string> { "*.binlog" };
+
+    public override IEnumerable<ComponentType> SupportedComponentTypes { get; } = new[] { ComponentType.NuGet };
+
+    public override int Version { get; } = 1;
+
+    private static void ProcessResolvedPackageReference(Dictionary<string, HashSet<string>> topLevelDependencies, Dictionary<string, Dictionary<string, string>> projectResolvedDependencies, NamedNode node)
+    {
+        var doRemoveOperation = node is RemoveItem;
+        var doAddOperation = node is AddItem;
+        if (TopLevelPackageItemNames.Contains(node.Name))
+        {
+            var projectEvaluation = node.GetNearestParent<ProjectEvaluation>();
+            if (projectEvaluation is not null)
+            {
+                foreach (var child in node.Children.OfType<Item>())
+                {
+                    var packageName = child.Name;
+                    if (!topLevelDependencies.TryGetValue(projectEvaluation.ProjectFile, out var topLevel))
+                    {
+                        topLevel = new(StringComparer.OrdinalIgnoreCase);
+                        topLevelDependencies[projectEvaluation.ProjectFile] = topLevel;
+                    }
+
+                    if (doRemoveOperation)
+                    {
+                        topLevel.Remove(packageName);
+                    }
+
+                    if (doAddOperation)
+                    {
+                        topLevel.Add(packageName);
+                    }
+                }
+            }
+        }
+        else if (ResolvedPackageItemNames.TryGetValue(node.Name, out var metadataNames))
+        {
+            var nameMetadata = metadataNames.NameMetadata;
+            var versionMetadata = metadataNames.VersionMetadata;
+            var originalProject = node.GetNearestParent<Project>();
+            if (originalProject is not null)
+            {
+                foreach (var child in node.Children.OfType<Item>())
+                {
+                    var packageName = GetChildMetadataValue(child, nameMetadata);
+                    var packageVersion = GetChildMetadataValue(child, versionMetadata);
+                    if (packageName is not null && packageVersion is not null)
+                    {
+                        var project = originalProject;
+                        while (project is not null)
+                        {
+                            if (!projectResolvedDependencies.TryGetValue(project.ProjectFile, out var projectDependencies))
+                            {
+                                projectDependencies = new(StringComparer.OrdinalIgnoreCase);
+                                projectResolvedDependencies[project.ProjectFile] = projectDependencies;
+                            }
+
+                            if (doRemoveOperation)
+                            {
+                                projectDependencies.Remove(packageName);
+                            }
+
+                            if (doAddOperation)
+                            {
+                                projectDependencies[packageName] = packageVersion;
+                            }
+
+                            project = project.GetNearestParent<Project>();
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private static string GetChildMetadataValue(TreeNode node, string metadataItemName)
+    {
+        var metadata = node.Children.OfType<Metadata>();
+        var metadataValue = metadata.FirstOrDefault(m => m.Name.Equals(metadataItemName, StringComparison.OrdinalIgnoreCase))?.Value;
+        return metadataValue;
+    }
+
+    protected override Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            if (!isMSBuildRegistered)
+            {
+                // this must happen once per process, and never again
+                var defaultInstance = MSBuildLocator.QueryVisualStudioInstances().First();
+                MSBuildLocator.RegisterInstance(defaultInstance);
+                isMSBuildRegistered = true;
+            }
+
+            var singleFileComponentRecorder = this.ComponentRecorder.CreateSingleFileComponentRecorder(processRequest.ComponentStream.Location);
+            var buildRoot = BinaryLog.ReadBuild(processRequest.ComponentStream.Stream);
+            this.RecordLockfileVersion(buildRoot.FileFormatVersion);
+            this.ProcessBinLog(buildRoot, singleFileComponentRecorder);
+        }
+        catch (Exception e)
+        {
+            // If something went wrong, just ignore the package
+            this.Logger.LogError(e, "Failed to process MSBuild binary log {BinLogFile}", processRequest.ComponentStream.Location);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    protected override Task OnDetectionFinishedAsync()
+    {
+        return Task.CompletedTask;
+    }
+
+    private void ProcessBinLog(Build buildRoot, ISingleFileComponentRecorder componentRecorder)
+    {
+        // maps a project path to a set of resolved dependencies
+        var projectTopLevelDependencies = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+        var projectResolvedDependencies = new Dictionary<string, Dictionary<string, string>>(StringComparer.OrdinalIgnoreCase);
+        buildRoot.VisitAllChildren<BaseNode>(node =>
+        {
+            switch (node)
+            {
+                case NamedNode namedNode when namedNode is AddItem or RemoveItem:
+                    ProcessResolvedPackageReference(projectTopLevelDependencies, projectResolvedDependencies, namedNode);
+                    break;
+                default:
+                    break;
+            }
+        });
+
+        // dependencies were resolved per project, we need to re-arrange them to be per package/version
+        var projectsPerPackage = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+        foreach (var projectPath in projectResolvedDependencies.Keys)
+        {
+            var projectDependencies = projectResolvedDependencies[projectPath];
+            foreach (var (packageName, packageVersion) in projectDependencies)
+            {
+                var key = $"{packageName}/{packageVersion}";
+                if (!projectsPerPackage.TryGetValue(key, out var projectPaths))
+                {
+                    projectPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                    projectsPerPackage[key] = projectPaths;
+                }
+
+                projectPaths.Add(projectPath);
+            }
+        }
+
+        // report it all
+        foreach (var (packageNameAndVersion, projectPaths) in projectsPerPackage)
+        {
+            var parts = packageNameAndVersion.Split('/', 2);
+            var packageName = parts[0];
+            var packageVersion = parts[1];
+            var component = new NuGetComponent(packageName, packageVersion);
+            var libraryComponent = new DetectedComponent(component);
+            foreach (var projectPath in projectPaths)
+            {
+                libraryComponent.FilePaths.Add(projectPath);
+            }
+
+            componentRecorder.RegisterUsage(libraryComponent);
+        }
+    }
+}

--- a/src/Microsoft.ComponentDetection.Detectors/nuget/NuGetMSBuildBinaryLogComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/nuget/NuGetMSBuildBinaryLogComponentDetector.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using Microsoft.Build.Locator;
@@ -183,6 +184,12 @@ public class NuGetMSBuildBinaryLogComponentDetector : FileComponentDetector
         var projectsPerPackage = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
         foreach (var projectPath in projectResolvedDependencies.Keys)
         {
+            if (Path.GetExtension(projectPath).Equals(".sln", StringComparison.OrdinalIgnoreCase))
+            {
+                // don't report solution files
+                continue;
+            }
+
             var projectDependencies = projectResolvedDependencies[projectPath];
             foreach (var (packageName, packageVersion) in projectDependencies)
             {
@@ -198,8 +205,9 @@ public class NuGetMSBuildBinaryLogComponentDetector : FileComponentDetector
         }
 
         // report it all
-        foreach (var (packageNameAndVersion, projectPaths) in projectsPerPackage)
+        foreach (var packageNameAndVersion in projectsPerPackage.Keys.OrderBy(p => p))
         {
+            var projectPaths = projectsPerPackage[packageNameAndVersion];
             var parts = packageNameAndVersion.Split('/', 2);
             var packageName = parts[0];
             var packageVersion = parts[1];

--- a/src/Microsoft.ComponentDetection.Detectors/nuget/NuGetMSBuildBinaryLogComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/nuget/NuGetMSBuildBinaryLogComponentDetector.cs
@@ -39,7 +39,6 @@ public class NuGetMSBuildBinaryLogComponentDetector : FileComponentDetector
     };
 
     private static readonly object MSBuildRegistrationGate = new();
-    private static bool isMSBuildRegistered;
 
     public NuGetMSBuildBinaryLogComponentDetector(
         IObservableDirectoryWalkerFactory walkerFactory,
@@ -166,12 +165,11 @@ public class NuGetMSBuildBinaryLogComponentDetector : FileComponentDetector
     {
         lock (MSBuildRegistrationGate)
         {
-            if (!isMSBuildRegistered)
+            if (!MSBuildLocator.IsRegistered)
             {
                 // this must happen once per process, and never again
                 var defaultInstance = MSBuildLocator.QueryVisualStudioInstances().First();
                 MSBuildLocator.RegisterInstance(defaultInstance);
-                isMSBuildRegistered = true;
             }
         }
     }

--- a/src/Microsoft.ComponentDetection.Orchestrator/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Extensions/ServiceCollectionExtensions.cs
@@ -105,6 +105,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IComponentDetector, NuGetComponentDetector>();
         services.AddSingleton<IComponentDetector, NuGetPackagesConfigDetector>();
         services.AddSingleton<IComponentDetector, NuGetProjectModelProjectCentricComponentDetector>();
+        services.AddSingleton<IComponentDetector, NuGetMSBuildBinaryLogComponentDetector>();
 
         // PIP
         services.AddSingleton<IPyPiClient, PyPiClient>();

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/MSBuildTestUtilities.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/MSBuildTestUtilities.cs
@@ -58,6 +58,7 @@ public static class MSBuildTestUtilities
     public static async Task<Stream> GetBinLogStreamFromFileContentsAsync(
         string defaultFilePath,
         string defaultFileContents,
+        string targetName = null,
         (string FileName, string Contents)[] additionalFiles = null,
         (string Name, string Version, string TargetFramework, string AdditionalMetadataXml)[] mockedPackages = null)
     {
@@ -79,7 +80,8 @@ public static class MSBuildTestUtilities
         await MockNuGetPackagesInDirectoryAsync(tempDir, mockedPackages);
 
         // generate the binlog
-        var (exitCode, stdOut, stdErr) = await RunProcessAsync("dotnet", $"build \"{fullDefaultFilePath}\" /t:GenerateBuildDependencyFile /bl:msbuild.binlog", workingDirectory: tempDir.DirectoryPath);
+        targetName ??= "GenerateBuildDependencyFile";
+        var (exitCode, stdOut, stdErr) = await RunProcessAsync("dotnet", $"build \"{fullDefaultFilePath}\" /t:{targetName} /bl:msbuild.binlog", workingDirectory: tempDir.DirectoryPath);
         exitCode.Should().Be(0, $"STDOUT:\n{stdOut}\n\nSTDERR:\n{stdErr}");
 
         // copy it to memory so the temporary directory can be cleaned up

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/MSBuildTestUtilities.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/MSBuildTestUtilities.cs
@@ -1,0 +1,335 @@
+﻿namespace Microsoft.ComponentDetection.Detectors.Tests;
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using System.Xml.XPath;
+using FluentAssertions;
+
+public static class MSBuildTestUtilities
+{
+    public const int TestTargetFrameworkVersion = 6;
+    public static readonly string TestTargetFramework = $"net{TestTargetFrameworkVersion}.0";
+
+    // we need to find the file `Microsoft.NETCoreSdk.BundledVersions.props` in the SDK directory
+    private static readonly Lazy<string> BundledVersionsPropsPath = new(static () =>
+    {
+        // get the sdk version
+        using var tempDir = new TemporaryProjectDirectory();
+        var projectContents = @"
+            <Project Sdk=""Microsoft.NET.Sdk"">
+                <Target Name=""_ReportCurrentSdkVersion"">
+                <Message Text=""_CurrentSdkVersion=$(NETCoreSdkVersion)"" Importance=""High"" />
+                </Target>
+            </Project>
+            ";
+        var projectPath = Path.Combine(tempDir.DirectoryPath, "project.csproj");
+        File.WriteAllText(projectPath, projectContents);
+        var (exitCode, stdout, stderr) = RunProcessAsync("dotnet", $"msbuild {projectPath} /t:_ReportCurrentSdkVersion").Result;
+        if (exitCode != 0)
+        {
+            throw new NotSupportedException($"Failed to report the current SDK version:\n{stdout}\n{stderr}");
+        }
+
+        var matches = Regex.Matches(stdout, "_CurrentSdkVersion=(?<SdkVersion>.*)$", RegexOptions.Multiline);
+        if (matches.Count == 0)
+        {
+            throw new NotSupportedException($"Failed to find the current SDK version in the output:\n{stdout}");
+        }
+
+        var sdkVersionString = matches.First().Groups["SdkVersion"].Value.Trim();
+
+        // find the actual SDK directory
+        var privateCoreLibPath = typeof(object).Assembly.Location; // e.g., C:\Program Files\dotnet\shared\Microsoft.NETCore.App\8.0.4\System.Private.CoreLib.dll
+        var sdkDirectory = Path.Combine(Path.GetDirectoryName(privateCoreLibPath), "..", "..", "..", "sdk", sdkVersionString); // e.g., C:\Program Files\dotnet\sdk\8.0.204
+        var bundledVersionsPropsPath = Path.Combine(sdkDirectory, "Microsoft.NETCoreSdk.BundledVersions.props");
+        var normalizedPath = new FileInfo(bundledVersionsPropsPath);
+        return normalizedPath.FullName;
+    });
+
+    public static async Task<Stream> GetBinLogStreamFromFileContentsAsync(
+        string projectContents,
+        (string FileName, string Contents)[] additionalFiles = null,
+        (string Name, string Version, string TargetFramework, string AdditionalMetadataXml)[] mockedPackages = null)
+    {
+        // write all files
+        using var tempDir = new TemporaryProjectDirectory();
+        var fullProjectPath = Path.Combine(tempDir.DirectoryPath, "project.csproj");
+        await File.WriteAllTextAsync(fullProjectPath, projectContents);
+        if (additionalFiles is not null)
+        {
+            foreach (var (fileName, contents) in additionalFiles)
+            {
+                var fullFilePath = Path.Combine(tempDir.DirectoryPath, fileName);
+                var fullFileDirectory = Path.GetDirectoryName(fullFilePath);
+                Directory.CreateDirectory(fullFileDirectory);
+                await File.WriteAllTextAsync(fullFilePath, contents);
+            }
+        }
+
+        await MockNuGetPackagesInDirectoryAsync(tempDir, mockedPackages);
+
+        // generate the binlog
+        var (exitCode, stdOut, stdErr) = await RunProcessAsync("dotnet", $"build \"{fullProjectPath}\" /t:GenerateBuildDependencyFile /bl:msbuild.binlog", workingDirectory: tempDir.DirectoryPath);
+        exitCode.Should().Be(0, $"STDOUT:\n{stdOut}\n\nSTDERR:\n{stdErr}");
+
+        // copy it to memory so the temporary directory can be cleaned up
+        var fullBinLogPath = Path.Combine(tempDir.DirectoryPath, "msbuild.binlog");
+        using var binLogStream = File.OpenRead(fullBinLogPath);
+        var inMemoryStream = new MemoryStream();
+        await binLogStream.CopyToAsync(inMemoryStream);
+        inMemoryStream.Position = 0;
+        return inMemoryStream;
+    }
+
+    private static async Task MockNuGetPackagesInDirectoryAsync(
+        TemporaryProjectDirectory tempDir,
+        (string Name, string Version, string TargetFramework, string AdditionalMetadataXml)[] mockedPackages)
+    {
+        if (mockedPackages is not null)
+        {
+            var nugetConfig = @"
+                <configuration>
+                  <packageSources>
+                    <clear />
+                    <add key=""local-feed"" value=""local-packages"" />
+                  </packageSources>
+                </configuration>
+                ";
+            await File.WriteAllTextAsync(Path.Combine(tempDir.DirectoryPath, "NuGet.Config"), nugetConfig);
+            var packagesPath = Path.Combine(tempDir.DirectoryPath, "local-packages");
+            Directory.CreateDirectory(packagesPath);
+
+            var mockedPackagesWithFiles = mockedPackages.Select(p =>
+            {
+                return (
+                    p.Name,
+                    p.Version,
+                    p.TargetFramework,
+                    p.AdditionalMetadataXml,
+                    Files: new[] { ($"lib/{p.TargetFramework}/{p.Name}.dll", Array.Empty<byte>()) });
+            });
+
+            var allPackages = mockedPackagesWithFiles.Concat(GetCommonPackages());
+
+            using var sha512 = SHA512.Create(); // this is used to compute the hash of each package below
+            foreach (var package in allPackages)
+            {
+                var nuspec = NugetTestUtilities.GetValidNuspec(package.Name, package.Version, Array.Empty<string>());
+                if (package.AdditionalMetadataXml is not null)
+                {
+                    // augment the nuspec
+                    var doc = XDocument.Parse(nuspec);
+                    var additionalMetadata = XElement.Parse(package.AdditionalMetadataXml);
+                    additionalMetadata = WithNamespace(additionalMetadata, doc.Root.Name.Namespace);
+
+                    var metadataElement = doc.Root.Descendants().First(e => e.Name.LocalName == "metadata");
+                    metadataElement.Add(additionalMetadata);
+                    nuspec = doc.ToString();
+                }
+
+                var nupkg = await NugetTestUtilities.ZipNupkgComponentAsync(package.Name, nuspec, additionalFiles: package.Files);
+
+                // to create a local nuget package source, we need a directory structure like this:
+                // local-packages/<package-name>/<package-version>/
+                var packagePath = Path.Combine(packagesPath, package.Name.ToLower(), package.Version.ToLower());
+                Directory.CreateDirectory(packagePath);
+
+                // and we need the following files:
+                // 1. the package
+                var nupkgPath = Path.Combine(packagePath, $"{package.Name}.{package.Version}.nupkg".ToLower());
+                using (var nupkgFileStream = File.OpenWrite(nupkgPath))
+                {
+                    await nupkg.CopyToAsync(nupkgFileStream);
+                }
+
+                // 2. the nuspec
+                var nuspecPath = Path.Combine(packagePath, $"{package.Name}.nuspec".ToLower());
+                await File.WriteAllTextAsync(nuspecPath, nuspec);
+
+                // 3. SHA512 hash of the package
+                var hash = sha512.ComputeHash(File.ReadAllBytes(nupkgPath));
+                var hashString = Convert.ToBase64String(hash);
+                var hashPath = $"{nupkgPath}.sha512";
+                await File.WriteAllTextAsync(hashPath, hashString);
+
+                // 4. a JSON metadata file
+                var metadata = $@"{{""version"": 2, ""contentHash"": ""{hashString}"", ""source"": null}}";
+                var metadataPath = Path.Combine(packagePath, ".nupkg.metadata");
+                await File.WriteAllTextAsync(metadataPath, metadata);
+            }
+        }
+    }
+
+    private static XElement WithNamespace(XElement element, XNamespace ns)
+    {
+        return new XElement(
+            ns + element.Name.LocalName,
+            element.Attributes(),
+            element.Elements().Select(e => WithNamespace(e, ns)),
+            element.Value);
+    }
+
+    private static IEnumerable<(string Name, string Version, string TargetFramework, string AdditionalMetadataXml, (string Path, byte[] Content)[] Files)> GetCommonPackages()
+    {
+        // to allow the tests to not require the network, we need to mock some common packages
+        yield return MakeWellKnownReferencePackage("Microsoft.AspNetCore.App", null);
+        yield return MakeWellKnownReferencePackage("Microsoft.WindowsDesktop.App", null);
+
+        var frameworksXml = $@"
+            <FileList TargetFrameworkIdentifier="".NETCoreApp"" TargetFrameworkVersion=""{TestTargetFrameworkVersion}.0"" FrameworkName=""Microsoft.NETCore.App"" Name="".NET Runtime"">
+            </FileList>
+            ";
+        yield return MakeWellKnownReferencePackage("Microsoft.NETCore.App", new[] { ("data/FrameworkList.xml", Encoding.UTF8.GetBytes(frameworksXml)) });
+    }
+
+    private static (string Name, string Version, string TargetFramework, string AdditionalMetadataXml, (string Path, byte[] Content)[] Files) MakeWellKnownReferencePackage(string packageName, (string Path, byte[] Content)[] files)
+    {
+        var propsDocument = XDocument.Load(BundledVersionsPropsPath.Value);
+        var xpathQuery = $@"
+            /Project/ItemGroup/KnownFrameworkReference
+                [
+                    @Include='{packageName}' and
+                    @TargetingPackName='{packageName}.Ref' and
+                    @TargetFramework='{TestTargetFramework}'
+                ]
+            ";
+        var matchingFrameworkElement = propsDocument.XPathSelectElement(xpathQuery);
+        if (matchingFrameworkElement is null)
+        {
+            throw new NotSupportedException($"Unable to find {packageName}.Ref");
+        }
+
+        var expectedVersion = matchingFrameworkElement.Attribute("TargetingPackVersion").Value;
+        return (
+            $"{packageName}.Ref",
+            expectedVersion,
+            TestTargetFramework,
+            "<packageTypes><packageType name=\"DotnetPlatform\" /></packageTypes>",
+            files);
+    }
+
+    public static Task<(int ExitCode, string Output, string Error)> RunProcessAsync(string fileName, string arguments = "", string workingDirectory = null)
+    {
+        var tcs = new TaskCompletionSource<(int, string, string)>();
+
+        var redirectInitiated = new ManualResetEventSlim();
+        var process = new Process
+        {
+            StartInfo =
+            {
+                FileName = fileName,
+                Arguments = arguments,
+                UseShellExecute = false, // required to redirect output
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+            },
+            EnableRaisingEvents = true,
+        };
+
+        if (workingDirectory is not null)
+        {
+            process.StartInfo.WorkingDirectory = workingDirectory;
+        }
+
+        var stdout = new StringBuilder();
+        var stderr = new StringBuilder();
+
+        process.OutputDataReceived += (_, e) => stdout.AppendLine(e.Data);
+        process.ErrorDataReceived += (_, e) => stderr.AppendLine(e.Data);
+
+        process.Exited += (sender, args) =>
+        {
+            // It is necessary to wait until we have invoked 'BeginXReadLine' for our redirected IO. Then,
+            // we must call WaitForExit to make sure we've received all OutputDataReceived/ErrorDataReceived calls
+            // or else we'll be returning a list we're still modifying. For paranoia, we'll start a task here rather
+            // than enter right back into the Process type and start a wait which isn't guaranteed to be safe.
+            var unused = Task.Run(() =>
+            {
+                redirectInitiated.Wait();
+                redirectInitiated.Dispose();
+                redirectInitiated = null;
+
+                process.WaitForExit();
+
+                tcs.TrySetResult((process.ExitCode, stdout.ToString(), stderr.ToString()));
+                process.Dispose();
+            });
+        };
+
+        if (!process.Start())
+        {
+            throw new InvalidOperationException("Process failed to start");
+        }
+
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+
+        redirectInitiated.Set();
+
+        return tcs.Task;
+    }
+
+    private class TemporaryProjectDirectory : IDisposable
+    {
+        private const string DirectoryBuildPropsContents = @"
+            <Project>
+              <PropertyGroup>
+                <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+              </PropertyGroup>
+            </Project>
+            ";
+
+        private readonly Dictionary<string, string> originalEnvironment = new();
+
+        public TemporaryProjectDirectory()
+        {
+            var testDataPath = Path.Combine(Path.GetDirectoryName(this.GetType().Assembly.Location), "test-data");
+            Directory.CreateDirectory(testDataPath);
+
+            // ensure tests don't crawl the directory tree
+            File.WriteAllText(Path.Combine(testDataPath, "Directory.Build.props"), DirectoryBuildPropsContents);
+            File.WriteAllText(Path.Combine(testDataPath, "Directory.Build.targets"), "<Project />");
+            File.WriteAllText(Path.Combine(testDataPath, "Directory.Packages.props"), "<Project />");
+
+            // create temporary project directory
+            this.DirectoryPath = Path.Combine(testDataPath, Guid.NewGuid().ToString("d"));
+            Directory.CreateDirectory(this.DirectoryPath);
+
+            // ensure each project gets a fresh package cache
+            foreach (var envName in new[] { "NUGET_PACKAGES", "NUGET_HTTP_CACHE_PATH", "NUGET_SCRATCH", "NUGET_PLUGINS_CACHE_PATH" })
+            {
+                this.originalEnvironment[envName] = Environment.GetEnvironmentVariable(envName);
+                var dir = Path.Join(this.DirectoryPath, envName);
+                Directory.CreateDirectory(dir);
+                Environment.SetEnvironmentVariable(envName, dir);
+            }
+        }
+
+        public string DirectoryPath { get; }
+
+        public void Dispose()
+        {
+            foreach (var (key, value) in this.originalEnvironment)
+            {
+                Environment.SetEnvironmentVariable(key, value);
+            }
+
+            try
+            {
+                Directory.Delete(this.DirectoryPath, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/Microsoft.ComponentDetection.Detectors.Tests.csproj
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/Microsoft.ComponentDetection.Detectors.Tests.csproj
@@ -7,7 +7,10 @@
 
     <ItemGroup Label="Package References">
         <PackageReference Include="FluentAssertions.Analyzers" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="Runtime" PrivateAssets="All" />
+        <PackageReference Include="Microsoft.Build.Locator" />
         <PackageReference Include="Microsoft.Extensions.Logging" />
+        <PackageReference Include="MSBuild.StructuredLogger" />
         <PackageReference Include="NuGet.Versioning" />
         <PackageReference Include="SemanticVersioning" />
         <PackageReference Include="System.Reactive" />

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/NuGetMSBuildBinaryLogComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/NuGetMSBuildBinaryLogComponentDetectorTests.cs
@@ -196,6 +196,14 @@ EndGlobal
             .OrderBy(c => c.Name)
             .Select(c => $"{c.Name}/{c.Version}");
         project2Components.Should().Equal("Package.B/4.5.6");
+
+        var solutionComponents = detectedComponents
+            .Where(d => d.FilePaths.Any(p => p.Replace("\\", "/").EndsWith("/solution.sln")))
+            .Select(d => d.Component)
+            .Cast<NuGetComponent>()
+            .OrderBy(c => c.Name)
+            .Select(c => $"{c.Name}/{c.Version}");
+        solutionComponents.Should().BeEmpty();
     }
 
     private async Task<(IndividualDetectorScanResult ScanResult, IComponentRecorder ComponentRecorder)> ExecuteDetectorAndGetBinLogAsync(

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/NuGetMSBuildBinaryLogComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/NuGetMSBuildBinaryLogComponentDetectorTests.cs
@@ -1,0 +1,123 @@
+﻿namespace Microsoft.ComponentDetection.Detectors.Tests;
+
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.ComponentDetection.Contracts.TypedComponent;
+using Microsoft.ComponentDetection.Detectors.NuGet;
+using Microsoft.ComponentDetection.TestsUtilities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[TestClass]
+[TestCategory("Governance/All")]
+[TestCategory("Governance/ComponentDetection")]
+public class NuGetMSBuildBinaryLogComponentDetectorTests : BaseDetectorTest<NuGetMSBuildBinaryLogComponentDetector>
+{
+    [TestMethod]
+    public async Task DependenciesAreReportedForEachProjectFile()
+    {
+        // the contents of `projectContents` are the root entrypoint to the detector, but MSBuild will crawl to the other project file
+        var (scanResult, componentRecorder) = await this.ExecuteDetectorAndGetBinLogAsync(
+            projectContents: $@"
+                <Project Sdk=""Microsoft.NET.Sdk"">
+                  <PropertyGroup>
+                    <TargetFramework>{MSBuildTestUtilities.TestTargetFramework}</TargetFramework>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <ProjectReference Include=""other-project/other-project.csproj"" />
+                  </ItemGroup>
+                </Project>
+                ",
+            additionalFiles: new[]
+                {
+                    ("other-project/other-project.csproj", $@"
+                        <Project Sdk=""Microsoft.NET.Sdk"">
+                          <PropertyGroup>
+                            <TargetFramework>{MSBuildTestUtilities.TestTargetFramework}</TargetFramework>
+                          </PropertyGroup>
+                          <ItemGroup>
+                            <PackageReference Include=""Some.Package"" Version=""1.2.3"" />
+                          </ItemGroup>
+                        </Project>
+                        "),
+                },
+            mockedPackages: new[]
+                {
+                    ("Some.Package", "1.2.3", MSBuildTestUtilities.TestTargetFramework, "<dependencies><dependency id=\"Transitive.Dependency\" version=\"4.5.6\" /></dependencies>"),
+                    ("Transitive.Dependency", "4.5.6", MSBuildTestUtilities.TestTargetFramework, null),
+                });
+
+        var detectedComponents = componentRecorder.GetDetectedComponents();
+
+        // components are reported for each project file
+        var originalFileComponents = detectedComponents
+            .Where(d => d.FilePaths.Any(p => p.Replace("\\", "/").EndsWith("/project.csproj")))
+            .Select(d => d.Component)
+            .Cast<NuGetComponent>()
+            .OrderBy(c => c.Name)
+            .Select(c => $"{c.Name}/{c.Version}");
+        originalFileComponents.Should().Equal("Some.Package/1.2.3", "Transitive.Dependency/4.5.6");
+
+        var referencedFileComponents = detectedComponents
+            .Where(d => d.FilePaths.Any(p => p.Replace("\\", "/").EndsWith("/other-project/other-project.csproj")))
+            .Select(d => d.Component)
+            .Cast<NuGetComponent>()
+            .OrderBy(c => c.Name)
+            .Select(c => $"{c.Name}/{c.Version}");
+        referencedFileComponents.Should().Equal("Some.Package/1.2.3", "Transitive.Dependency/4.5.6");
+    }
+
+    [TestMethod]
+    public async Task RemovedPackagesAreNotReported()
+    {
+        // This is a very specific scenario that should be tested, but we don't want any changes to this repo's SDK to
+        // change the outcome of the test, so we're doing it manually.  The scenario is the SDK knowingly replacing an
+        // assembly from an outdated transitive package.  One example common in the wild is the package
+        // `Microsoft.Extensions.Configuration.Json/6.0.0` which contains a transitive dependency on
+        // `System.Text.Json/6.0.0`, but the SDK version 6.0.424 or later pulls this reference out of the dependency
+        // set and replaces the .dll with a local updated copy.  The end result is the `package.assets.json` file
+        // reports that `System.Text.Json/6.0.0` is referenced by a project, but after build and at runtime, this isn't
+        // the case and can lead to false positives when reporting dependencies.  The way the SDK accomplishes this is
+        // by removing `System.Text.Json.dll` from the group `@(RuntimeCopyLocalItems)`.  To accomplish this in the
+        // test, we're inserting a custom target that does this same action.
+        var (scanResult, componentRecorder) = await this.ExecuteDetectorAndGetBinLogAsync(
+            projectContents: $@"
+                <Project Sdk=""Microsoft.NET.Sdk"">
+                  <PropertyGroup>
+                    <TargetFramework>{MSBuildTestUtilities.TestTargetFramework}</TargetFramework>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <PackageReference Include=""Some.Package"" Version=""1.2.3"" />
+                  </ItemGroup>
+                  <Target Name=""TEST_RemovePackageWithOutdatedVersion"" BeforeTargets=""GenerateBuildDependencyFile"" AfterTargets=""ResolveAssemblyReferences"">
+                    <ItemGroup>
+                      <!-- The SDK removes the specific .dll with metadata from the original package. -->
+                      <RuntimeCopyLocalItems Remove=""$(NUGET_PACKAGES)/**/Transitive.Dependency.dll"" NuGetPackageId=""Transitive.Dependency"" NuGetPackageVersion=""4.5.6"" />
+                    </ItemGroup>
+                  </Target>
+                </Project>
+                ",
+            mockedPackages: new[]
+                {
+                    ("Some.Package", "1.2.3", MSBuildTestUtilities.TestTargetFramework, "<dependencies><dependency id=\"Transitive.Dependency\" version=\"4.5.6\" /></dependencies>"),
+                    ("Transitive.Dependency", "4.5.6", MSBuildTestUtilities.TestTargetFramework, null),
+                });
+
+        var detectedComponents = componentRecorder.GetDetectedComponents();
+
+        var packages = detectedComponents.Select(d => d.Component).Cast<NuGetComponent>().OrderBy(c => c.Name).Select(c => $"{c.Name}/{c.Version}");
+        packages.Should().Equal("Some.Package/1.2.3");
+    }
+
+    private async Task<(Contracts.IndividualDetectorScanResult ScanResult, Contracts.IComponentRecorder ComponentRecorder)> ExecuteDetectorAndGetBinLogAsync(
+        string projectContents,
+        (string FileName, string Content)[] additionalFiles = null,
+        (string Name, string Version, string TargetFramework, string DependenciesXml)[] mockedPackages = null)
+    {
+        using var binLogStream = await MSBuildTestUtilities.GetBinLogStreamFromFileContentsAsync(projectContents, additionalFiles, mockedPackages);
+        var (scanResult, componentRecorder) = await this.DetectorTestUtility
+            .WithFile("msbuild.binlog", binLogStream)
+            .ExecuteDetectorAsync();
+        return (scanResult, componentRecorder);
+    }
+}

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/Utilities/TemporaryFile.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/Utilities/TemporaryFile.cs
@@ -1,0 +1,41 @@
+﻿namespace Microsoft.ComponentDetection.Detectors.Tests.Utilities;
+
+using System;
+using System.IO;
+
+public sealed class TemporaryFile : IDisposable
+{
+    static TemporaryFile()
+    {
+        TemporaryDirectory = Path.Combine(Path.GetDirectoryName(typeof(TemporaryFile).Assembly.Location), "temporary-files");
+        Directory.CreateDirectory(TemporaryDirectory);
+    }
+
+    // Creates a temporary file in the test directory with the optional given file extension.  The test/debug directory
+    // is used to avoid polluting the user's temp directory and so that a `git clean` operation will remove any
+    // remaining files.
+    public TemporaryFile(string extension = null)
+    {
+        if (extension is not null && !extension.StartsWith("."))
+        {
+            throw new ArgumentException("Extension must start with a period.", nameof(extension));
+        }
+
+        this.FilePath = Path.Combine(TemporaryDirectory, $"{Guid.NewGuid():d}{extension}");
+    }
+
+    private static string TemporaryDirectory { get; }
+
+    public string FilePath { get; }
+
+    public void Dispose()
+    {
+        try
+        {
+            File.Delete(this.FilePath);
+        }
+        catch
+        {
+        }
+    }
+}


### PR DESCRIPTION
Adds a new NuGet component detector to scan MSBuild binary log (`*.binlog`) files.

There was one major reason to add this: the current NuGet component detector that scans `project.assets.json` isn't always 100% accurate.  This can happen when a given NuGet package has a transitive dependency on a `System.*` package, but the installed SDK has a newer version of that file that is replaced at build time.

One common example: a project has `<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />`.  That package has a transitive dependency on `System.Text.Json/6.0.0`.  No matter the SDK used to restore and build the project, the `project.assets.json` file will report that the package `System.Text.Json/6.0.0` was used and implies that it'll be present at runtime.  However, if the `6.0.424` SDK or newer was used to build, the `System.Text.Json.dll` file from the `6.0.0` package is removed and replaced with a newer `System.Text.Json.dll` from the SDK's runtime package.

To avoid reporting a false positive for a package that was replaced at build time (and therefore won't be present at runtime) the MSBuild binary log scanner was added.

If a binary log is generated with the `/bl` flag, every MSBuild event will be recorded.  The new detector in this PR scans each event for the relevant `AddItem` and `RemoveItem` elements (corresponding to things like `<SomeItemGroup Include="..." ... />` and `<SomeItemGroup Remove="..." ... />` and uses that to build a 100% accurate dependency set.

Most of the content of this PR is to support the tests to make them as reliable as possible through 2 different means:

1. Generate a fresh `.binlog` file for each test by running the appropriate `dotnet build ...` command.  This ensures there are no large binary test assets added to this repo; they're simply generated as needed.
2. Mock all necessary NuGet packages to prevent network access.  To accomplish this, 3 common NuGet packages are faked for the tests: `Microsoft.NETCore.App.Ref`, `Microsoft.AspNetCore.App.Ref`, and `Microsoft.WindowsDesktop.App.Ref`.

### Future work

To fully prevent reporting false positives, it would be a good idea to merge the binary log detector and the `project.assets.json` detector so that if a binary log is present and covers a given `.csproj`, _only_ the binary log detector is used and fall back to the original detector otherwise.  Without this work, the binary log detector will properly **not** report `System.Text.Json/6.0.0`, but the `project.assets.json` detector would, so the false positive will still appear.