### PR TITLE
Fix path rebasing on linux

### DIFF
--- a/test/Microsoft.ComponentDetection.Detectors.Tests/DotNetComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/DotNetComponentDetectorTests.cs
@@ -185,6 +185,12 @@ public class DotNetComponentDetectorTests : BaseDetectorTest<DotNetComponentDete
         LockFile lockFile = new();
         using var textWriter = new StringWriter();
 
+        // assets file always includes a trailing separator
+        if (!Path.EndsInDirectorySeparator(outputPath))
+        {
+            outputPath += Path.DirectorySeparatorChar;
+        }
+
         lockFile.Targets = targetFrameworks.Select(tfm => new LockFileTarget() { TargetFramework = NuGetFramework.Parse(tfm) }).ToList();
         lockFile.PackageSpec = new()
         {


### PR DESCRIPTION
The assets file always included a trailing separator, whereas the output of GetDirectoryName did not.  This was causing rebasing to fail to find a matching replacement path.

Most of this change is just improving some comments.  The fix is to switch from `pathUtilityService.NormalizePath` to `NormalizeDirectory` which also trims trailing separators.