### PR TITLE
Remove incomplete ELF Syft results for Mariner 2.0

### DIFF
--- a/src/Microsoft.ComponentDetection.Common/Telemetry/Records/LinuxScannerSyftTelemetryRecord.cs
+++ b/src/Microsoft.ComponentDetection.Common/Telemetry/Records/LinuxScannerSyftTelemetryRecord.cs
@@ -8,5 +8,5 @@ public class LinuxScannerSyftTelemetryRecord : BaseDetectionTelemetryRecord
 
     public string Exception { get; set; }
 
-    public int Mariner2ComponentsRemoved { get; set; }
+    public string[] Mariner2ComponentsRemoved { get; set; }
 }

--- a/src/Microsoft.ComponentDetection.Common/Telemetry/Records/LinuxScannerSyftTelemetryRecord.cs
+++ b/src/Microsoft.ComponentDetection.Common/Telemetry/Records/LinuxScannerSyftTelemetryRecord.cs
@@ -7,4 +7,6 @@ public class LinuxScannerSyftTelemetryRecord : BaseDetectionTelemetryRecord
     public string LinuxComponents { get; set; }
 
     public string Exception { get; set; }
+
+    public int Mariner2ComponentsRemoved { get; set; }
 }

--- a/src/Microsoft.ComponentDetection.Detectors/linux/LinuxContainerDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/linux/LinuxContainerDetector.cs
@@ -35,7 +35,7 @@ public class LinuxContainerDetector : IComponentDetector
 
     public IEnumerable<ComponentType> SupportedComponentTypes => [ComponentType.Linux];
 
-    public int Version => 5;
+    public int Version => 6;
 
     public bool NeedsAutomaticRootDependencyCalculation => false;
 

--- a/src/Microsoft.ComponentDetection.Detectors/linux/LinuxScanner.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/linux/LinuxScanner.cs
@@ -121,6 +121,8 @@ public class LinuxScanner : ILinuxScanner
                         && !artifact.Version.Contains('-', StringComparison.OrdinalIgnoreCase)) // dash character indicates that the release version was properly appended to the version, so allow these
                     .ToList();
 
+                // Confirms that the package version was detected elsewhere in the image before removing,
+                // such as the rpmmanifest
                 var elfVersionsRemoved = new List<string>();
                 foreach (var elfArtifact in elfVersionsWithoutRelease)
                 {

--- a/src/Microsoft.ComponentDetection.Detectors/linux/LinuxScanner.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/linux/LinuxScanner.cs
@@ -104,7 +104,27 @@ public class LinuxScanner : ILinuxScanner
         try
         {
             var syftOutput = JsonConvert.DeserializeObject<SyftOutput>(stdout);
-            var linuxComponentsWithLayers = syftOutput.Artifacts
+
+            // This workaround ignores some packages that originate from the mariner 2.0 image that
+            // have not been properly tagged with the release and epoch fields in their versions. This
+            // was fixed for azurelinux 3.0 with https://github.com/microsoft/azurelinux/pull/10405, but
+            // 2.0 no longer recieves non-security updates and will be deprecated in July 2025.
+            // This became a problem after the Syft update https://github.com/anchore/syft/pull/3008 which
+            // allowed for Syft to respect the package type that is listed in the ELF notes file. Since
+            // mariner 2.0 lists the packages as RPMs, Syft categorizes them as such.
+            var validArtifacts = syftOutput.Artifacts.ToList();
+            if (syftOutput.Distro.Id == "mariner" && syftOutput.Distro.VersionId == "2.0")
+            {
+                validArtifacts = validArtifacts
+                    .Where(artifact =>
+                        artifact.FoundBy != "elf-binary-package-cataloger" // a number of detectors execute with Syft, this one can container invalid results
+                        || artifact.Version.Contains('-', StringComparison.OrdinalIgnoreCase)) // dash character indicates that the release version was properly appended to the version, so allow these
+                    .ToList();
+            }
+
+            syftTelemetryRecord.Mariner2ComponentsRemoved = syftOutput.Artifacts.Length - validArtifacts.Count;
+
+            var linuxComponentsWithLayers = validArtifacts
                 .DistinctBy(artifact => (artifact.Name, artifact.Version))
                 .Where(artifact => AllowedArtifactTypes.Contains(artifact.Type))
                 .Select(artifact =>

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/LinuxScannerTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/LinuxScannerTests.cs
@@ -169,6 +169,42 @@ public class LinuxScannerTests
                 ]
             }";
 
+    private const string SyftOutputKeepNonduplicatedMarinerPackages = @"{
+                ""distro"": {
+                    ""prettyName"": ""CBL-Mariner/Linux"",
+                    ""name"": ""Common Base Linux Mariner"",
+                    ""id"": ""mariner"",
+                    ""version"": ""2.0.20250304"",
+                    ""versionID"": ""2.0"",
+                },
+                ""artifacts"": [
+                    {
+                        ""id"": ""4af20256df269904"",
+                        ""name"": ""busybox"",
+                        ""version"": ""1.35.0"",
+                        ""type"": ""rpm"",
+                        ""foundBy"": ""elf-binary-package-cataloger"",
+                        ""locations"": [
+                            {
+                                ""path"": ""/usr/sbin/busybox"",
+                                ""layerID"": ""sha256:81caca2c07d9859b258a9cdfb1b1ab9d063f30ab73a4de9ea2ae760fd175bac6"",
+                                ""accessPath"": ""/usr/sbin/busybox"",
+                                ""annotations"": { ""evidence"": ""primary"" }
+                            }
+                        ],
+                        ""cpes"": [
+                            {
+                                ""cpe"": ""cpe:2.3:a:busybox:busybox:1.35.0:*:*:*:*:*:*:*"",
+                                ""source"": ""syft-generated""
+                            }
+                        ],
+                        ""purl"": ""pkg:rpm/mariner/busybox@1.35.0?distro=mariner-2.0"",
+                        ""metadataType"": ""elf-binary-package-note-json-payload"",
+                        ""metadata"": { ""type"": ""rpm"", ""os"": ""mariner"", ""osVersion"": ""2.0"" }
+                    },
+                ]
+            }";
+
     private readonly LinuxScanner linuxScanner;
     private readonly Mock<IDockerService> mockDockerService;
     private readonly Mock<ILogger<LinuxScanner>> mockLogger;
@@ -237,6 +273,25 @@ public class LinuxScannerTests
         var package = result.First();
         package.Name.Should().Be("busybox");
         package.Version.Should().Be("1.35.0-13.cm2");
+        package.Release.Should().Be("2.0");
+        package.Distribution.Should().Be("mariner");
+        package.Author.Should().Be(null);
+        package.License.Should().Be(null);
+    }
+
+    [TestMethod]
+    [DataRow(SyftOutputKeepNonduplicatedMarinerPackages)]
+    public async Task TestLinuxScanner_SyftOutputKeepNonduplicatedMarinerPackages_Async(string syftOutput)
+    {
+        this.mockDockerService.Setup(service => service.CreateAndRunContainerAsync(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((syftOutput, string.Empty));
+
+        var result = (await this.linuxScanner.ScanLinuxAsync("fake_hash", [new DockerLayer { LayerIndex = 0, DiffId = "sha256:81caca2c07d9859b258a9cdfb1b1ab9d063f30ab73a4de9ea2ae760fd175bac6" }], 0)).First().LinuxComponents;
+
+        result.Should().ContainSingle();
+        var package = result.First();
+        package.Name.Should().Be("busybox");
+        package.Version.Should().Be("1.35.0");
         package.Release.Should().Be("2.0");
         package.Distribution.Should().Be("mariner");
         package.Author.Should().Be(null);

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/LinuxScannerTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/LinuxScannerTests.cs
@@ -95,6 +95,80 @@ public class LinuxScannerTests
                 ]
             }";
 
+    private const string SyftOutputIgnoreInvalidMarinerPackages = @"{
+                ""distro"": {
+                    ""prettyName"": ""CBL-Mariner/Linux"",
+                    ""name"": ""Common Base Linux Mariner"",
+                    ""id"": ""mariner"",
+                    ""version"": ""2.0.20250304"",
+                    ""versionID"": ""2.0"",
+                },
+                ""artifacts"": [
+                    {
+                        ""id"": ""4af20256df269904"",
+                        ""name"": ""busybox"",
+                        ""version"": ""1.35.0"",
+                        ""type"": ""rpm"",
+                        ""foundBy"": ""elf-binary-package-cataloger"",
+                        ""locations"": [
+                            {
+                                ""path"": ""/usr/sbin/busybox"",
+                                ""layerID"": ""sha256:81caca2c07d9859b258a9cdfb1b1ab9d063f30ab73a4de9ea2ae760fd175bac6"",
+                                ""accessPath"": ""/usr/sbin/busybox"",
+                                ""annotations"": { ""evidence"": ""primary"" }
+                            }
+                        ],
+                        ""cpes"": [
+                            {
+                                ""cpe"": ""cpe:2.3:a:busybox:busybox:1.35.0:*:*:*:*:*:*:*"",
+                                ""source"": ""syft-generated""
+                            }
+                        ],
+                        ""purl"": ""pkg:rpm/mariner/busybox@1.35.0?distro=mariner-2.0"",
+                        ""metadataType"": ""elf-binary-package-note-json-payload"",
+                        ""metadata"": { ""type"": ""rpm"", ""os"": ""mariner"", ""osVersion"": ""2.0"" }
+                    },
+                    {
+                        ""id"": ""45849b2d67d236b0"",
+                        ""name"": ""busybox"",
+                        ""version"": ""1.35.0-13.cm2"",
+                        ""type"": ""rpm"",
+                        ""foundBy"": ""rpm-db-cataloger"",
+                        ""locations"": [
+                            {
+                                ""path"": ""/var/lib/rpmmanifest/container-manifest-2"",
+                                ""layerID"": ""sha256:81caca2c07d9859b258a9cdfb1b1ab9d063f30ab73a4de9ea2ae760fd175bac6"",
+                                ""accessPath"": ""/var/lib/rpmmanifest/container-manifest-2"",
+                                ""annotations"": { ""evidence"": ""primary"" }
+                            }
+                        ],
+                        ""cpes"": [
+                            {
+                                ""cpe"": ""cpe:2.3:a:microsoftcorporation:busybox:1.35.0-13.cm2:*:*:*:*:*:*:*"",
+                                ""source"": ""syft-generated""
+                            },
+                            {
+                                ""cpe"": ""cpe:2.3:a:busybox:busybox:1.35.0-13.cm2:*:*:*:*:*:*:*"",
+                                ""source"": ""syft-generated""
+                            }
+                        ],
+                        ""purl"": ""pkg:rpm/busybox@1.35.0-13.cm2?arch=x86_64&upstream=busybox-1.35.0-13.cm2.src.rpm"",
+                        ""metadataType"": ""rpm-db-entry"",
+                        ""metadata"": {
+                            ""name"": ""busybox"",
+                            ""version"": ""1.35.0"",
+                            ""epoch"": null,
+                            ""architecture"": ""x86_64"",
+                            ""release"": ""13.cm2"",
+                            ""sourceRpm"": ""busybox-1.35.0-13.cm2.src.rpm"",
+                            ""size"": 3512551,
+                            ""vendor"": ""Microsoft Corporation"",
+                            ""files"": null
+                        }
+                    },
+                ]
+            }";
+
     private readonly LinuxScanner linuxScanner;
     private readonly Mock<IDockerService> mockDockerService;
     private readonly Mock<ILogger<LinuxScanner>> mockLogger;
@@ -146,6 +220,25 @@ public class LinuxScannerTests
         package.Version.Should().Be("1.0.0");
         package.Release.Should().Be("1.0.0");
         package.Distribution.Should().Be("test-distribution");
+        package.Author.Should().Be(null);
+        package.License.Should().Be(null);
+    }
+
+    [TestMethod]
+    [DataRow(SyftOutputIgnoreInvalidMarinerPackages)]
+    public async Task TestLinuxScanner_SyftOutputIgnoreInvalidMarinerPackages_Async(string syftOutput)
+    {
+        this.mockDockerService.Setup(service => service.CreateAndRunContainerAsync(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((syftOutput, string.Empty));
+
+        var result = (await this.linuxScanner.ScanLinuxAsync("fake_hash", [new DockerLayer { LayerIndex = 0, DiffId = "sha256:81caca2c07d9859b258a9cdfb1b1ab9d063f30ab73a4de9ea2ae760fd175bac6" }], 0)).First().LinuxComponents;
+
+        result.Should().ContainSingle();
+        var package = result.First();
+        package.Name.Should().Be("busybox");
+        package.Version.Should().Be("1.35.0-13.cm2");
+        package.Release.Should().Be("2.0");
+        package.Distribution.Should().Be("mariner");
         package.Author.Should().Be(null);
         package.License.Should().Be(null);
     }


### PR DESCRIPTION
Mariner 2.0 images do not contain a specific enough version in its ELF notes. https://github.com/microsoft/azurelinux/pull/10405 fixes it for azure linux 3.0, but the change is unable to be ported to 2.0. The packages we skip here are detected with the release version elsewhere in the image, so we are safe to remove the incomplete duplicates.