### PR TITLE
Optionally propagate source file root to Detector's scan request

### DIFF
--- a/src/Microsoft.ComponentDetection.Contracts/ScanRequest.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/ScanRequest.cs
@@ -20,7 +20,8 @@ public class ScanRequest
     /// <param name="componentRecorder">Detector component recorder.</param>
     /// <param name="maxThreads">Max number of threads to use for detection.</param>
     /// <param name="cleanupCreatedFiles">Whether or not to cleanup files that are created during detection.</param>
-    public ScanRequest(DirectoryInfo sourceDirectory, ExcludeDirectoryPredicate directoryExclusionPredicate, ILogger logger, IDictionary<string, string> detectorArgs, IEnumerable<string> imagesToScan, IComponentRecorder componentRecorder, int maxThreads = 5, bool cleanupCreatedFiles = true)
+    /// <param name="sourceFileRoot">Directory where source files can be found. In most scenarios this will be the same as <paramref name="sourceDirectory"/> but source code can be a different folder.</param>
+    public ScanRequest(DirectoryInfo sourceDirectory, ExcludeDirectoryPredicate directoryExclusionPredicate, ILogger logger, IDictionary<string, string> detectorArgs, IEnumerable<string> imagesToScan, IComponentRecorder componentRecorder, int maxThreads = 5, bool cleanupCreatedFiles = true, DirectoryInfo sourceFileRoot = null)
     {
         this.SourceDirectory = sourceDirectory;
         this.DirectoryExclusionPredicate = directoryExclusionPredicate;
@@ -29,12 +30,18 @@ public class ScanRequest
         this.ComponentRecorder = componentRecorder;
         this.MaxThreads = maxThreads;
         this.CleanupCreatedFiles = cleanupCreatedFiles;
+        this.SourceFileRoot = sourceFileRoot;
     }
 
     /// <summary>
     /// Gets the source directory to consider the working directory for the detection operation.
     /// </summary>
     public DirectoryInfo SourceDirectory { get; private set; }
+
+    /// <summary>
+    /// Directory where source files can be found.
+    /// </summary>
+    public DirectoryInfo SourceFileRoot { get; private set; }
 
     /// <summary>
     /// Gets a predicate which evaluates directories, if the predicate returns true the directory will be excluded.

--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/DetectorProcessingService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/DetectorProcessingService.cs
@@ -99,7 +99,8 @@ public class DetectorProcessingService : IDetectorProcessingService
                                 settings.DockerImagesToScan,
                                 componentRecorder,
                                 settings.MaxDetectionThreads ?? DefaultMaxDetectionThreads,
-                                settings.CleanupCreatedFiles ?? true),
+                                settings.CleanupCreatedFiles ?? true,
+                                settings.SourceFileRoot),
                             cancellationToken),
                         isExperimentalDetector,
                         record);

--- a/test/Microsoft.ComponentDetection.TestsUtilities/DetectorTestUtilityBuilder.cs
+++ b/test/Microsoft.ComponentDetection.TestsUtilities/DetectorTestUtilityBuilder.cs
@@ -95,7 +95,8 @@ public class DetectorTestUtilityBuilder<T>
                 null,
                 new Dictionary<string, string>(),
                 null,
-                this.componentRecorder);
+                this.componentRecorder,
+                sourceFileRoot: new DirectoryInfo(Path.GetTempPath()));
         }
         else
         {


### PR DESCRIPTION
## Context
Custom detectors that inherit from `IDetector` can optionally access the `SourceFileRoot` property in the `ScanRequest` class. 

This is useful if a custom detector wants to use placeholders of the reported file paths under certain conditions rather than just the source directory being scanned by the detector.