### PR TITLE
Revert to treating PackageDownload as Development Dependency

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/nuget/NuGetPackageReferenceFrameworkAwareDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/nuget/NuGetPackageReferenceFrameworkAwareDetector.cs
@@ -192,13 +192,12 @@ public class NuGetPackageReferenceFrameworkAwareDetector : FileComponentDetector
 
                 var libraryComponent = new DetectedComponent(new NuGetComponent(packageDownload.Name, packageDownload.VersionRange.MinVersion.ToNormalizedString()));
 
-                // Conservatively assume that PackageDownloads are not develeopment dependencies even though usage will not effect any runtime behavior.
-                // Most often they are used for some runtime deployment -- runtime packs, host packs, AOT infrastructure, etc, so opt in treating them as non-development-dependencies.
+                // PackageDownload is always a development dependency since it's usage does not make it part of the application
                 singleFileComponentRecorder.RegisterUsage(
                     libraryComponent,
                     isExplicitReferencedDependency: true,
                     parentComponentId: null,
-                    isDevelopmentDependency: false,
+                    isDevelopmentDependency: true,
                     targetFramework: framework.FrameworkName?.GetShortFolderName());
             }
         }

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/nuget/NuGetPackageReferenceFrameworkAwareDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/nuget/NuGetPackageReferenceFrameworkAwareDetectorTests.cs
@@ -276,7 +276,7 @@ public class NuGetPackageReferenceFrameworkAwareDetectorTests : BaseDetectorTest
             .ExecuteDetectorAsync();
 
         var detectedComponents = componentRecorder.GetDetectedComponents();
-        detectedComponents.Should().AllSatisfy(c => componentRecorder.GetEffectiveDevDependencyValue(c.Component.Id).GetValueOrDefault(), "All should be development dependencies");
+        detectedComponents.Should().AllSatisfy(c => componentRecorder.GetEffectiveDevDependencyValue(c.Component.Id).Should().BeTrue(), "All should be development dependencies");
     }
 
     [TestMethod]
@@ -289,7 +289,7 @@ public class NuGetPackageReferenceFrameworkAwareDetectorTests : BaseDetectorTest
 
         // net42.15 is not a known framework, but it can import framework packages from the closest known framework.
         var detectedComponents = componentRecorder.GetDetectedComponents();
-        detectedComponents.Should().AllSatisfy(c => componentRecorder.GetEffectiveDevDependencyValue(c.Component.Id).GetValueOrDefault(), "All should be development dependencies");
+        detectedComponents.Should().AllSatisfy(c => componentRecorder.GetEffectiveDevDependencyValue(c.Component.Id).Should().BeTrue(), "All should be development dependencies");
     }
 
     [TestMethod]
@@ -329,6 +329,7 @@ public class NuGetPackageReferenceFrameworkAwareDetectorTests : BaseDetectorTest
 
         var dependencies = componentRecorder.GetDetectedComponents();
         dependencies.Should().HaveCount(3, "PackageDownload dependencies should exist.");
+        dependencies.Should().AllSatisfy(c => componentRecorder.GetEffectiveDevDependencyValue(c.Component.Id).Should().BeTrue(), "All PackageDownloads should be development dependencies");
         dependencies.Select(c => c.Component).Should().AllBeOfType<NuGetComponent>();
         dependencies.Select(c => c.TargetFrameworks).Should().AllSatisfy(tfms => tfms.Should().BeEquivalentTo(["net8.0"]));
     }


### PR DESCRIPTION
While we do know that some PackageDownloads are used at runtime and have active alerts against them - the user action to fix those isn't centered around updating the dependency, it's instead about updating the SDK. As such, we feel that treating them as non-development dependencies now may result in user confusion and lot lead to the right result.