### PR TITLE
Move null guard statement up in NuGetComponentDetector.IsValidPath to avoid uncessary throw of ArgumentNullException in FileInfo constructor

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/nuget/NuGetComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/nuget/NuGetComponentDetector.cs
@@ -254,6 +254,11 @@ public class NuGetComponentDetector : FileComponentDetector
     /// <returns>True if path is valid, otherwise it retuns false. </returns>
     private bool IsValidPath(string potentialPath)
     {
+        if (potentialPath == null)
+        {
+            return false;
+        }
+
         FileInfo fileInfo = null;
 
         try
@@ -261,11 +266,6 @@ public class NuGetComponentDetector : FileComponentDetector
             fileInfo = new FileInfo(potentialPath);
         }
         catch
-        {
-            return false;
-        }
-
-        if (potentialPath == null)
         {
             return false;
         }


### PR DESCRIPTION
Moves guard statement up in the NuGetComponentDetector to avoid unnecessary throw in the FileInfo constructor