### PR TITLE
Align environment between snapshot publish and verify

### DIFF
--- a/.github/workflows/snapshot-publish.yml
+++ b/.github/workflows/snapshot-publish.yml
@@ -2,6 +2,8 @@ name: Publish snapshot of test scan
 
 env:
   CD_DETECTOR_EXPERIMENTS: 1
+  PipReportSkipFallbackOnFailure: "true"
+  PIP_INDEX_URL: "https://pypi.python.org/simple"
 
 on:
   push:


### PR DESCRIPTION
The snapshot publish pipeline is missing two env variables that change the behavior of pip and might generate different results because of this.

*snapshot-verify.yml*
https://github.com/microsoft/component-detection/blob/main/.github/workflows/snapshot-verify.yml#L5

*snapshot-publish.yml*
https://github.com/microsoft/component-detection/blob/main/.github/workflows/snapshot-publish.yml#L4