### PR TITLE
Fix detector component filepath custom overrides

### DIFF
--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/GraphTranslation/DefaultGraphTranslationService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/GraphTranslation/DefaultGraphTranslationService.cs
@@ -103,7 +103,11 @@ public class DefaultGraphTranslationService : IGraphTranslationService
                     // clone custom locations and make them relative to root.
                     var declaredRawFilePaths = component.FilePaths ?? [];
                     var componentCustomLocations = JsonConvert.DeserializeObject<HashSet<string>>(JsonConvert.SerializeObject(declaredRawFilePaths));
-                    component.FilePaths?.Clear();
+
+                    if (updateLocations)
+                    {
+                        component.FilePaths?.Clear();
+                    }
 
                     // Information about each component is relative to all of the graphs it is present in, so we take all graphs containing a given component and apply the graph data.
                     foreach (var graphKvp in dependencyGraphsByLocation.Where(x => x.Value.Contains(component.Component.Id)))
@@ -269,7 +273,7 @@ public class DefaultGraphTranslationService : IGraphTranslationService
             try
             {
                 var relativePath = rootUri.MakeRelativeUri(new Uri(path)).ToString();
-                if (!relativePath.StartsWith('/'))
+                if (!relativePath.StartsWith('/') && !relativePath.Contains(':', StringComparison.CurrentCultureIgnoreCase))
                 {
                     relativePath = "/" + relativePath;
                 }

--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/GraphTranslation/DefaultGraphTranslationService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/GraphTranslation/DefaultGraphTranslationService.cs
@@ -273,7 +273,7 @@ public class DefaultGraphTranslationService : IGraphTranslationService
             try
             {
                 var relativePath = rootUri.MakeRelativeUri(new Uri(path)).ToString();
-                if (!relativePath.StartsWith('/') && !relativePath.Contains(':', StringComparison.CurrentCultureIgnoreCase))
+                if (!relativePath.StartsWith('/'))
                 {
                     relativePath = "/" + relativePath;
                 }

--- a/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/DefaultGraphTranslationServiceTests.cs
+++ b/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/DefaultGraphTranslationServiceTests.cs
@@ -156,7 +156,8 @@ public class DefaultGraphTranslationServiceTests
         var resultNpmComponent = result.ComponentsFound.Single(c => c.Component.Type == ComponentType.Npm);
         var resultNugetComponent = result.ComponentsFound.Single(c => c.Component.Type == ComponentType.NuGet);
 
-        resultNpmComponent.LocationsFoundAt.Should().BeEquivalentTo([npmCustomPath, detectedFilePath, relatedFilePath, npmCustomPath2]);
+        // for now there is a bug that adds a forward slash to the path for symbolic links. This will be fixed in a future PR if we can parse dependency graph better for those.
+        resultNpmComponent.LocationsFoundAt.Should().BeEquivalentTo([npmCustomPath, detectedFilePath, relatedFilePath, $"/{npmCustomPath2}"]);
         resultNugetComponent.LocationsFoundAt.Should().BeEquivalentTo([nugetCustomPath, detectedFilePath, relatedFilePath]);
 
         var actualNpmComponent = resultNpmComponent.Component as NpmComponent;


### PR DESCRIPTION
## Context
A detector does not need to specify location where a component was found. Nevertheless, custom wrapper plugins can report additional locations if desired and that shouldn't be blocked. 

In PR https://github.com/microsoft/component-detection/pull/648 a regression occurred while trying to address an experiments framework bug. We don't want to unsuspectingly record locations for experimental detectors before producing the final graph. We added a check to prevent experiments from overriding the graph, but this was partially incomplete, because we are clearing the file paths at the top of the method.

## Solution
Use the same flag to verify if the component file paths should be updated and only clear the list when generating final graph.
