### PR TITLE
Register VS Code built-in packages as skipped

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/npm/NpmComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/npm/NpmComponentDetector.cs
@@ -79,10 +79,18 @@ public class NpmComponentDetector : FileComponentDetector
         var name = packageJToken["name"].ToString();
         var version = packageJToken["version"].ToString();
         var authorToken = packageJToken["author"];
+        var enginesToken = packageJToken["engines"];
 
         if (!SemanticVersion.TryParse(version, out _))
         {
             this.Logger.LogWarning("Unable to parse version {NpmPackageVersion} for package {NpmPackageName} found at path {NpmPackageLocation}. This may indicate an invalid npm package component and it will not be registered.", version, name, filePath);
+            singleFileComponentRecorder.RegisterPackageParseFailure($"{name} - {version}");
+            return false;
+        }
+
+        if (enginesToken != null && enginesToken["vscode"] != null)
+        {
+            this.Logger.LogInformation("{NpmPackageName} found at path {NpmPackageLocation} represents a built-in VS Code extension. This package will not be registered.", name, filePath);
             singleFileComponentRecorder.RegisterPackageParseFailure($"{name} - {version}");
             return false;
         }

--- a/src/Microsoft.ComponentDetection.Detectors/npm/NpmComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/npm/NpmComponentDetector.cs
@@ -40,7 +40,7 @@ public class NpmComponentDetector : FileComponentDetector
 
     public override IEnumerable<ComponentType> SupportedComponentTypes { get; } = [ComponentType.Npm];
 
-    public override int Version { get; } = 2;
+    public override int Version { get; } = 3;
 
     protected override async Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs, CancellationToken cancellationToken = default)
     {

--- a/src/Microsoft.ComponentDetection.Detectors/npm/NpmComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/npm/NpmComponentDetector.cs
@@ -91,7 +91,6 @@ public class NpmComponentDetector : FileComponentDetector
         if (enginesToken != null && enginesToken["vscode"] != null)
         {
             this.Logger.LogInformation("{NpmPackageName} found at path {NpmPackageLocation} represents a built-in VS Code extension. This package will not be registered.", name, filePath);
-            singleFileComponentRecorder.RegisterPackageParseFailure($"{name} - {version}");
             return false;
         }
 

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/NpmTestUtilities.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/NpmTestUtilities.cs
@@ -117,6 +117,32 @@ public static class NpmTestUtilities
         return ("package.json", packageJsonTemplate, Path.Combine(Path.GetTempPath(), "package.json"));
     }
 
+    public static (string PackageJsonName, string PackageJsonContents, string PackageJsonPath) GetPackageJsonNoDependenciesForNameAndVersionWithNodeEngine(string packageName, string packageVersion)
+    {
+        var packagejson = @"{{
+                ""name"": ""{0}"",
+                ""version"": ""{1}"",
+                ""engines"": {{
+                    ""node"": ""^20.0.0""
+                }}
+            }}";
+        var packageJsonTemplate = string.Format(packagejson, packageName, packageVersion);
+        return ("package.json", packageJsonTemplate, Path.Combine(Path.GetTempPath(), "package.json"));
+    }
+
+    public static (string PackageJsonName, string PackageJsonContents, string PackageJsonPath) GetPackageJsonNoDependenciesForNameAndVersionWithVSCodeEngine(string packageName, string packageVersion)
+    {
+        var packagejson = @"{{
+                ""name"": ""{0}"",
+                ""version"": ""{1}"",
+                ""engines"": {{
+                    ""vscode"": ""^1.0.0""
+                }}
+            }}";
+        var packageJsonTemplate = string.Format(packagejson, packageName, packageVersion);
+        return ("package.json", packageJsonTemplate, Path.Combine(Path.GetTempPath(), "package.json"));
+    }
+
     public static (string PackageJsonName, string PackageJsonContents, string PackageJsonPath) GetPackageJsonNoDependenciesForAuthorAndEmailInJsonFormat(
         string authorName, string authorEmail = null)
     {


### PR DESCRIPTION
<!-- Enter your PR description here -->
This PR modifies the existing NPM component detector to skip components corresponding to VS Code built-in extensions in order to reduce false positives while scanning the VS Code repository.

Example component that should not be flagged: https://github.com/microsoft/vscode/blob/main/extensions/handlebars/package.json

<!-- Please complete this new detector checklist -->
#### New Detector Checklist

- [x] I have gone through the docs for creating a new detector [here](https://github.com/microsoft/component-detection/blob/main/docs/creating-a-new-detector.md)
- [ ] My new detector implements `IDefaultOffComponentDetector`
- [ ] I have created a PR to the [verification repo](https://github.com/microsoft/componentdetection-verification) with components that my new detector can find
- [ ] (If necessary) I have updated the [Feature Overview](https://github.com/microsoft/component-detection/blob/main/README.md#feature-overview) table in the README
