### PR TITLE
Fix Experiments evaluation of new dep dependencies

### DIFF
--- a/src/Microsoft.ComponentDetection.Orchestrator/Experiments/Models/ExperimentDiff.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Experiments/Models/ExperimentDiff.cs
@@ -39,6 +39,18 @@ public class ExperimentDiff
         var controlDetectorList = new List<ExperimentDetector>();
         var experimentDetectorList = new List<ExperimentDetector>();
 
+        foreach (var id in this.AddedIds)
+        {
+            var newComponent = newComponentDictionary[id];
+            if (newComponent.DevelopmentDependency)
+            {
+                developmentDependencyChanges.Add(new DevelopmentDependencyChange(
+                    id,
+                    false, // Old value is false because the component was not present in the old dictionary
+                    newComponent.DevelopmentDependency));
+            }
+        }
+
         // Need performance benchmark to see if this is worth parallelization
         foreach (var id in newComponentDictionary.Keys.Intersect(oldComponentDictionary.Keys))
         {

--- a/src/Microsoft.ComponentDetection.Orchestrator/Experiments/Models/ExperimentDiff.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Experiments/Models/ExperimentDiff.cs
@@ -39,23 +39,24 @@ public class ExperimentDiff
         var controlDetectorList = new List<ExperimentDetector>();
         var experimentDetectorList = new List<ExperimentDetector>();
 
-        foreach (var id in this.AddedIds)
-        {
-            var newComponent = newComponentDictionary[id];
-            if (newComponent.DevelopmentDependency)
-            {
-                developmentDependencyChanges.Add(new DevelopmentDependencyChange(
-                    id,
-                    oldValue: false,
-                    newValue: newComponent.DevelopmentDependency));
-            }
-        }
-
         // Need performance benchmark to see if this is worth parallelization
-        foreach (var id in newComponentDictionary.Keys.Intersect(oldComponentDictionary.Keys))
+        foreach (var newComponentPair in newComponentDictionary)
         {
-            var oldComponent = oldComponentDictionary[id];
-            var newComponent = newComponentDictionary[id];
+            var newComponent = newComponentPair.Value;
+            var id = newComponentPair.Key;
+
+            if (!oldComponentDictionary.TryGetValue(id, out var oldComponent))
+            {
+                if (newComponent.DevelopmentDependency)
+                {
+                    developmentDependencyChanges.Add(new DevelopmentDependencyChange(
+                        id,
+                        oldValue: false,
+                        newValue: newComponent.DevelopmentDependency));
+                }
+
+                continue;
+            }
 
             if (oldComponent.DevelopmentDependency != newComponent.DevelopmentDependency)
             {

--- a/src/Microsoft.ComponentDetection.Orchestrator/Experiments/Models/ExperimentDiff.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Experiments/Models/ExperimentDiff.cs
@@ -46,8 +46,8 @@ public class ExperimentDiff
             {
                 developmentDependencyChanges.Add(new DevelopmentDependencyChange(
                     id,
-                    false, // Old value is false because the component was not present in the old dictionary
-                    newComponent.DevelopmentDependency));
+                    oldValue: false,
+                    newValue: newComponent.DevelopmentDependency));
             }
         }
 

--- a/test/Microsoft.ComponentDetection.Orchestrator.Tests/Experiments/ExperimentDiffTests.cs
+++ b/test/Microsoft.ComponentDetection.Orchestrator.Tests/Experiments/ExperimentDiffTests.cs
@@ -139,4 +139,27 @@ public class ExperimentDiffTests
 
         action.Should().NotThrow();
     }
+
+    [TestMethod]
+    public void ExperimentDiff_DiffsAddedDevDependenciesMissingInControlGroup()
+    {
+        var componentA = ExperimentTestUtils.CreateRandomScannedComponent();
+        componentA.IsDevelopmentDependency = true;
+
+        var diff = new ExperimentDiff(
+            [],
+            [new ExperimentComponent(componentA)]);
+
+        diff.DevelopmentDependencyChanges.Should().ContainSingle();
+
+        var change = diff.DevelopmentDependencyChanges.First();
+        change.Id.Should().Be(componentA.Component.Id);
+        change.OldValue.Should().BeFalse();
+        change.NewValue.Should().BeTrue();
+
+        diff.AddedIds.Should().BeEquivalentTo([componentA.Component.Id]);
+        diff.RemovedIds.Should().BeEmpty();
+        diff.AddedRootIds.Should().BeEmpty();
+        diff.RemovedRootIds.Should().BeEmpty();
+    }
 }


### PR DESCRIPTION
## Context
As we were evaluating the .NET experiment for new detector, we noticed a bug in our experimental diffing evaluation. If a new dev dependency is introduced that is not reported in control group, it should still be reported as a dev dependency. As of now, that component only gets added to the `AddedIds` but it never gets flagged as dev dependency.