### PR TITLE
Framework package updates

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/nuget/FrameworkPackages/FrameworkPackages.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/nuget/FrameworkPackages/FrameworkPackages.cs
@@ -23,6 +23,7 @@ internal sealed partial class FrameworkPackages : IEnumerable<KeyValuePair<strin
     {
         NETStandard20.Register();
         NETStandard21.Register();
+        NET461.Register();
         NETCoreApp20.Register();
         NETCoreApp21.Register();
         NETCoreApp22.Register();

--- a/src/Microsoft.ComponentDetection.Detectors/nuget/FrameworkPackages/FrameworkPackages.net461.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/nuget/FrameworkPackages/FrameworkPackages.net461.cs
@@ -1,0 +1,16 @@
+namespace Microsoft.ComponentDetection.Detectors.NuGet;
+
+using static global::NuGet.Frameworks.FrameworkConstants.CommonFrameworks;
+
+/// <summary>
+/// Framework packages for .NETFramework,Version=v4.6.1.
+/// </summary>
+internal partial class FrameworkPackages
+{
+    internal static class NET461
+    {
+        internal static FrameworkPackages Instance { get; } = new(Net461, DefaultFrameworkKey, NETStandard20.Instance);
+
+        internal static void Register() => FrameworkPackages.Register(Instance);
+    }
+}

--- a/src/Microsoft.ComponentDetection.Detectors/nuget/FrameworkPackages/FrameworkPackages.netcoreapp2.0.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/nuget/FrameworkPackages/FrameworkPackages.netcoreapp2.0.cs
@@ -12,6 +12,7 @@ internal partial class FrameworkPackages
         internal static FrameworkPackages Instance { get; } = new(NetCoreApp20, FrameworkNames.NetCoreApp, NETStandard20.Instance)
         {
             { "Microsoft.CSharp", "4.4.0" },
+            { "Microsoft.NETCore.App", "2.0.0" },
             { "Microsoft.VisualBasic", "10.2.0" },
             { "Microsoft.Win32.Registry", "4.4.0" },
             { "runtime.any.System.Collections", "4.3.0" },
@@ -182,6 +183,7 @@ internal partial class FrameworkPackages
             { "System.Numerics.Vectors", "4.4.0" },
             { "System.ObjectModel", "4.3.0" },
             { "System.Private.DataContractSerialization", "4.3.0" },
+            { "System.Private.Uri", "4.3.0" },
             { "System.Reflection.DispatchProxy", "4.4.0" },
             { "System.Reflection.Emit", "4.7.0" },
             { "System.Reflection.Emit.ILGeneration", "4.7.0" },

--- a/src/Microsoft.ComponentDetection.Detectors/nuget/FrameworkPackages/FrameworkPackages.netcoreapp2.1.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/nuget/FrameworkPackages/FrameworkPackages.netcoreapp2.1.cs
@@ -12,6 +12,7 @@ internal partial class FrameworkPackages
         internal static FrameworkPackages Instance { get; } = new(NetCoreApp21, FrameworkNames.NetCoreApp, NETCoreApp20.Instance)
         {
             { "Microsoft.CSharp", "4.5.0" },
+            { "Microsoft.NETCore.App", "2.1.0" },
             { "Microsoft.VisualBasic", "10.3.0" },
             { "Microsoft.Win32.Registry", "4.5.0" },
             { "System.Buffers", "4.5.0" },


### PR DESCRIPTION
### Include non-implementation packages on .NETCore 2.x
Microsoft.NETCore.App contains only reference assemblies, but it was listed in CVEs, so should be excluded.  The same is true for System.Private.Uri.
I did not include these previously because they weren't part of package overrides list, nor were they found through package comparisons - since conflict resolution doesn't need to do anything with non-implementation packages.  They are important for CG though since they've been used in CVE reports.

### Include framework packages for .NET 4.6.1
.NET 4.6.1 supports .NET Standard and has built in support for it that will win over nuget packages.
In .NET 4.6.1 - .NET 4.7.1 this comes from the Microsoft.NET.Build.Extensions component, after that it's built into the framework itself.

@grvillic 