### PR TITLE
Fixed scan of multiple go files for the Go117 detector

### DIFF
--- a/test/Microsoft.ComponentDetection.Detectors.Tests/Go117ComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/Go117ComponentDetectorTests.cs
@@ -51,6 +51,9 @@ public class Go117ComponentDetectorTests : BaseDetectorTest<Go117ComponentDetect
     {
         var goMod = string.Empty;
 
+        this.commandLineMock.Setup(x => x.CanCommandBeLocatedAsync("go", null, null, It.Is<string[]>(p => p.SequenceEqual(new List<string> { "version" }.ToArray()))))
+        .ReturnsAsync(true);
+
         this.commandLineMock.Setup(x => x.ExecuteCommandAsync("go", null, null, default, It.Is<string[]>(p => p.SequenceEqual(new List<string> { "version" }.ToArray()))))
         .ReturnsAsync(new CommandLineExecutionResult
         {
@@ -85,6 +88,9 @@ public class Go117ComponentDetectorTests : BaseDetectorTest<Go117ComponentDetect
     {
         var goMod = string.Empty;
 
+        this.commandLineMock.Setup(x => x.CanCommandBeLocatedAsync("go", null, null, It.Is<string[]>(p => p.SequenceEqual(new List<string> { "version" }.ToArray()))))
+        .ReturnsAsync(true);
+
         this.commandLineMock.Setup(x => x.ExecuteCommandAsync("go", null, null, default, It.Is<string[]>(p => p.SequenceEqual(new List<string> { "version" }.ToArray()))))
         .ReturnsAsync(new CommandLineExecutionResult
         {
@@ -114,6 +120,9 @@ public class Go117ComponentDetectorTests : BaseDetectorTest<Go117ComponentDetect
         var goModParserMock = new Mock<IGoParser>();
         this.mockParserFactory.Setup(x => x.CreateParser(GoParserType.GoMod, It.IsAny<ILogger>())).Returns(goModParserMock.Object);
 
+        this.commandLineMock.Setup(x => x.CanCommandBeLocatedAsync("go", null, null, It.Is<string[]>(p => p.SequenceEqual(new List<string> { "version" }.ToArray()))))
+        .ReturnsAsync(true);
+
         this.commandLineMock.Setup(x => x.ExecuteCommandAsync("go", null, null, default, It.Is<string[]>(p => p.SequenceEqual(new List<string> { "version" }.ToArray()))))
         .ReturnsAsync(new CommandLineExecutionResult
         {
@@ -136,6 +145,9 @@ public class Go117ComponentDetectorTests : BaseDetectorTest<Go117ComponentDetect
         var goSumParserMock = new Mock<IGoParser>();
         this.mockParserFactory.Setup(x => x.CreateParser(GoParserType.GoSum, It.IsAny<ILogger>())).Returns(goSumParserMock.Object);
 
+        this.commandLineMock.Setup(x => x.CanCommandBeLocatedAsync("go", null, null, It.Is<string[]>(p => p.SequenceEqual(new List<string> { "version" }.ToArray()))))
+        .ReturnsAsync(true);
+
         this.commandLineMock.Setup(x => x.ExecuteCommandAsync("go", null, null, default, It.Is<string[]>(p => p.SequenceEqual(new List<string> { "version" }.ToArray()))))
         .ReturnsAsync(new CommandLineExecutionResult
         {
@@ -150,5 +162,26 @@ public class Go117ComponentDetectorTests : BaseDetectorTest<Go117ComponentDetect
         scanResult.ResultCode.Should().Be(ProcessingResultCode.Success);
 
         goSumParserMock.Verify(parser => parser.ParseAsync(It.IsAny<ISingleFileComponentRecorder>(), It.IsAny<IComponentStream>(), It.IsAny<GoGraphTelemetryRecord>()), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task Go117ModDetector_ExecutingGoVersionFails_DetectorDoesNotFail()
+    {
+        var goModParserMock = new Mock<IGoParser>();
+        this.mockParserFactory.Setup(x => x.CreateParser(GoParserType.GoMod, It.IsAny<ILogger>())).Returns(goModParserMock.Object);
+
+        this.commandLineMock.Setup(x => x.CanCommandBeLocatedAsync("go", null, null, It.Is<string[]>(p => p.SequenceEqual(new List<string> { "version" }.ToArray()))))
+        .ReturnsAsync(true);
+
+        this.commandLineMock.Setup(x => x.ExecuteCommandAsync("go", null, null, default, It.Is<string[]>(p => p.SequenceEqual(new List<string> { "version" }.ToArray()))))
+        .Throws(new InvalidOperationException("Failed to execute go version"));
+
+        var (scanResult, componentRecorder) = await this.DetectorTestUtility
+            .WithFile("go.mod", string.Empty)
+            .ExecuteDetectorAsync();
+
+        scanResult.ResultCode.Should().Be(ProcessingResultCode.Success);
+
+        goModParserMock.Verify(parser => parser.ParseAsync(It.IsAny<ISingleFileComponentRecorder>(), It.IsAny<IComponentStream>(), It.IsAny<GoGraphTelemetryRecord>()), Times.Once);
     }
 }


### PR DESCRIPTION
### The Problem

The issue with the go detector was that the command 
```csharp
var processExecution = await this.commandLineInvocationService.ExecuteCommandAsync("go", null, null, cancellationToken: default, new List<string> { "version" }.ToArray());
```

Was throwing an exception because it couldn't find go CLI, even when go was installed. Internally the method `ExecuteCommandAsync` uses other method called `CanCommandBeLocatedAsync` but it calls this method without passing the parameters for the execution of `go`. The problem is that when CanCommandBeLocatedAsync was executing `go` without parameters the process was returning 2 and we expect that a successful command execution should returns 0 [see here](https://github.com/microsoft/component-detection/blob/f763e9632f96139c8f50660a566f6dbb1eb852df/src/Microsoft.ComponentDetection.Common/CommandLineInvocationService.cs#L38).

During local testing this was causing issues when there are multiple files been scanned. When there is only one mod file the detector was successfully returning the components because the recording of such components happens before checking the go version. When there were multiple files is when the problem manifest.

### The Solution

We need to call `CanCommandBeLocatedAsync` with the parameters for the execution of `go` to avoid the issue. We need to do this before calling `ExecuteCommandAsync` to ensure that the command is located. This solves the problem because when `CanCommandBeLocatedAsync` founds the command it adds it to a [local cache of located commands](https://github.com/microsoft/component-detection/blob/f763e9632f96139c8f50660a566f6dbb1eb852df/src/Microsoft.ComponentDetection.Common/CommandLineInvocationService.cs#L40). This prevents `ExecuteCommandAsync` to fails because when it executes its own check, it sees the command in the cache and bypass [the system call](https://github.com/microsoft/component-detection/blob/f763e9632f96139c8f50660a566f6dbb1eb852df/src/Microsoft.ComponentDetection.Common/CommandLineInvocationService.cs#L26).

Ideally, we shouldn't need to call `CanCommandBeLocatedAsync` if the method `ExecuteComandAsync` already does the check. We could modify the call to `CanCommandBeLocatedAsync` inside `ExecuteCommandAsync` to also consider the parameters. I didn't make such change in this PR because we need to also consider another parameter called `additionalCandidateCommands` and how passing the parameters work in every situation. This is not heavily tested and for that reason I decided not to make that change in this PR. This pattern of calling `CanCommandBeLocatedAsync` before `ExecuteCommandAsync` is already used in other parts of the codebase.
