### PR TITLE
Introduce config as code support

### DIFF
--- a/src/Microsoft.ComponentDetection.Common/ComponentDetectionConfigFileService.cs
+++ b/src/Microsoft.ComponentDetection.Common/ComponentDetectionConfigFileService.cs
@@ -1,0 +1,129 @@
+namespace Microsoft.ComponentDetection.Common;
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.ComponentDetection.Contracts;
+using Microsoft.Extensions.Logging;
+using YamlDotNet.Serialization;
+
+/// <inheritdoc />
+public class ComponentDetectionConfigFileService : IComponentDetectionConfigFileService
+{
+    private const string ComponentDetectionConfigFileEnvVar = "ComponentDetection.ComponentDetectionConfigFile";
+    private readonly IFileUtilityService fileUtilityService;
+    private readonly IEnvironmentVariableService environmentVariableService;
+    private readonly IPathUtilityService pathUtilityService;
+    private readonly ComponentDetectionConfigFile componentDetectionConfig;
+    private readonly ILogger<FastDirectoryWalkerFactory> logger;
+    private bool serviceInitComplete;
+
+    public ComponentDetectionConfigFileService(
+        IFileUtilityService fileUtilityService,
+        IEnvironmentVariableService environmentVariableService,
+        IPathUtilityService pathUtilityService,
+        ILogger<FastDirectoryWalkerFactory> logger)
+    {
+        this.fileUtilityService = fileUtilityService;
+        this.pathUtilityService = pathUtilityService;
+        this.environmentVariableService = environmentVariableService;
+        this.logger = logger;
+        this.componentDetectionConfig = new ComponentDetectionConfigFile();
+        this.serviceInitComplete = false;
+    }
+
+    public ComponentDetectionConfigFile GetComponentDetectionConfig()
+    {
+        this.EnsureInit();
+        return this.componentDetectionConfig;
+    }
+
+    public async Task InitAsync(string explicitConfigPath, string rootDirectoryPath = null)
+    {
+        await this.LoadFromEnvironmentVariableAsync();
+        if (!string.IsNullOrEmpty(explicitConfigPath))
+        {
+            await this.LoadComponentDetectionConfigAsync(explicitConfigPath);
+        }
+
+        if (!string.IsNullOrEmpty(rootDirectoryPath))
+        {
+            await this.LoadComponentDetectionConfigFilesFromRootDirectoryAsync(rootDirectoryPath);
+        }
+
+        this.serviceInitComplete = true;
+    }
+
+    private async Task LoadComponentDetectionConfigFilesFromRootDirectoryAsync(string rootDirectoryPath)
+    {
+        var workingDir = this.pathUtilityService.NormalizePath(rootDirectoryPath);
+
+        var reportFile = new FileInfo(Path.Combine(workingDir, "ComponentDetection.yml"));
+        if (this.fileUtilityService.Exists(reportFile.FullName))
+        {
+            await this.LoadComponentDetectionConfigAsync(reportFile.FullName);
+        }
+    }
+
+    private async Task LoadFromEnvironmentVariableAsync()
+    {
+        if (this.environmentVariableService.DoesEnvironmentVariableExist(ComponentDetectionConfigFileEnvVar))
+        {
+            var possibleConfigFilePath = this.environmentVariableService.GetEnvironmentVariable(ComponentDetectionConfigFileEnvVar);
+            if (this.fileUtilityService.Exists(possibleConfigFilePath))
+            {
+                await this.LoadComponentDetectionConfigAsync(possibleConfigFilePath);
+            }
+        }
+    }
+
+    private async Task LoadComponentDetectionConfigAsync(string configFile)
+    {
+        if (!this.fileUtilityService.Exists(configFile))
+        {
+            throw new InvalidOperationException($"Attempted to load non-existant ComponentDetectionConfig file: {configFile}");
+        }
+
+        var configFileInfo = new FileInfo(configFile);
+        var fileContents = await this.fileUtilityService.ReadAllTextAsync(configFileInfo);
+        var newConfig = this.ParseComponentDetectionConfig(fileContents);
+        this.MergeComponentDetectionConfig(newConfig);
+        this.logger.LogInformation("Loaded component detection config file from {ConfigFile}", configFile);
+    }
+
+    /// <summary>
+    /// Merges two component detection configs, giving precedence to values already set in the first file.
+    /// </summary>
+    /// <param name="newConfig">The new config file to be merged into the existing config set.</param>
+    private void MergeComponentDetectionConfig(ComponentDetectionConfigFile newConfig)
+    {
+        foreach ((var name, var value) in newConfig.Variables)
+        {
+            if (!this.componentDetectionConfig.Variables.ContainsKey(name))
+            {
+                this.componentDetectionConfig.Variables[name] = value;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Reads the component detection config from a file path.
+    /// </summary>
+    /// <param name="configFileContent">The string contents of the config yaml file.</param>
+    /// <returns>The ComponentDetection config file as an object.</returns>
+    private ComponentDetectionConfigFile ParseComponentDetectionConfig(string configFileContent)
+    {
+        var deserializer = new DeserializerBuilder()
+            .IgnoreUnmatchedProperties()
+            .Build();
+        return deserializer.Deserialize<ComponentDetectionConfigFile>(new StringReader(configFileContent));
+    }
+
+    private void EnsureInit()
+    {
+        if (!this.serviceInitComplete)
+        {
+            throw new InvalidOperationException("ComponentDetection config files have not been loaded yet!");
+        }
+    }
+}

--- a/src/Microsoft.ComponentDetection.Common/IComponentDetectionConfigFileService.cs
+++ b/src/Microsoft.ComponentDetection.Common/IComponentDetectionConfigFileService.cs
@@ -1,0 +1,25 @@
+namespace Microsoft.ComponentDetection.Common;
+
+using System.Threading.Tasks;
+using Microsoft.ComponentDetection.Contracts;
+
+/// <summary>
+/// Provides methods for writing files.
+/// </summary>
+public interface IComponentDetectionConfigFileService
+{
+    /// <summary>
+    /// Initializes the Component detection config service.
+    /// Checks the following for the presence of a config file:
+    /// 1. The environment variable "ComponentDetection.ConfigFilePath" and the path exists
+    /// 2. If there is a file present at the root directory named "ComponentDetection.yml".
+    /// </summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    Task InitAsync(string explicitConfigPath, string rootDirectoryPath = null);
+
+    /// <summary>
+    /// Retrieves the merged config files.
+    /// </summary>
+    /// <returns>The ComponentDetection config file as an object.</returns>
+    ComponentDetectionConfigFile GetComponentDetectionConfig();
+}

--- a/src/Microsoft.ComponentDetection.Common/Microsoft.ComponentDetection.Common.csproj
+++ b/src/Microsoft.ComponentDetection.Common/Microsoft.ComponentDetection.Common.csproj
@@ -5,6 +5,7 @@
         <PackageReference Include="Microsoft.Extensions.Logging" />
         <PackageReference Include="System.Reactive" />
         <PackageReference Include="System.Threading.Tasks.Dataflow" />
+        <PackageReference Include="yamldotnet" />
     </ItemGroup>
 
     <ItemGroup Label="Package References">

--- a/src/Microsoft.ComponentDetection.Contracts/ComponentDetectionConfigFile.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/ComponentDetectionConfigFile.cs
@@ -1,0 +1,16 @@
+namespace Microsoft.ComponentDetection.Contracts;
+
+using System.Collections.Generic;
+using YamlDotNet.Serialization;
+
+/// <summary>
+/// Represents the ComponentDetection.yml config file.
+/// </summary>
+public class ComponentDetectionConfigFile
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether the detection should be stopped.
+    /// </summary>
+    [YamlMember(Alias = "variables")]
+    public Dictionary<string, string> Variables { get; set; } = [];
+}

--- a/src/Microsoft.ComponentDetection.Contracts/Microsoft.ComponentDetection.Contracts.csproj
+++ b/src/Microsoft.ComponentDetection.Contracts/Microsoft.ComponentDetection.Contracts.csproj
@@ -8,6 +8,7 @@
         <PackageReference Include="Microsoft.Extensions.Logging" />
         <PackageReference Include="Newtonsoft.Json" />
         <PackageReference Include="packageurl-dotnet" />
+        <PackageReference Include="yamldotnet" />
         <PackageReference Include="System.Memory" />
         <PackageReference Include="System.Reactive" />
         <PackageReference Include="System.Text.Json" />

--- a/src/Microsoft.ComponentDetection.Orchestrator/Commands/BaseSettings.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Commands/BaseSettings.cs
@@ -37,6 +37,10 @@ public abstract class BaseSettings : CommandSettings
     [CommandOption("--Output")]
     public string Output { get; set; }
 
+    [Description("File path for a ComponentDetection.yml config file with more instructions for detection")]
+    [CommandOption("--ComponentDetectionConfigFile")]
+    public string ComponentDetectionConfigFile { get; set; }
+
     /// <inheritdoc />
     public override ValidationResult Validate()
     {

--- a/src/Microsoft.ComponentDetection.Orchestrator/Commands/ScanCommand.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Commands/ScanCommand.cs
@@ -18,6 +18,7 @@ public sealed class ScanCommand : AsyncCommand<ScanSettings>
     private const string ManifestRelativePath = "ScanManifest_{timestamp}.json";
     private readonly IFileWritingService fileWritingService;
     private readonly IScanExecutionService scanExecutionService;
+    private readonly IComponentDetectionConfigFileService componentDetectionConfigFileService;
     private readonly ILogger<ScanCommand> logger;
 
     /// <summary>
@@ -25,14 +26,17 @@ public sealed class ScanCommand : AsyncCommand<ScanSettings>
     /// </summary>
     /// <param name="fileWritingService">The file writing service.</param>
     /// <param name="scanExecutionService">The scan execution service.</param>
+    /// <param name="componentDetectionConfigFileService">The component detection config file service.</param>
     /// <param name="logger">The logger.</param>
     public ScanCommand(
         IFileWritingService fileWritingService,
         IScanExecutionService scanExecutionService,
+        IComponentDetectionConfigFileService componentDetectionConfigFileService,
         ILogger<ScanCommand> logger)
     {
         this.fileWritingService = fileWritingService;
         this.scanExecutionService = scanExecutionService;
+        this.componentDetectionConfigFileService = componentDetectionConfigFileService;
         this.logger = logger;
     }
 
@@ -40,6 +44,7 @@ public sealed class ScanCommand : AsyncCommand<ScanSettings>
     public override async Task<int> ExecuteAsync(CommandContext context, ScanSettings settings)
     {
         this.fileWritingService.Init(settings.Output);
+        await this.componentDetectionConfigFileService.InitAsync(settings.ComponentDetectionConfigFile, settings.SourceDirectory.FullName);
         var result = await this.scanExecutionService.ExecuteScanAsync(settings);
         this.WriteComponentManifest(settings, result);
         return 0;

--- a/src/Microsoft.ComponentDetection.Orchestrator/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Extensions/ServiceCollectionExtensions.cs
@@ -46,6 +46,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IEnvironmentVariableService, EnvironmentVariableService>();
         services.AddSingleton<IObservableDirectoryWalkerFactory, FastDirectoryWalkerFactory>();
         services.AddSingleton<IFileUtilityService, FileUtilityService>();
+        services.AddSingleton<IComponentDetectionConfigFileService, ComponentDetectionConfigFileService>();
         services.AddSingleton<IDirectoryUtilityService, DirectoryUtilityService>();
         services.AddSingleton<IFileWritingService, FileWritingService>();
         services.AddSingleton<IGraphTranslationService, DefaultGraphTranslationService>();

--- a/test/Microsoft.ComponentDetection.Orchestrator.Tests/Commands/ScanCommandTests.cs
+++ b/test/Microsoft.ComponentDetection.Orchestrator.Tests/Commands/ScanCommandTests.cs
@@ -19,6 +19,7 @@ public class ScanCommandTests
 {
     private Mock<IFileWritingService> fileWritingServiceMock;
     private Mock<IScanExecutionService> scanExecutionServiceMock;
+    private Mock<IComponentDetectionConfigFileService> componentDetectionConfigFileServiceMock;
     private Mock<ILogger<ScanCommand>> loggerMock;
     private ScanCommand command;
 
@@ -27,11 +28,13 @@ public class ScanCommandTests
     {
         this.fileWritingServiceMock = new Mock<IFileWritingService>();
         this.scanExecutionServiceMock = new Mock<IScanExecutionService>();
+        this.componentDetectionConfigFileServiceMock = new Mock<IComponentDetectionConfigFileService>();
         this.loggerMock = new Mock<ILogger<ScanCommand>>();
 
         this.command = new ScanCommand(
             this.fileWritingServiceMock.Object,
             this.scanExecutionServiceMock.Object,
+            this.componentDetectionConfigFileServiceMock.Object,
             this.loggerMock.Object);
     }
 


### PR DESCRIPTION
Introduces the ability to use code files in source to set config settings. 

As an MVP, supports a yaml file ComponentDetection.yml that can store a variables dictionary

Ex
```
variables:
  key: "value"
```

The values in these config files are ordered in priority:
1. Any config file set as the environment variable `ComponentDetection.ComponentDetectionConfigFile`
2. Any config file passed as an argument: `--ComponentDetectionConfigFile`
3. Any `ComponentDetection.yml` file present in the root directory being scanned. 