### PR TITLE
Add DotNetComponent

### DIFF
--- a/docs/detectors/dotnet.md
+++ b/docs/detectors/dotnet.md
@@ -1,0 +1,36 @@
+# DotNet SDK Detection
+
+## Requirements
+
+DotNet SDK Detection depends on `project.assets.json` files in the project output / intermediates.
+
+## Detection Strategy 
+
+The `project.assets.json` will be produced when a project is restored and built.  From this we can locate 
+the project file that was built.  From the project file location we probe for the .NET SDK version used.  
+We look up the directory path to find a `global.json`[1] then will run `dotnet --version` in that 
+directory to determine which version of the .NET SDK it will select.  If no `global.json` is found, then 
+probing will stop when the detector encounters `SourceDirectory`, `SourceFileRoot`, or the root of the drive 
+and proceed to run `dotnet --version` in that directory.  Repositories control the version of the .NET SDK 
+used to build their project by either preinstalling on their build machine or container, or acquiring during 
+the build pipeline.  The .NET SDK version used is important as this version selects redistributable content 
+that becomes part of the application (the dotnet host, runtime for self-contained or AOT apps, build tools 
+which generate source, etc).
+
+In addition to recording the SDK version used, the detector will report the framework versions targeted by 
+the project as `TargetFramework` values as well as the type of project `application` or `library`.  These 
+are important because applications may be built to target old framework versions which may be out of support
+and have unreported vulnerabilities.  `TargetFramework` is determined from the `project.assets.json` while 
+the type of the project is determined by locating the project's output assembly in a subdirectory of the 
+output path and reading the PE COFF header's characteristics for `IMAGE_FILE_EXECUTABLE_IMAGE`[2].
+
+[1]: https://learn.microsoft.com/en-us/dotnet/core/tools/global-json
+[2]: https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#characteristics
+
+## Known Limitations
+
+If the `dotnet` executable is not on the path the detector may fail to locate the version used to build the 
+project.  The detector will fallback to parsing the `global.json` in this case if it is present.
+Detection of the output type is done by locating the output assembly under the output path specified in 
+`project.assets.json`.  Some build systems may place project intermediates in a different location.  In this
+case the project type will be reported as `unknown`.

--- a/src/Microsoft.ComponentDetection.Common/CommandLineInvocationService.cs
+++ b/src/Microsoft.ComponentDetection.Common/CommandLineInvocationService.cs
@@ -60,7 +60,7 @@ public class CommandLineInvocationService : ICommandLineInvocationService
         CancellationToken cancellationToken = default,
         params string[] parameters)
     {
-        var isCommandLocatable = await this.CanCommandBeLocatedAsync(command, additionalCandidateCommands);
+        var isCommandLocatable = await this.CanCommandBeLocatedAsync(command, additionalCandidateCommands, workingDirectory, parameters);
         if (!isCommandLocatable)
         {
             throw new InvalidOperationException(

--- a/src/Microsoft.ComponentDetection.Contracts/TypedComponent/ComponentType.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/TypedComponent/ComponentType.cs
@@ -59,4 +59,7 @@ public enum ComponentType : byte
 
     [EnumMember]
     Swift = 18,
+
+    [EnumMember]
+    DotNet = 19,
 }

--- a/src/Microsoft.ComponentDetection.Contracts/TypedComponent/DotNetComponent.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/TypedComponent/DotNetComponent.cs
@@ -4,6 +4,8 @@ using System;
 
 public class DotNetComponent : TypedComponent
 {
+    private const string UnknownValue = "unknown";
+
     private DotNetComponent()
     {
         /* Reserved for deserialization */
@@ -16,9 +18,9 @@ public class DotNetComponent : TypedComponent
             throw new ArgumentNullException(nameof(sdkVersion), $"Either {nameof(sdkVersion)} or {nameof(targetFramework)} of component type {nameof(DotNetComponent)} must be specified.");
         }
 
-        this.SdkVersion = string.IsNullOrWhiteSpace(sdkVersion) ? "unknown" : sdkVersion;
-        this.TargetFramework = string.IsNullOrWhiteSpace(targetFramework) ? "unknown" : targetFramework;
-        this.ProjectType = string.IsNullOrWhiteSpace(projectType) ? "unknown" : projectType;
+        this.SdkVersion = string.IsNullOrWhiteSpace(sdkVersion) ? UnknownValue : sdkVersion;
+        this.TargetFramework = string.IsNullOrWhiteSpace(targetFramework) ? UnknownValue : targetFramework;
+        this.ProjectType = string.IsNullOrWhiteSpace(projectType) ? UnknownValue : projectType;
     }
 
     /// <summary>

--- a/src/Microsoft.ComponentDetection.Contracts/TypedComponent/DotNetComponent.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/TypedComponent/DotNetComponent.cs
@@ -1,0 +1,64 @@
+namespace Microsoft.ComponentDetection.Contracts.TypedComponent;
+
+using System.Text;
+
+#nullable enable
+
+using PackageUrl;
+
+public class DotNetComponent : TypedComponent
+{
+    private DotNetComponent()
+    {
+        /* Reserved for deserialization */
+    }
+
+    public DotNetComponent(string? sdkVersion, string? targetFramework = null, string? projectType = null)
+    {
+        this.SdkVersion = sdkVersion;
+        this.TargetFramework = targetFramework;
+        this.ProjectType = projectType;  // application, library, or null
+    }
+
+    /// <summary>
+    /// SDK Version detected, could be null if no global.json exists and no dotnet is on the path.
+    /// </summary>
+    public string? SdkVersion { get; set; }
+
+    /// <summary>
+    /// Target framework for this instance.  Null in the case of global.json.
+    /// </summary>
+    public string? TargetFramework { get; set; }
+
+    /// <summary>
+    /// Project type: application, library.  Null in the case of global.json or if no project output could be discovered.
+    /// </summary>
+    public string? ProjectType { get; set; }
+
+    public override ComponentType Type => ComponentType.DotNet;
+
+    /// <summary>
+    /// Provides an id like `dotnet {SdkVersion} - {TargetFramework} - {ProjectType}` where targetFramework and projectType are only present if not null.
+    /// </summary>
+    public override string Id
+    {
+        get
+        {
+            var builder = new StringBuilder($"dotnet {this.SdkVersion ?? "unknown"}");
+            if (this.TargetFramework is not null)
+            {
+                builder.Append($" - {this.TargetFramework}");
+
+                if (this.ProjectType is not null)
+                {
+                    builder.Append($" - {this.ProjectType}");
+                }
+            }
+
+            return builder.ToString();
+        }
+    }
+
+    // TODO - do we need to add a type to prul https://github.com/package-url/purl-spec/blob/main/PURL-TYPES.rst
+    public override PackageURL PackageUrl => new PackageURL("generic", null, "dotnet-sdk", this.SdkVersion ?? "unknown", null, null);
+}

--- a/src/Microsoft.ComponentDetection.Detectors/dotnet/DotNetComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/dotnet/DotNetComponentDetector.cs
@@ -166,7 +166,7 @@ public class DotNetComponentDetector : FileComponentDetector, IExperimentalDetec
         }
         else if (projectDirectory.Equals(this.sourceDirectory, StringComparison.OrdinalIgnoreCase) ||
                  projectDirectory.Equals(this.sourceFileRootDirectory, StringComparison.OrdinalIgnoreCase) ||
-                 parentDirectory is null ||
+                 string.IsNullOrEmpty(parentDirectory) ||
                  projectDirectory.Equals(parentDirectory, StringComparison.OrdinalIgnoreCase))
         {
             // if we are at the source directory, source file root, or have reached a root directory, run `dotnet --version`

--- a/src/Microsoft.ComponentDetection.Detectors/dotnet/DotNetComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/dotnet/DotNetComponentDetector.cs
@@ -56,7 +56,7 @@ public class DotNetComponentDetector : FileComponentDetector, IExperimentalDetec
 
     public override IEnumerable<string> Categories => ["DotNet"];
 
-    private string? NormalizeDirectory(string? path) => this.pathUtilityService.NormalizePath(path)?.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+    private string? NormalizeDirectory(string? path) => string.IsNullOrEmpty(path) ? path : Path.TrimEndingDirectorySeparator(this.pathUtilityService.NormalizePath(path));
 
     private async Task<string?> RunDotNetVersionAsync(string workingDirectoryPath, CancellationToken cancellationToken)
     {

--- a/src/Microsoft.ComponentDetection.Detectors/dotnet/DotNetComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/dotnet/DotNetComponentDetector.cs
@@ -1,0 +1,186 @@
+namespace Microsoft.ComponentDetection.Detectors.DotNet;
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection.PortableExecutable;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using global::NuGet.ProjectModel;
+using Microsoft.ComponentDetection.Contracts;
+using Microsoft.ComponentDetection.Contracts.Internal;
+using Microsoft.ComponentDetection.Contracts.TypedComponent;
+using Microsoft.Extensions.Logging;
+
+public class DotNetComponentDetector : FileComponentDetector, IExperimentalDetector
+{
+    private const string GlobalJsonFileName = "global.json";
+    private readonly ICommandLineInvocationService commandLineInvocationService;
+    private readonly IDirectoryUtilityService directoryUtilityService;
+    private readonly IFileUtilityService fileUtilityService;
+    private readonly IPathUtilityService pathUtilityService;
+    private readonly LockFileFormat lockFileFormat = new();
+    private readonly Dictionary<string, string?> sdkVersionCache = [];
+    private string? sourceDirectory;
+    private string? sourceFileRootDirectory;
+
+    public DotNetComponentDetector(
+        IComponentStreamEnumerableFactory componentStreamEnumerableFactory,
+        ICommandLineInvocationService commandLineInvocationService,
+        IDirectoryUtilityService directoryUtilityService,
+        IFileUtilityService fileUtilityService,
+        IPathUtilityService pathUtilityService,
+        IObservableDirectoryWalkerFactory walkerFactory,
+        ILogger<DotNetComponentDetector> logger)
+    {
+        this.commandLineInvocationService = commandLineInvocationService;
+        this.ComponentStreamEnumerableFactory = componentStreamEnumerableFactory;
+        this.directoryUtilityService = directoryUtilityService;
+        this.fileUtilityService = fileUtilityService;
+        this.pathUtilityService = pathUtilityService;
+        this.Scanner = walkerFactory;
+        this.Logger = logger;
+    }
+
+    public override string Id => "DotNet";
+
+    public override IList<string> SearchPatterns { get; } = [LockFileFormat.AssetsFileName];
+
+    public override IEnumerable<ComponentType> SupportedComponentTypes => [ComponentType.DotNet];
+
+    public override int Version { get; } = 1;
+
+    public override IEnumerable<string> Categories => ["DotNet"];
+
+    private async Task<string?> RunDotNetVersionAsync(string workingDirectoryPath, CancellationToken cancellationToken)
+    {
+        var workingDirectory = new DirectoryInfo(workingDirectoryPath);
+
+        var process = await this.commandLineInvocationService.ExecuteCommandAsync("dotnet", ["dotnet.exe"], workingDirectory, cancellationToken, "--version").ConfigureAwait(false);
+        return process.ExitCode == 0 ? process.StdOut.Trim() : null;
+    }
+
+    public override Task<IndividualDetectorScanResult> ExecuteDetectorAsync(ScanRequest request, CancellationToken cancellationToken = default)
+    {
+        this.sourceDirectory = this.pathUtilityService.NormalizePath(request.SourceDirectory.FullName);
+        this.sourceFileRootDirectory = this.pathUtilityService.NormalizePath(request.SourceFileRoot?.FullName);
+
+        return base.ExecuteDetectorAsync(request, cancellationToken);
+    }
+
+    protected override async Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs, CancellationToken cancellationToken = default)
+    {
+        var lockFile = this.lockFileFormat.Read(processRequest.ComponentStream.Stream, processRequest.ComponentStream.Location);
+
+        var projectPath = lockFile.PackageSpec.RestoreMetadata.ProjectPath;
+        var projectDirectory = this.pathUtilityService.GetParentDirectory(projectPath);
+        var sdkVersion = await this.GetSdkVersionAsync(projectDirectory, cancellationToken);
+
+        var projectName = lockFile.PackageSpec.RestoreMetadata.ProjectName;
+        var projectOutputPath = lockFile.PackageSpec.RestoreMetadata.OutputPath;
+        var targetType = this.GetProjectType(projectOutputPath, projectName, cancellationToken);
+
+        var componentReporter = this.ComponentRecorder.CreateSingleFileComponentRecorder(projectPath);
+        foreach (var target in lockFile.Targets)
+        {
+            var targetFramework = target.TargetFramework?.GetShortFolderName();
+
+            componentReporter.RegisterUsage(new DetectedComponent(new DotNetComponent(sdkVersion, targetFramework, targetType)));
+        }
+    }
+
+    private string? GetProjectType(string projectOutputPath, string projectName, CancellationToken cancellationToken)
+    {
+        if (this.directoryUtilityService.Exists(projectOutputPath))
+        {
+            var namePattern = (projectName ?? "*") + ".dll";
+
+            // look for the compiled output, first as dll then as exe.
+            var candidates = this.directoryUtilityService.EnumerateFiles(projectOutputPath, namePattern, SearchOption.AllDirectories)
+                     .Concat(this.directoryUtilityService.EnumerateFiles(projectOutputPath, namePattern, SearchOption.AllDirectories));
+            foreach (var candidate in candidates)
+            {
+                if (this.IsApplication(candidate))
+                {
+                    return "application";
+                }
+                else
+                {
+                    return "library";
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private bool IsApplication(string assemblyPath)
+    {
+        try
+        {
+            using var peReader = new PEReader(this.fileUtilityService.MakeFileStream(assemblyPath));
+
+            // despite the name `IsExe` this is actually based of the CoffHeader Characteristics
+            return peReader.PEHeaders.IsExe;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Recursively get the sdk version from the project directory or parent directories.
+    /// </summary>
+    /// <param name="projectDirectory">Directory to start the search.</param>
+    /// <param name="cancellationToken">Cancellation token to halt the search.</param>
+    /// <returns>Sdk version found, or null if no version can be detected.</returns>
+    private async Task<string?> GetSdkVersionAsync(string projectDirectory, CancellationToken cancellationToken)
+    {
+        // normalize since we need to use as a key
+        projectDirectory = this.pathUtilityService.NormalizePath(projectDirectory);
+        if (this.sdkVersionCache.TryGetValue(projectDirectory, out var sdkVersion))
+        {
+            return sdkVersion;
+        }
+
+        var parentDirectory = this.pathUtilityService.GetParentDirectory(projectDirectory);
+        var globalJsonPath = Path.Combine(projectDirectory, GlobalJsonFileName);
+
+        if (this.fileUtilityService.Exists(globalJsonPath))
+        {
+            var globalJson = await JsonDocument.ParseAsync(this.fileUtilityService.MakeFileStream(globalJsonPath), cancellationToken: cancellationToken);
+            if (globalJson.RootElement.TryGetProperty("sdk", out var sdk))
+            {
+                if (sdk.TryGetProperty("version", out var version))
+                {
+                    sdkVersion = version.GetString();
+                    var globalJsonComponent = new DetectedComponent(new DotNetComponent(sdkVersion));
+                    var recorder = this.ComponentRecorder.CreateSingleFileComponentRecorder(globalJsonPath);
+                    recorder.RegisterUsage(globalJsonComponent, isExplicitReferencedDependency: true);
+                }
+            }
+        }
+        else if (projectDirectory.Equals(this.sourceDirectory, StringComparison.OrdinalIgnoreCase) ||
+                 projectDirectory.Equals(this.sourceFileRootDirectory, StringComparison.OrdinalIgnoreCase) ||
+                 parentDirectory is null ||
+                 projectDirectory.Equals(parentDirectory, StringComparison.OrdinalIgnoreCase))
+        {
+            // if we are at the source directory, source file root, or have reached a root directory, run `dotnet --version`
+            // this could fail if dotnet is not on the path, or if the global.json is malformed
+            sdkVersion = await this.RunDotNetVersionAsync(projectDirectory, cancellationToken);
+        }
+        else
+        {
+            // recurse up the directory tree
+            sdkVersion = await this.GetSdkVersionAsync(parentDirectory, cancellationToken);
+        }
+
+        this.sdkVersionCache[projectDirectory] = sdkVersion;
+
+        return sdkVersion;
+    }
+}

--- a/src/Microsoft.ComponentDetection.Detectors/yarn/YarnLockComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/yarn/YarnLockComponentDetector.cs
@@ -7,7 +7,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
-using DotNet.Globbing;
+using global::DotNet.Globbing;
 using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Contracts.Internal;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;

--- a/src/Microsoft.ComponentDetection.Orchestrator/Experiments/DotNetDetectorExperiment.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Experiments/DotNetDetectorExperiment.cs
@@ -1,0 +1,22 @@
+namespace Microsoft.ComponentDetection.Orchestrator.Experiments.Configs;
+
+using Microsoft.ComponentDetection.Contracts;
+using Microsoft.ComponentDetection.Detectors.DotNet;
+
+/// <summary>
+/// Validating the <see cref="DotNetDetectorExperiment"/>.
+/// </summary>
+public class DotNetDetectorExperiment : IExperimentConfiguration
+{
+    /// <inheritdoc />
+    public string Name => "DotNetDetector";
+
+    /// <inheritdoc />
+    public bool IsInControlGroup(IComponentDetector componentDetector) => false;
+
+    /// <inheritdoc />
+    public bool IsInExperimentGroup(IComponentDetector componentDetector) => componentDetector is DotNetComponentDetector;
+
+    /// <inheritdoc />
+    public bool ShouldRecord(IComponentDetector componentDetector, int numComponents) => true;
+}

--- a/src/Microsoft.ComponentDetection.Orchestrator/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Extensions/ServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Detectors.CocoaPods;
 using Microsoft.ComponentDetection.Detectors.Conan;
 using Microsoft.ComponentDetection.Detectors.Dockerfile;
+using Microsoft.ComponentDetection.Detectors.DotNet;
 using Microsoft.ComponentDetection.Detectors.Go;
 using Microsoft.ComponentDetection.Detectors.Gradle;
 using Microsoft.ComponentDetection.Detectors.Ivy;
@@ -65,6 +66,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IExperimentConfiguration, SimplePipExperiment>();
         services.AddSingleton<IExperimentConfiguration, RustCliDetectorExperiment>();
         services.AddSingleton<IExperimentConfiguration, Go117DetectorExperiment>();
+        services.AddSingleton<IExperimentConfiguration, DotNetDetectorExperiment>();
 
         // Detectors
         // CocoaPods
@@ -78,6 +80,9 @@ public static class ServiceCollectionExtensions
 
         // Dockerfile
         services.AddSingleton<IComponentDetector, DockerfileComponentDetector>();
+
+        // DotNet
+        services.AddSingleton<IComponentDetector, DotNetComponentDetector>();
 
         // Go
         services.AddSingleton<IComponentDetector, GoComponentDetector>();

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/DotNetComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/DotNetComponentDetectorTests.cs
@@ -1,0 +1,348 @@
+namespace Microsoft.ComponentDetection.Detectors.Tests;
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using global::NuGet.Frameworks;
+using global::NuGet.ProjectModel;
+using Microsoft.ComponentDetection.Contracts;
+using Microsoft.ComponentDetection.Contracts.TypedComponent;
+using Microsoft.ComponentDetection.Detectors.DotNet;
+using Microsoft.ComponentDetection.TestsUtilities;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+[TestClass]
+[TestCategory("Governance/All")]
+[TestCategory("Governance/ComponentDetection")]
+public class DotNetComponentDetectorTests : BaseDetectorTest<DotNetComponentDetector>
+{
+    private static readonly string RootDir = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "C:" : @"\";
+
+    private readonly Mock<ILogger<DotNetComponentDetector>> mockLogger = new();
+
+    // uses ExecuteCommandAsync
+    private readonly Mock<ICommandLineInvocationService> mockCommandLineInvocationService = new();
+    private readonly CommandLineExecutionResult commandLineExecutionResult = new();
+
+    // uses Exists, EnumerateFiles
+    private readonly Mock<IDirectoryUtilityService> mockDirectoryUtilityService = new();
+
+    // uses Exists, MakeFileStream
+    private readonly Mock<IFileUtilityService> mockFileUtilityService = new();
+    private readonly Dictionary<string, Dictionary<string, Stream>> files = [];
+
+    // uses GetParentDirectory, NormalizePath
+    private readonly Mock<IPathUtilityService> mockPathUtilityService = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DotNetComponentDetectorTests"/> class.
+    /// </summary>
+    public DotNetComponentDetectorTests()
+    {
+        this.DetectorTestUtility.AddServiceMock(this.mockLogger)
+                                .AddServiceMock(this.mockCommandLineInvocationService)
+                                .AddServiceMock(this.mockDirectoryUtilityService)
+                                .AddServiceMock(this.mockFileUtilityService)
+                                .AddServiceMock(this.mockPathUtilityService);
+
+        this.mockFileUtilityService.Setup(x => x.Exists(It.IsAny<string>())).Returns((string p) => this.FileExists(p));
+        this.mockFileUtilityService.Setup(x => x.MakeFileStream(It.IsAny<string>())).Returns((string p) => this.OpenFile(p));
+        this.mockDirectoryUtilityService.Setup(x => x.Exists(It.IsAny<string>())).Returns((string p) => this.DirectoryExists(p));
+
+        // ignore pattern and search option since we don't really need them for tests
+        this.mockDirectoryUtilityService.Setup(x => x.EnumerateFiles(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SearchOption>())).Returns((string d, string p, SearchOption s) => this.EnumerateFilesRecursive(d));
+
+        this.mockPathUtilityService.Setup(x => x.NormalizePath(It.IsAny<string>())).Returns((string p) => p);  // don't do normalization
+        this.mockPathUtilityService.Setup(x => x.GetParentDirectory(It.IsAny<string>())).Returns((string p) => Path.GetDirectoryName(p));
+
+        this.mockCommandLineInvocationService.Setup(x => x.ExecuteCommandAsync(It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<DirectoryInfo>(), It.IsAny<CancellationToken>(), It.IsAny<string[]>())).Returns(Task.FromResult(this.commandLineExecutionResult));
+    }
+
+    private bool FileExists(string path)
+    {
+        var fileName = Path.GetFileName(path);
+        var directory = Path.GetDirectoryName(path);
+
+        return this.files.TryGetValue(directory, out var fileNames) &&
+               fileNames.TryGetValue(fileName, out _);
+    }
+
+    private Stream OpenFile(string path)
+    {
+        var fileName = Path.GetFileName(path);
+        var directory = Path.GetDirectoryName(path);
+
+        return this.files.TryGetValue(directory, out var fileNames) &&
+               fileNames.TryGetValue(fileName, out var stream) ? stream : null;
+    }
+
+    private bool DirectoryExists(string directory) => this.files.ContainsKey(directory);
+
+    private IEnumerable<string> EnumerateFilesRecursive(string directory)
+    {
+        if (this.files.TryGetValue(directory, out var fileNames))
+        {
+            foreach (var fileName in fileNames.Keys)
+            {
+                var filePath = Path.Combine(directory, fileName);
+
+                if (fileName.EndsWith(Path.DirectorySeparatorChar))
+                {
+                    foreach (var subFile in this.EnumerateFilesRecursive(filePath.TrimEnd(Path.DirectorySeparatorChar)))
+                    {
+                        yield return subFile;
+                    }
+                }
+                else
+                {
+                    yield return filePath;
+                }
+            }
+        }
+    }
+
+    private void AddFile(string path, Stream content)
+    {
+        var fileName = Path.GetFileName(path);
+        var directory = Path.GetDirectoryName(path);
+        this.AddDirectory(directory);
+        this.files[directory][fileName] = content;
+    }
+
+    private void AddDirectory(string path, string subDirectory = null)
+    {
+        if (path is null)
+        {
+            return;
+        }
+
+        if (subDirectory is not null)
+        {
+            // use a trailing slash to indicate a sub directory in the files collection
+            subDirectory += Path.DirectorySeparatorChar;
+        }
+
+        if (this.files.TryGetValue(path, out var directoryFiles))
+        {
+            if (subDirectory is not null)
+            {
+                directoryFiles.Add(subDirectory, null);
+            }
+        }
+        else
+        {
+            this.files.Add(path, subDirectory is null ? [] : new() { { subDirectory, null } });
+            this.AddDirectory(Path.GetDirectoryName(path), Path.GetFileName(path));
+        }
+    }
+
+    private void SetCommandResult(int exitCode, string stdOut = null, string stdErr = null)
+    {
+        this.commandLineExecutionResult.ExitCode = exitCode;
+        this.commandLineExecutionResult.StdOut = stdOut;
+        this.commandLineExecutionResult.StdErr = stdErr;
+    }
+
+    [TestCleanup]
+    public void ClearMocks()
+    {
+        this.files.Clear();
+        this.SetCommandResult(-1);
+    }
+
+    private static string ProjectAssets(string projectName, string outputPath, string projectPath, params string[] targetFrameworks)
+    {
+        LockFileFormat format = new();
+        LockFile lockFile = new();
+        using var textWriter = new StringWriter();
+
+        lockFile.Targets = targetFrameworks.Select(tfm => new LockFileTarget() { TargetFramework = NuGetFramework.Parse(tfm) }).ToList();
+        lockFile.PackageSpec = new()
+        {
+            RestoreMetadata = new()
+            {
+                ProjectName = projectName,
+                OutputPath = outputPath,
+                ProjectPath = projectPath,
+            },
+        };
+
+        format.Write(textWriter, lockFile);
+        return textWriter.ToString();
+    }
+
+    private static Stream GlobalJson(string sdkVersion)
+    {
+        var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream, new() { Indented = true }))
+        {
+            writer.WriteStartObject();
+            writer.WritePropertyName("sdk");
+            writer.WriteStartObject();
+            writer.WriteString("version", sdkVersion);
+            writer.WriteEndObject();
+            writer.WriteEndObject();
+        }
+
+        stream.Position = 0;
+        return stream;
+    }
+
+    [TestMethod]
+    public async Task TestDotNetDetectorWithNoFiles_ReturnsSuccessfullyAsync()
+    {
+        var (scanResult, componentRecorder) = await this.DetectorTestUtility.ExecuteDetectorAsync();
+
+        scanResult.ResultCode.Should().Be(ProcessingResultCode.Success);
+        componentRecorder.GetDetectedComponents().Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task TestDotNetDetectorGlobalJson_ReturnsSDKVersion()
+    {
+        var projectPath = Path.Combine(RootDir, "path", "to", "project");
+        var projectAssets = ProjectAssets("projectName", "does-not-exist", projectPath, "net8.0");
+        var globalJson = GlobalJson("42.0.800");
+        this.AddFile(projectPath, null);
+        this.AddFile(Path.Combine(RootDir, "path", "global.json"), globalJson);
+
+        var (scanResult, componentRecorder) = await this.DetectorTestUtility
+            .WithFile("project.assets.json", projectAssets)
+            .ExecuteDetectorAsync();
+
+        scanResult.ResultCode.Should().Be(ProcessingResultCode.Success);
+
+        var detectedComponents = componentRecorder.GetDetectedComponents();
+        detectedComponents.Should().HaveCount(2);
+
+        var discoveredComponents = detectedComponents.ToArray();
+        discoveredComponents.Where(component => component.Component.Id == "dotnet 42.0.800").Should().ContainSingle();
+        discoveredComponents.Where(component => component.Component.Id == "dotnet 42.0.800 - net8.0").Should().ContainSingle();
+    }
+
+    [TestMethod]
+    public async Task TestDotNetDetectorNoGlobalJson_ReturnsDotNetVersion()
+    {
+        var projectPath = Path.Combine(RootDir, "path", "to", "project");
+        var projectAssets = ProjectAssets("projectName", "does-not-exist", projectPath, "net8.0");
+        this.AddFile(projectPath, null);
+        this.SetCommandResult(0, "86.75.309");
+
+        var (scanResult, componentRecorder) = await this.DetectorTestUtility
+            .WithFile("project.assets.json", projectAssets)
+            .ExecuteDetectorAsync();
+
+        scanResult.ResultCode.Should().Be(ProcessingResultCode.Success);
+
+        var detectedComponents = componentRecorder.GetDetectedComponents();
+        detectedComponents.Should().ContainSingle();
+
+        var discoveredComponents = detectedComponents.ToArray();
+        discoveredComponents.Where(component => component.Component.Id == "dotnet 86.75.309 - net8.0").Should().ContainSingle();
+    }
+
+    [TestMethod]
+    public async Task TestDotNetDetectorNoGlobalJsonNoDotnet_ReturnsUnknownVersion()
+    {
+        var projectPath = Path.Combine(RootDir, "path", "to", "project");
+        var projectAssets = ProjectAssets("projectName", "does-not-exist", projectPath, "net8.0");
+        this.AddFile(projectPath, null);
+        this.SetCommandResult(-1);
+
+        var (scanResult, componentRecorder) = await this.DetectorTestUtility
+            .WithFile("project.assets.json", projectAssets)
+            .ExecuteDetectorAsync();
+
+        scanResult.ResultCode.Should().Be(ProcessingResultCode.Success);
+
+        var detectedComponents = componentRecorder.GetDetectedComponents();
+        detectedComponents.Should().ContainSingle();
+
+        var discoveredComponents = detectedComponents.ToArray();
+        discoveredComponents.Where(component => component.Component.Id == "dotnet unknown - net8.0").Should().ContainSingle();
+    }
+
+    [TestMethod]
+    public async Task TestDotNetDetectorMultipleTargetFrameworks()
+    {
+        var projectPath = Path.Combine(RootDir, "path", "to", "project");
+        var projectAssets = ProjectAssets("projectName", "does-not-exist", projectPath, "net8.0", "net6.0", "netstandard2.0");
+        this.AddFile(projectPath, null);
+        this.SetCommandResult(0, "1.2.3");
+
+        var (scanResult, componentRecorder) = await this.DetectorTestUtility
+            .WithFile("project.assets.json", projectAssets)
+            .ExecuteDetectorAsync();
+
+        scanResult.ResultCode.Should().Be(ProcessingResultCode.Success);
+
+        var detectedComponents = componentRecorder.GetDetectedComponents();
+        detectedComponents.Should().HaveCount(3);
+
+        var discoveredComponents = detectedComponents.ToArray();
+        discoveredComponents.Where(component => component.Component.Id == "dotnet 1.2.3 - net8.0").Should().ContainSingle();
+        discoveredComponents.Where(component => component.Component.Id == "dotnet 1.2.3 - net6.0").Should().ContainSingle();
+        discoveredComponents.Where(component => component.Component.Id == "dotnet 1.2.3 - netstandard2.0").Should().ContainSingle();
+    }
+
+    [TestMethod]
+    public async Task TestDotNetDetectorMultipleProjectsWithDifferentOutputTypeAndSdkVersion()
+    {
+        // dotnet on the path with be version 1.2.3
+        this.SetCommandResult(0, "1.2.3");
+
+        // dotnet from global.json will be 4.5.6
+        var globalJson = GlobalJson("4.5.6");
+        this.AddFile(Path.Combine(RootDir, "path", "global.json"), globalJson);
+
+        // set up a library project - under global.json
+        var libraryProjectName = "library";
+        var libraryProjectPath = Path.Combine(RootDir, "path", "to", "project", $"{libraryProjectName}.csproj");
+        this.AddFile(libraryProjectPath, null);
+        var libraryOutputPath = Path.Combine(Path.GetDirectoryName(libraryProjectPath), "obj");
+        var libraryAssetsPath = Path.Combine(libraryOutputPath, "project.assets.json");
+        var libraryAssets = ProjectAssets("library", libraryOutputPath, libraryProjectPath, "net8.0", "net6.0", "netstandard2.0");
+        var libraryAssemblyStream = File.OpenRead(typeof(DotNetComponent).Assembly.Location);
+        this.AddFile(Path.Combine(libraryOutputPath, "Release", "net8.0", "library.dll"), libraryAssemblyStream);
+        this.AddFile(Path.Combine(libraryOutputPath, "Release", "net6.0", "library.dll"), libraryAssemblyStream);
+        this.AddFile(Path.Combine(libraryOutputPath, "Release", "netstandard2.0", "library.dll"), libraryAssemblyStream);
+
+        // set up an application - not under global.json
+        var applicationProjectName = "application";
+        var applicationProjectPath = Path.Combine(RootDir, "anotherPath", "to", "project", $"{applicationProjectName}.csproj");
+        this.AddFile(applicationProjectPath, null);
+        var applicationOutputPath = Path.Combine(Path.GetDirectoryName(applicationProjectPath), "obj");
+        var applicationAssetsPath = Path.Combine(applicationOutputPath, "project.assets.json");
+        var applicationAssets = ProjectAssets("application", applicationOutputPath, applicationProjectPath, "net8.0", "net4.8");
+        var applicationAssemblyStream = File.OpenRead(Assembly.GetEntryAssembly().Location);
+        this.AddFile(Path.Combine(applicationOutputPath, "Release", "net8.0", "application.dll"), applicationAssemblyStream);
+        this.AddFile(Path.Combine(applicationOutputPath, "Release", "net4.8", "application.exe"), applicationAssemblyStream);
+
+        var (scanResult, componentRecorder) = await this.DetectorTestUtility
+            .WithFile(libraryAssetsPath, libraryAssets)
+            .WithFile(applicationAssetsPath, applicationAssets)
+            .ExecuteDetectorAsync();
+
+        scanResult.ResultCode.Should().Be(ProcessingResultCode.Success);
+
+        var detectedComponents = componentRecorder.GetDetectedComponents();
+        detectedComponents.Should().HaveCount(6);
+
+        var discoveredComponents = detectedComponents.ToArray();
+        discoveredComponents.Where(component => component.Component.Id == "dotnet 4.5.6").Should().ContainSingle();
+        discoveredComponents.Where(component => component.Component.Id == "dotnet 4.5.6 - net8.0 - library").Should().ContainSingle();
+        discoveredComponents.Where(component => component.Component.Id == "dotnet 4.5.6 - net6.0 - library").Should().ContainSingle();
+        discoveredComponents.Where(component => component.Component.Id == "dotnet 4.5.6 - netstandard2.0 - library").Should().ContainSingle();
+        discoveredComponents.Where(component => component.Component.Id == "dotnet 1.2.3 - net8.0 - application").Should().ContainSingle();
+        discoveredComponents.Where(component => component.Component.Id == "dotnet 1.2.3 - net48 - application").Should().ContainSingle();
+    }
+}

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/DotNetComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/DotNetComponentDetectorTests.cs
@@ -343,7 +343,7 @@ public class DotNetComponentDetectorTests : BaseDetectorTest<DotNetComponentDete
         this.SetCommandResult((c, d) => new CommandLineExecutionResult()
         {
             ExitCode = 0,
-            StdOut = d.FullName == globalJsonDir ? "4.5.6" : "1.2.3",
+            StdOut = d.FullName.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) == globalJsonDir ? "4.5.6" : "1.2.3",
         });
 
         // set up a library project - under global.json

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/DotNetComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/DotNetComponentDetectorTests.cs
@@ -120,7 +120,7 @@ public class DotNetComponentDetectorTests : BaseDetectorTest<DotNetComponentDete
 
     private void AddDirectory(string path, string subDirectory = null)
     {
-        if (path is null)
+        if (string.IsNullOrEmpty(path))
         {
             return;
         }

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/DotNetComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/DotNetComponentDetectorTests.cs
@@ -26,7 +26,7 @@ using Moq;
 [TestCategory("Governance/ComponentDetection")]
 public class DotNetComponentDetectorTests : BaseDetectorTest<DotNetComponentDetector>
 {
-    private static readonly string RootDir = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "C:" : @"\";
+    private static readonly string RootDir = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "C:" : @"/";
 
     private readonly Mock<ILogger<DotNetComponentDetector>> mockLogger = new();
 
@@ -101,7 +101,7 @@ public class DotNetComponentDetectorTests : BaseDetectorTest<DotNetComponentDete
 
                 if (fileName.EndsWith(Path.DirectorySeparatorChar))
                 {
-                    foreach (var subFile in this.EnumerateFilesRecursive(filePath.TrimEnd(Path.DirectorySeparatorChar)))
+                    foreach (var subFile in this.EnumerateFilesRecursive(Path.TrimEndingDirectorySeparator(filePath)))
                     {
                         yield return subFile;
                     }
@@ -343,7 +343,7 @@ public class DotNetComponentDetectorTests : BaseDetectorTest<DotNetComponentDete
         this.SetCommandResult((c, d) => new CommandLineExecutionResult()
         {
             ExitCode = 0,
-            StdOut = d.FullName.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) == globalJsonDir ? "4.5.6" : "1.2.3",
+            StdOut = d.FullName == globalJsonDir ? "4.5.6" : "1.2.3",
         });
 
         // set up a library project - under global.json
@@ -431,14 +431,14 @@ public class DotNetComponentDetectorTests : BaseDetectorTest<DotNetComponentDete
     public async Task TestDotNetDetectorNoGlobalJsonSourceRoot()
     {
         // DetectorTestUtility runs under Path.GetTempPath()
-        var scanRoot = Path.GetTempPath().TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var scanRoot = Path.TrimEndingDirectorySeparator(Path.GetTempPath());
 
         var projectPath = Path.Combine(scanRoot, "path", "to", "project");
         var projectAssets = ProjectAssets("projectName", "does-not-exist", projectPath, "net8.0");
         this.AddFile(projectPath, null);
         this.SetCommandResult((c, d) =>
         {
-            d.FullName.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar).Should().BeEquivalentTo(scanRoot);
+            d.FullName.Should().BeEquivalentTo(scanRoot);
             return new CommandLineExecutionResult()
             {
                 ExitCode = 0,

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/Microsoft.ComponentDetection.Detectors.Tests.csproj
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/Microsoft.ComponentDetection.Detectors.Tests.csproj
@@ -8,6 +8,7 @@
     <ItemGroup Label="Package References">
         <PackageReference Include="FluentAssertions.Analyzers" PrivateAssets="all" />
         <PackageReference Include="Microsoft.Extensions.Logging" />
+        <PackageReference Include="NuGet.ProjectModel" />
         <PackageReference Include="NuGet.Versioning" />
         <PackageReference Include="SemanticVersioning" />
         <PackageReference Include="System.Reactive" />


### PR DESCRIPTION
The DotNetComponent type is used to report usage of the .NET SDK version

This is important as the .NET SDK will add redistributable content to the project, so using an older version may mean your application contains unserviced copies of the host or runtime. The TargetFramework and project type is reported as well since these influence what content the SDK may reference.

Some remaining work:

- [ ] Add documentation
- [x] Support concurrency (protect cache)
- [x] More tests - bad assembly, shared files under same global.json/root, ensure we halt global.json search appropriately.
- [x] Answer question about PURL