### PR TITLE
Add Swift Package Manager component detection support

### DIFF
--- a/.github/workflows/snapshot-publish.yml
+++ b/.github/workflows/snapshot-publish.yml
@@ -2,6 +2,8 @@ name: Publish snapshot of test scan
 
 env:
   CD_DETECTOR_EXPERIMENTS: 1
+  PipReportSkipFallbackOnFailure: "true"
+  PIP_INDEX_URL: "https://pypi.python.org/simple"
 
 on:
   push:
@@ -54,7 +56,7 @@ jobs:
         run:
           dotnet run scan --Verbosity Verbose --SourceDirectory ${{ github.workspace }}/test/Microsoft.ComponentDetection.VerificationTests/resources --Output ${{ github.workspace }}/output
           --DockerImagesToScan "docker.io/library/debian@sha256:9b0e3056b8cd8630271825665a0613cc27829d6a24906dc0122b3b4834312f7d,mcr.microsoft.com/cbl-mariner/base/core@sha256:c1bc83a3d385eccbb2f7f7da43a726c697e22a996f693a407c35ac7b4387cd59,docker.io/library/alpine@sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870"
-          --DetectorArgs DockerReference=EnableIfDefaultOff,SPDX22SBOM=EnableIfDefaultOff,SimplePip=EnableIfDefaultOff
+          --DetectorArgs DockerReference=EnableIfDefaultOff,SPDX22SBOM=EnableIfDefaultOff
 
       - name: Upload output folder
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3

--- a/docs/detectors/swiftpm.md
+++ b/docs/detectors/swiftpm.md
@@ -1,0 +1,24 @@
+# Go Detection
+
+## Requirements
+
+Swift Package Manager detection requires the following file to be present in the scan directory:
+
+-   `Package.resolved` file
+
+## Detection strategy
+
+The detector `SwiftPMResolvedComponentDetector` only parses the `Package.resolved` file to get the dependencies.
+This file contains a json representation of the resolved dependencies of the project with the transitive dependencies.
+The version, the url and commit hash of the dependencies are stored in this file. 
+
+[This is the only reference in the Apple documentation to the `Package.resolved` file.][1]
+
+
+## Known limitations
+
+Right now the detector does not support parsing `Package.swift` file to get the dependencies. 
+It only supports parsing `Package.resolved` file. 
+Some projects only commit the `Package.swift`, which is why it is planned to support parsing `Package.swift` in the future.
+
+[1]: https://docs.swift.org/package-manager/PackageDescription/PackageDescription.html#package-dependency

--- a/src/Microsoft.ComponentDetection.Contracts/DetectorClass.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/DetectorClass.cs
@@ -44,4 +44,7 @@ public enum DetectorClass
 
     /// <summary>Indicates a detector applies to Docker references.</summary>
     DockerReference,
+
+    /// <summary> Indicates a detector applies to SwiftPM packages.</summary>
+    SwiftPM,
 }

--- a/src/Microsoft.ComponentDetection.Contracts/TypedComponent/ComponentType.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/TypedComponent/ComponentType.cs
@@ -56,4 +56,7 @@ public enum ComponentType : byte
 
     [EnumMember]
     Conan = 17,
+
+    [EnumMember]
+    SwiftPM = 18,
 }

--- a/src/Microsoft.ComponentDetection.Contracts/TypedComponent/SwiftPMComponent.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/TypedComponent/SwiftPMComponent.cs
@@ -1,0 +1,50 @@
+namespace Microsoft.ComponentDetection.Contracts.TypedComponent;
+
+using System;
+using System.Collections.Generic;
+using PackageUrl;
+
+/// <summary>
+/// Represents a SwiftPM component.
+/// </summary>
+public class SwiftPMComponent : TypedComponent
+{
+    private readonly string packageUrl;
+
+    private readonly string hash;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SwiftPMComponent"/> class.
+    /// </summary>
+    /// <param name="name">The name of the component.</param>
+    /// <param name="version">The version of the component.</param>
+    /// <param name="packageUrl">The package URL of the component.</param>
+    /// <param name="hash">The hash of the component.</param>
+    public SwiftPMComponent(string name, string version, string packageUrl, string hash)
+    {
+        this.Name = this.ValidateRequiredInput(name, nameof(name), nameof(ComponentType.SwiftPM));
+        this.Version = this.ValidateRequiredInput(version, nameof(version), nameof(ComponentType.SwiftPM));
+        this.packageUrl = this.ValidateRequiredInput(packageUrl, nameof(packageUrl), nameof(ComponentType.SwiftPM));
+        this.hash = this.ValidateRequiredInput(hash, nameof(hash), nameof(ComponentType.SwiftPM));
+    }
+
+    public string Name { get; }
+
+    public string Version { get; }
+
+    public override ComponentType Type => ComponentType.SwiftPM;
+
+    public override string Id => $"{this.Name} {this.Version} - {this.Type}";
+
+    // The type is swiftpm
+    public PackageURL PackageURL => new PackageURL(
+        type: "swift",
+        @namespace: new Uri(this.packageUrl).Host,
+        name: this.Name,
+        version: this.hash, // Hash has priority over version when creating a PackageURL
+        qualifiers: new SortedDictionary<string, string>
+        {
+            { "repository_url", this.packageUrl },
+        },
+        subpath: null);
+}

--- a/src/Microsoft.ComponentDetection.Detectors/swiftpm/Contracts/SwiftPMResolvedFile.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/swiftpm/Contracts/SwiftPMResolvedFile.cs
@@ -1,0 +1,51 @@
+namespace Microsoft.ComponentDetection.Contracts.TypedComponent;
+
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+/// <summary>
+/// Represents a SwiftPM component.
+/// </summary>
+public class SwiftPMResolvedFile
+{
+    [JsonProperty("pins")]
+    public IList<SwiftPMDependency> Pins { get; set; }
+
+    [JsonProperty("version")]
+    public int Version { get; set; }
+
+    public class SwiftPMDependency
+    {
+        // The name of the package
+        [JsonProperty("identity")]
+        public string Identity { get; set; }
+
+        // How the package is imported. Example: "remoteSourceControl"
+        // This is not an enum because the SwiftPM contract does not specify the possible values.
+        [JsonProperty("kind")]
+        public string Kind { get; set; }
+
+        // The unique path to the repository where the package is located. Example: Git repo URL.
+        [JsonProperty("location")]
+        public string Location { get; set; }
+
+        // Data about the package version and commit hash.
+        [JsonProperty("state")]
+        public SwiftPMState State { get; set; }
+
+        public class SwiftPMState
+        {
+            // The commit hash of the package.
+            [JsonProperty("revision")]
+            public string Revision { get; set; }
+
+            // The version of the package. Might be missing.
+            [JsonProperty("version")]
+            public string Version { get; set; }
+
+            // The branch of the package. Might be missing.
+            [JsonProperty("branch")]
+            public string Branch { get; set; }
+        }
+    }
+}

--- a/src/Microsoft.ComponentDetection.Detectors/swiftpm/SwiftPMResolvedComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/swiftpm/SwiftPMResolvedComponentDetector.cs
@@ -1,0 +1,105 @@
+namespace Microsoft.ComponentDetection.Detectors.SwiftPM;
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.ComponentDetection.Contracts;
+using Microsoft.ComponentDetection.Contracts.Internal;
+using Microsoft.ComponentDetection.Contracts.TypedComponent;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+/// <summary>
+/// Detects SwiftPM components.
+/// </summary>
+public class SwiftPMResolvedComponentDetector : FileComponentDetector, IDefaultOffComponentDetector
+{
+    public SwiftPMResolvedComponentDetector(
+        IComponentStreamEnumerableFactory componentStreamEnumerableFactory,
+        IObservableDirectoryWalkerFactory walkerFactory,
+        ILogger<SwiftPMResolvedComponentDetector> logger)
+    {
+        this.ComponentStreamEnumerableFactory = componentStreamEnumerableFactory;
+        this.Scanner = walkerFactory;
+        this.Logger = logger;
+    }
+
+    public override string Id { get; } = "SwiftPM";
+
+    public override IEnumerable<string> Categories => [Enum.GetName(DetectorClass.SwiftPM)];
+
+    public override IList<string> SearchPatterns { get; } = ["Package.resolved"];
+
+    public override IEnumerable<ComponentType> SupportedComponentTypes => [ComponentType.SwiftPM];
+
+    public override int Version => 2;
+
+    protected override Task OnFileFoundAsync(
+        ProcessRequest processRequest,
+        IDictionary<string, string> detectorArgs,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            this.ProcessPackageResolvedFile(processRequest.SingleFileComponentRecorder, processRequest.ComponentStream);
+        }
+        catch (Exception exception)
+        {
+            this.Logger.LogError(exception, "SwiftPMComponentDetector: Error processing Package.resolved file: {Location}", processRequest.ComponentStream.Location);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private void ProcessPackageResolvedFile(ISingleFileComponentRecorder singleFileComponentRecorder, IComponentStream componentStream)
+    {
+        var parsedResolvedFile = this.ReadAndParseResolvedFile(componentStream.Stream);
+
+        foreach (var package in parsedResolvedFile.Pins)
+        {
+            // We are only interested in packages coming from remote sources such as git
+            // The Package Kind is not an enum because the SwiftPM contract does not specify the possible values.
+            var targetSwiftPackageKind = "remoteSourceControl";
+            if (package.Kind == targetSwiftPackageKind)
+            {
+                // The version of the package is not always available.
+                var version = package.State.Version ?? package.State.Branch ?? package.State.Revision;
+
+                var detectedSwiftPMComponent = new SwiftPMComponent(
+                    name: package.Identity,
+                    version: version,
+                    packageUrl: package.Location,
+                    hash: package.State.Revision);
+                var newDetectedSwiftComponent = new DetectedComponent(component: detectedSwiftPMComponent, detector: this);
+                singleFileComponentRecorder.RegisterUsage(newDetectedSwiftComponent);
+
+                // We also register a Git component for the same package so that the git URL is registered.
+                // SwiftPM directly downloads the package from the git URL.
+                var detectedGitComponent = new GitComponent(
+                    repositoryUrl: new Uri(package.Location),
+                    commitHash: package.State.Revision,
+                    tag: version);
+                var newDetectedGitComponent = new DetectedComponent(component: detectedGitComponent, detector: this);
+                singleFileComponentRecorder.RegisterUsage(newDetectedGitComponent);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Reads the stream of the package resolved file and parses it.
+    /// </summary>
+    /// <param name="stream">The stream of the file to parse.</param>
+    /// <returns>The parsed object.</returns>
+    private SwiftPMResolvedFile ReadAndParseResolvedFile(Stream stream)
+    {
+        string resolvedFile;
+        using (var reader = new StreamReader(stream))
+        {
+            resolvedFile = reader.ReadToEnd();
+        }
+
+        return JsonConvert.DeserializeObject<SwiftPMResolvedFile>(resolvedFile);
+    }
+}

--- a/src/Microsoft.ComponentDetection.Orchestrator/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Extensions/ServiceCollectionExtensions.cs
@@ -19,6 +19,7 @@ using Microsoft.ComponentDetection.Detectors.Poetry;
 using Microsoft.ComponentDetection.Detectors.Ruby;
 using Microsoft.ComponentDetection.Detectors.Rust;
 using Microsoft.ComponentDetection.Detectors.Spdx;
+using Microsoft.ComponentDetection.Detectors.SwiftPM;
 using Microsoft.ComponentDetection.Detectors.Vcpkg;
 using Microsoft.ComponentDetection.Detectors.Yarn;
 using Microsoft.ComponentDetection.Detectors.Yarn.Parsers;
@@ -141,6 +142,9 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IYarnLockParser, YarnLockParser>();
         services.AddSingleton<IYarnLockFileFactory, YarnLockFileFactory>();
         services.AddSingleton<IComponentDetector, YarnLockComponentDetector>();
+
+        // SwiftPM
+        services.AddSingleton<IComponentDetector, SwiftPMResolvedComponentDetector>();
 
         return services;
     }

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/SwiftPMComponentTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/SwiftPMComponentTests.cs
@@ -1,0 +1,80 @@
+namespace Microsoft.ComponentDetection.Detectors.Tests.SwiftPM;
+
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using Microsoft.ComponentDetection.Contracts.TypedComponent;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PackageUrl;
+
+[TestClass]
+public class SwiftPMComponentTests
+{
+    [TestMethod]
+    public void Constructor_ShouldInitializeProperties()
+    {
+        var name = "alamofire";
+        var version = "5.9.1";
+        var packageUrl = "https://github.com/Alamofire/Alamofire";
+        var hash = "f455c2975872ccd2d9c81594c658af65716e9b9a";
+
+        var component = new SwiftPMComponent(name, version, packageUrl, hash);
+
+        component.Name.Should().Be(name);
+        component.Version.Should().Be(version);
+        component.Type.Should().Be(ComponentType.SwiftPM);
+        component.Id.Should().Be($"{name} {version} - {component.Type}");
+    }
+
+    [TestMethod]
+    public void Constructor_ShouldThrowException_WhenNameIsNull()
+    {
+        Action action = () => new SwiftPMComponent(null, "5.9.1", "https://github.com/Alamofire/Alamofire", "f455c2975872ccd2d9c81594c658af65716e9b9a");
+        action.Should().Throw<ArgumentException>().WithMessage("*name*");
+    }
+
+    [TestMethod]
+    public void Constructor_ShouldThrowException_WhenVersionIsNull()
+    {
+        Action action = () => new SwiftPMComponent("alamofire", null, "https://github.com/Alamofire/Alamofire", "f455c2975872ccd2d9c81594c658af65716e9b9a");
+        action.Should().Throw<ArgumentException>().WithMessage("*version*");
+    }
+
+    [TestMethod]
+    public void Constructor_ShouldThrowException_WhenPackageUrlIsNull()
+    {
+        Action action = () => new SwiftPMComponent("alamofire", "5.9.1", null, "f455c2975872ccd2d9c81594c658af65716e9b9a");
+        action.Should().Throw<ArgumentException>().WithMessage("*packageUrl*");
+    }
+
+    [TestMethod]
+    public void Constructor_ShouldThrowException_WhenHashIsNull()
+    {
+        Action action = () => new SwiftPMComponent("alamofire", "5.9.1", "https://github.com/Alamofire/Alamofire", null);
+        action.Should().Throw<ArgumentException>().WithMessage("*hash*");
+    }
+
+    [TestMethod]
+    public void PackageURL_ShouldReturnCorrectPackageURL()
+    {
+        var name = "alamofire";
+        var version = "5.9.1";
+        var packageUrl = "https://github.com/Alamofire/Alamofire";
+        var hash = "f455c2975872ccd2d9c81594c658af65716e9b9a";
+
+        var component = new SwiftPMComponent(name, version, packageUrl, hash);
+
+        var expectedPackageURL = new PackageURL(
+            type: "swift",
+            @namespace: "github.com",
+            name: name,
+            version: hash,
+            qualifiers: new SortedDictionary<string, string>
+            {
+                { "repository_url", packageUrl },
+            },
+            subpath: null);
+
+        component.PackageURL.Should().BeEquivalentTo(expectedPackageURL);
+    }
+}

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/SwiftPMResolvedDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/SwiftPMResolvedDetectorTests.cs
@@ -1,0 +1,471 @@
+namespace Microsoft.ComponentDetection.Detectors.Tests.SwiftPM;
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.ComponentDetection.Contracts;
+using Microsoft.ComponentDetection.Contracts.TypedComponent;
+using Microsoft.ComponentDetection.Detectors.SwiftPM;
+using Microsoft.ComponentDetection.TestsUtilities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[TestClass]
+public class SwiftPMResolvedDetectorTests : BaseDetectorTest<SwiftPMResolvedComponentDetector>
+{
+    [TestMethod]
+    public async Task Test_GivenDetectorWithValidFile_WhenScan_ThenScanIsSuccessfulAndComponentsAreRegistered()
+    {
+        var validResolvedPackageFile = """
+{
+    "pins" : [
+        {
+            "identity" : "alamofire",
+            "kind" : "remoteSourceControl",
+            "location" : "https://github.com/Alamofire/Alamofire",
+            "state" : {
+                "revision" : "f455c2975872ccd2d9c81594c658af65716e9b9a",
+                "version" : "5.9.1"
+            }
+        }
+    ],
+    "version" : 2
+}
+""";
+        var (scanResult, componentRecorder) = await this.DetectorTestUtility.WithFile(
+            "Package.resolved",
+            validResolvedPackageFile)
+            .ExecuteDetectorAsync();
+
+        scanResult.ResultCode.Should().Be(ProcessingResultCode.Success);
+
+        var detectedComponents = componentRecorder.GetDetectedComponents();
+
+        // Two components are detected because this detector registers a SwiftPM and Git component.
+        detectedComponents.Should().HaveCount(2);
+
+        var typedComponents = detectedComponents.Select(c => c.Component).ToList();
+
+        typedComponents.Should().ContainEquivalentOf(
+            new SwiftPMComponent(
+                name: "alamofire",
+                version: "5.9.1",
+                packageUrl: "https://github.com/Alamofire/Alamofire",
+                hash: "f455c2975872ccd2d9c81594c658af65716e9b9a"));
+
+        typedComponents.Should().ContainEquivalentOf(
+            new GitComponent(
+                repositoryUrl: new Uri("https://github.com/Alamofire/Alamofire"),
+                commitHash: "f455c2975872ccd2d9c81594c658af65716e9b9a",
+                tag: "5.9.1"));
+    }
+
+    // Test for several packages
+    [TestMethod]
+    public async Task Test_GivenDetectorWithValidFileWithMultiplePackages_WhenScan_ThenScanIsSuccessfulAndComponentsAreRegistered()
+    {
+        var validLongResolvedPackageFile = this.validLongResolvedPackageFile;
+
+        var (scanResult, componentRecorder) = await this.DetectorTestUtility.WithFile(
+            "Package.resolved",
+            validLongResolvedPackageFile)
+            .ExecuteDetectorAsync();
+
+        scanResult.ResultCode.Should().Be(ProcessingResultCode.Success);
+
+        var detectedComponents = componentRecorder.GetDetectedComponents();
+
+        // Two components are detected because this detector registers a SwiftPM and Git component.
+        detectedComponents.Should().HaveCount(6);
+
+        var typedComponents = detectedComponents.Select(c => c.Component).ToList();
+
+        typedComponents.Should().ContainEquivalentOf(
+            new SwiftPMComponent(
+                name: "alamofire",
+                version: "5.6.0",
+                packageUrl: "https://github.com/Alamofire/Alamofire",
+                hash: "63dfa86548c4e5d5c6fd6ed42f638e388cbce529"));
+
+        typedComponents.Should().ContainEquivalentOf(
+            new GitComponent(
+                repositoryUrl: new Uri("https://github.com/sideeffect-io/AsyncExtensions"),
+                commitHash: "3442d3d046800f1974bda096faaf0ac510b21154",
+                tag: "0.5.3"));
+
+        typedComponents.Should().ContainEquivalentOf(
+            new GitComponent(
+                repositoryUrl: new Uri("https://github.com/devicekit/DeviceKit.git"),
+                commitHash: "d37e70cb2646666dcf276d7d3d4a9760a41ff8a6",
+                tag: "4.9.0"));
+    }
+
+    // Duplicate packages
+    [TestMethod]
+    public async Task Test_GivenDetectorWithValidFileWithDuplicatePackages_WhenScan_ThenScanIsSuccessfulAndComponentsAreRegisteredAndComponentsAreNotDuplicate()
+    {
+        var duplicatePackages = """
+{
+    "pins" : [
+        {
+            "identity" : "alamofire",
+            "kind" : "remoteSourceControl",
+            "location" : "https://github.com/Alamofire/Alamofire",
+            "state" : {
+                "revision" : "f455c2975872ccd2d9c81594c658af65716e9b9a",
+                "version" : "5.9.1"
+            }
+        },
+        {
+            "identity" : "alamofire",
+            "kind" : "remoteSourceControl",
+            "location" : "https://github.com/Alamofire/Alamofire",
+            "state" : {
+                "revision" : "f455c2975872ccd2d9c81594c658af65716e9b9a",
+                "version" : "5.9.1"
+            }
+        }
+    ],
+    "version" : 2
+}
+""";
+
+        var (scanResult, componentRecorder) = await this.DetectorTestUtility.WithFile(
+            "Package.resolved",
+            duplicatePackages)
+            .ExecuteDetectorAsync();
+
+        scanResult.ResultCode.Should().Be(ProcessingResultCode.Success);
+
+        var detectedComponents = componentRecorder.GetDetectedComponents();
+
+        // Two components are detected because this detector registers a SwiftPM and Git component.
+        // The duplicate package is not registered.
+        detectedComponents.Should().HaveCount(2);
+
+        var typedComponents = detectedComponents.Select(c => c.Component).ToList();
+
+        typedComponents.Should().ContainEquivalentOf(
+            new SwiftPMComponent(
+                name: "alamofire",
+                version: "5.9.1",
+                packageUrl: "https://github.com/Alamofire/Alamofire",
+                hash: "f455c2975872ccd2d9c81594c658af65716e9b9a"));
+
+        typedComponents.Should().ContainEquivalentOf(
+            new GitComponent(
+                repositoryUrl: new Uri("https://github.com/Alamofire/Alamofire"),
+                commitHash: "f455c2975872ccd2d9c81594c658af65716e9b9a",
+                tag: "5.9.1"));
+    }
+
+    [TestMethod]
+    public async Task Test_GivenInvalidJSONFile_WhenScan_ThenNoComponentRegisteredAndScanIsSuccessful()
+    {
+        var invalidJSONResolvedPackageFile = """
+{
+ INVALID JSON
+}
+""";
+        var (scanResult, componentRecorder) = await this.DetectorTestUtility.WithFile(
+            "Package.resolved",
+            invalidJSONResolvedPackageFile)
+            .ExecuteDetectorAsync();
+
+        scanResult.ResultCode.Should().Be(ProcessingResultCode.Success);
+        componentRecorder.GetDetectedComponents().Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task Test_GivenEmptyFile_WhenScan_ThenNoComponentRegisteredAndScanIsSuccessful()
+    {
+        var emptyResolvedPackageFile = string.Empty;
+        var (scanResult, componentRecorder) = await this.DetectorTestUtility.WithFile(
+            "Package.resolved",
+            emptyResolvedPackageFile)
+            .ExecuteDetectorAsync();
+
+        scanResult.ResultCode.Should().Be(ProcessingResultCode.Success);
+        componentRecorder.GetDetectedComponents().Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task Test_GivenResvoledPackageWithoutPins_WhenScan_ThenScanIsSuccessfulAndNoComponentsRegistered()
+    {
+        var resolvedPackageWithoutPins = """
+{
+    "pins" : [
+    ],
+    "version" : 2
+}
+""";
+
+        var (scanResult, componentRecorder) = await this.DetectorTestUtility.WithFile(
+            "Package.resolved",
+            resolvedPackageWithoutPins)
+            .ExecuteDetectorAsync();
+
+        scanResult.ResultCode.Should().Be(ProcessingResultCode.Success);
+        componentRecorder.GetDetectedComponents().Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task Test_GivenResolvedPackageWithoutIdentity_WhenScan_ThenScanIsSuccessfulAndNoComponentsRegistered()
+    {
+        var validResolvedPackageFile = """
+{
+    "pins" : [
+        {
+            "identity" : "",
+            "kind" : "remoteSourceControl",
+            "location" : "https://github.com/Alamofire/Alamofire",
+            "state" : {
+                "revision" : "f455c2975872ccd2d9c81594c658af65716e9b9a",
+                "version" : "5.9.1"
+            }
+        },
+        {
+            "kind" : "remoteSourceControl",
+            "location" : "https://github.com/SimplyDanny/SwiftLintPlugins",
+            "state" : {
+                "revision" : "6c3d6c32a37224179dc290f21e03d1238f3d963b",
+                "version" : "0.56.2"
+            }
+        }
+    ],
+    "version" : 2
+}
+""";
+
+        var (scanResult, componentRecorder) = await this.DetectorTestUtility.WithFile(
+            "Package.resolved",
+            validResolvedPackageFile)
+            .ExecuteDetectorAsync();
+
+        scanResult.ResultCode.Should().Be(ProcessingResultCode.Success);
+        componentRecorder.GetDetectedComponents().Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task Test_GivenResolvedPackageWithoutKind_WhenScan_ThenScanIsSuccessfulAndNoComponentsRegistered()
+    {
+        var resolvedPackageWithoutKind = """
+{
+    "pins" : [
+        {
+            "identity" : "alamofire",
+            "location" : "https://github.com/Alamofire/Alamofire",
+            "state" : {
+                "revision" : "f455c2975872ccd2d9c81594c658af65716e9b9a",
+                "version" : "5.9.1"
+            }
+        }
+    ],
+    "version" : 2
+}
+""";
+
+        var (scanResult, componentRecorder) = await this.DetectorTestUtility.WithFile(
+            "Package.resolved",
+            resolvedPackageWithoutKind)
+            .ExecuteDetectorAsync();
+
+        scanResult.ResultCode.Should().Be(ProcessingResultCode.Success);
+        componentRecorder.GetDetectedComponents().Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task Test_GivenResolvedPackageWithoutLocation_WhenScan_ThenScanIsSuccessfulAndNoComponentsRegistered()
+    {
+        var resolvedPackageWithoutLocation = """
+{
+    "pins" : [
+        {
+            "identity" : "alamofire",
+            "kind" : "remoteSourceControl",
+            "state" : {
+                "revision" : "f455c2975872ccd2d9c81594c658af65716e9b9a",
+                "version" : "5.9.1"
+            }
+        }
+    ],
+    "version" : 2
+}
+""";
+
+        var (scanResult, componentRecorder) = await this.DetectorTestUtility.WithFile(
+            "Package.resolved",
+            resolvedPackageWithoutLocation)
+            .ExecuteDetectorAsync();
+
+        scanResult.ResultCode.Should().Be(ProcessingResultCode.Success);
+        componentRecorder.GetDetectedComponents().Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task Test_GivenResolvedPackageWithoutState_WhenScan_ThenScanIsSuccessfulAndNoComponentsRegistered()
+    {
+        var resolvedPackageWithoutState = """
+{
+    "pins" : [
+        {
+            "identity" : "alamofire",
+            "kind" : "remoteSourceControl",
+            "location" : "https://github.com/Alamofire/Alamofire"
+        }
+    ],
+    "version" : 2
+}
+""";
+
+        var (scanResult, componentRecorder) = await this.DetectorTestUtility.WithFile(
+            "Package.resolved",
+            resolvedPackageWithoutState)
+            .ExecuteDetectorAsync();
+
+        scanResult.ResultCode.Should().Be(ProcessingResultCode.Success);
+        componentRecorder.GetDetectedComponents().Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task Test_GivenResolvedPackageWithEmptyState_WhenScan_ThenScanIsSuccessfulAndNoComponentsRegistered()
+    {
+        var resolvedPackageWithEmptyState = """
+{
+    "pins" : [
+        {
+            "identity" : "alamofire",
+            "kind" : "remoteSourceControl",
+            "location" : "https://github.com/Alamofire/Alamofire",
+            "state" : {}
+        }
+    ],
+    "version" : 2
+}
+""";
+
+        var (scanResult, componentRecorder) = await this.DetectorTestUtility.WithFile(
+            "Package.resolved",
+            resolvedPackageWithEmptyState)
+            .ExecuteDetectorAsync();
+
+        scanResult.ResultCode.Should().Be(ProcessingResultCode.Success);
+        componentRecorder.GetDetectedComponents().Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task Test_GivenResolvedPackageWithoutRevision_WhenScan_ThenScanIsSuccessfulAndNoComponentsRegistered()
+    {
+        var resolvedPackageWithoutRevision = """
+{
+    "pins" : [
+        {
+            "identity" : "alamofire",
+            "kind" : "remoteSourceControl",
+            "location" : "https://github.com/Alamofire/Alamofire",
+            "state" : {
+                "version" : "5.9.1"
+            }
+        }
+    ],
+    "version" : 2
+}
+""";
+
+        var (scanResult, componentRecorder) = await this.DetectorTestUtility.WithFile(
+            "Package.resolved",
+            resolvedPackageWithoutRevision)
+            .ExecuteDetectorAsync();
+
+        scanResult.ResultCode.Should().Be(ProcessingResultCode.Success);
+        componentRecorder.GetDetectedComponents().Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task Test_GivenResolvedPackageWithoutVersion_WhenScan_ThenScanIsSuccessfulAndComponentRegisteredWithRevisionHashAsVersion()
+    {
+        var resolvedPackageWithoutVersion = """
+{
+    "pins" : [
+        {
+            "identity" : "alamofire",
+            "kind" : "remoteSourceControl",
+            "location" : "https://github.com/Alamofire/Alamofire",
+            "state" : {
+                "revision" : "f455c2975872ccd2d9c81594c658af65716e9b9a"
+            }
+        }
+    ],
+    "version" : 2
+}
+""";
+
+        var (scanResult, componentRecorder) = await this.DetectorTestUtility.WithFile(
+            "Package.resolved",
+            resolvedPackageWithoutVersion)
+            .ExecuteDetectorAsync();
+
+        scanResult.ResultCode.Should().Be(ProcessingResultCode.Success);
+        componentRecorder.GetDetectedComponents().Should().HaveCount(2);
+
+        var detectedComponents = componentRecorder.GetDetectedComponents();
+        var typedComponents = detectedComponents.Select(c => c.Component).ToList();
+
+        typedComponents.Should().ContainEquivalentOf(
+            new SwiftPMComponent(
+                name: "alamofire",
+                version: "f455c2975872ccd2d9c81594c658af65716e9b9a",
+                packageUrl: "https://github.com/Alamofire/Alamofire",
+                hash: "f455c2975872ccd2d9c81594c658af65716e9b9a"));
+
+        typedComponents.Should().ContainEquivalentOf(
+            new GitComponent(
+                repositoryUrl: new Uri("https://github.com/Alamofire/Alamofire"),
+                commitHash: "f455c2975872ccd2d9c81594c658af65716e9b9a",
+                tag: "f455c2975872ccd2d9c81594c658af65716e9b9a"));
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1201:Elements should appear in the correct order", Justification = "Test data that is better placed at the end of the file.")]
+    private readonly string validLongResolvedPackageFile = """
+{
+  "originHash" : "6ad1e0d3ae43bde33043d3286afc3d98e5be09945ac257218cb6a9dba14466c3",
+  "pins" : [
+    {
+      "identity" : "alamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Alamofire/Alamofire",
+      "state" : {
+        "revision" : "63dfa86548c4e5d5c6fd6ed42f638e388cbce529",
+        "version" : "5.6.0"
+      }
+    },
+    {
+      "identity" : "asyncextensions",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sideeffect-io/AsyncExtensions",
+      "state" : {
+        "branch": null,
+        "revision" : "3442d3d046800f1974bda096faaf0ac510b21154",
+        "version" : "0.5.3"
+      }
+    },
+    {
+      "identity" : "devicekit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/devicekit/DeviceKit.git",
+      "state" : {
+        "revision" : "d37e70cb2646666dcf276d7d3d4a9760a41ff8a6",
+        "version" : "4.9.0"
+      }
+    },
+    {
+      "identity" : "localdependency",
+      "kind" : "localSource",
+      "location" : "../LocalDependency"
+    }
+  ],
+  "version" : 2
+}
+"""
+;
+}

--- a/test/Microsoft.ComponentDetection.VerificationTests/resources/swiftpm/Package.resolved
+++ b/test/Microsoft.ComponentDetection.VerificationTests/resources/swiftpm/Package.resolved
@@ -1,0 +1,60 @@
+{
+  "originHash" : "9e7d32d14f81c4312e8b239503282bdc958b2b52492ede2c123001eeac298b0e",
+  "pins" : [
+    {
+      "identity" : "appauth-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/openid/AppAuth-iOS.git",
+      "state" : {
+        "revision" : "c89ed571ae140f8eb1142735e6e23d7bb8c34cb2",
+        "version" : "1.7.5"
+      }
+    },
+    {
+      "identity" : "google-api-objectivec-client-for-rest",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/google-api-objectivec-client-for-rest",
+      "state" : {
+        "branch" : "main",
+        "revision" : "a8c1e0b1173659d0be452680582c28556372ef74"
+      }
+    },
+    {
+      "identity" : "googlesignin-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleSignIn-iOS",
+      "state" : {
+        "revision" : "a7965d134c5d3567026c523e0a8a583f73b62b0d",
+        "version" : "7.1.0"
+      }
+    },
+    {
+      "identity" : "gtm-session-fetcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/gtm-session-fetcher.git",
+      "state" : {
+        "revision" : "a2ab612cb980066ee56d90d60d8462992c07f24b",
+        "version" : "3.5.0"
+      }
+    },
+    {
+      "identity" : "gtmappauth",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GTMAppAuth.git",
+      "state" : {
+        "revision" : "5d7d66f647400952b1758b230e019b07c0b4b22a",
+        "version" : "4.1.1"
+      }
+    },
+    {
+      "identity" : "microsoft-authentication-library-for-objc",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/AzureAD/microsoft-authentication-library-for-objc",
+      "state" : {
+        "revision" : "9ae8b61c868962153d5fa6a2492deddf804b1acd",
+        "version" : "1.4.0"
+      }
+    }
+  ],
+  "version" : 3
+}


### PR DESCRIPTION
Component detection **does not** currently **support detection of Swift Package Manager**. This package manager is the new default for swift-related projects now that CocoaPods (supported by Component detection) [is on maintenance mode](https://blog.cocoapods.org/CocoaPods-Support-Plans/).

This new detector adds basic support to SwiftPM by parsing the JSON file `Package.resolved` that is generated when dependencies are resolved. This file is usually present in repositories and after building a Swift Package and its contents are enough to detect both direct and transitive dependencies.

This detector does not parse the `Package.swift` file (hard to parse and does not include transitive dependencies) and does not differentiate between build dependencies, transitive dependencies, and direct dependencies (it is not possible by just parsing `Package.resolved`).

This detector will register two kind of components: a `SwiftPMComponent` and a `GitComponent`. I have decided to also register a Git component because SwiftPM does not rely in a repository infrastructure such as NPM, it directly downloads other Swift Packages from the git repositories. I need feedback in this regard, since I do not know what is the best practice (maybe having two registered components for the same dependency is not a good idea?)

I had to invest time in troubleshooting the verification tests because I was not passing them. The issue is that the reference snapshot has less packages because the environments differ for `PipReport` since PR #1259. I have added the same environment vars to the snapshot-publish pipeline although maybe @pauld-msft could take a look at this PR to verify that my modification is correct.