### PR TITLE
Update manifest.schema.json to include DotNet

### DIFF
--- a/docs/schema/manifest.schema.json
+++ b/docs/schema/manifest.schema.json
@@ -117,7 +117,8 @@
               "Conda",
               "Spdx",
               "Vcpkg",
-              "DockerReference"
+              "DockerReference",
+              "DotNet"
             ]
           }
         }
@@ -343,7 +344,8 @@
             "Conda",
             "Spdx",
             "Vcpkg",
-            "DockerReference"
+            "DockerReference",
+            "DotNet"
           ]
         },
         "id": {


### PR DESCRIPTION
## Context
We recently introduced a new detector but we missed updating the manifest schema due to noisy failures with Pip tests, which will be fixed asap.