### PR TITLE
Mariner 2.0 Syft Tweak Ignore Logic

### DIFF
--- a/src/Microsoft.ComponentDetection.Common/Telemetry/Records/LinuxScannerSyftTelemetryRecord.cs
+++ b/src/Microsoft.ComponentDetection.Common/Telemetry/Records/LinuxScannerSyftTelemetryRecord.cs
@@ -8,5 +8,5 @@ public class LinuxScannerSyftTelemetryRecord : BaseDetectionTelemetryRecord
 
     public string Exception { get; set; }
 
-    public string[] Mariner2ComponentsRemoved { get; set; }
+    public string Mariner2ComponentsRemoved { get; set; }
 }

--- a/src/Microsoft.ComponentDetection.Detectors/linux/LinuxScanner.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/linux/LinuxScanner.cs
@@ -121,22 +121,14 @@ public class LinuxScanner : ILinuxScanner
                         && !artifact.Version.Contains('-', StringComparison.OrdinalIgnoreCase)) // dash character indicates that the release version was properly appended to the version, so allow these
                     .ToList();
 
-                // Confirms that the package version was detected elsewhere in the image before removing,
-                // such as the rpmmanifest
                 var elfVersionsRemoved = new List<string>();
                 foreach (var elfArtifact in elfVersionsWithoutRelease)
                 {
-                    if (validArtifacts.Any(artifact =>
-                        artifact.Name == elfArtifact.Name
-                        && artifact.Version.StartsWith(elfArtifact.Version)
-                        && artifact.FoundBy != "elf-binary-package-cataloger"))
-                    {
-                        elfVersionsRemoved.Add(elfArtifact.Name + " " + elfArtifact.Version);
-                        validArtifacts.Remove(elfArtifact);
-                    }
+                    elfVersionsRemoved.Add(elfArtifact.Name + " " + elfArtifact.Version);
+                    validArtifacts.Remove(elfArtifact);
                 }
 
-                syftTelemetryRecord.Mariner2ComponentsRemoved = [.. elfVersionsRemoved];
+                syftTelemetryRecord.Mariner2ComponentsRemoved = JsonConvert.SerializeObject(elfVersionsRemoved);
             }
 
             var linuxComponentsWithLayers = validArtifacts

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/LinuxScannerTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/LinuxScannerTests.cs
@@ -169,7 +169,7 @@ public class LinuxScannerTests
                 ]
             }";
 
-    private const string SyftOutputKeepNonduplicatedMarinerPackages = @"{
+    private const string SyftOutputRemoveNonduplicatedMarinerPackages = @"{
                 ""distro"": {
                     ""prettyName"": ""CBL-Mariner/Linux"",
                     ""name"": ""Common Base Linux Mariner"",
@@ -280,7 +280,7 @@ public class LinuxScannerTests
     }
 
     [TestMethod]
-    [DataRow(SyftOutputKeepNonduplicatedMarinerPackages)]
+    [DataRow(SyftOutputRemoveNonduplicatedMarinerPackages)]
     public async Task TestLinuxScanner_SyftOutputKeepNonduplicatedMarinerPackages_Async(string syftOutput)
     {
         this.mockDockerService.Setup(service => service.CreateAndRunContainerAsync(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
@@ -288,13 +288,6 @@ public class LinuxScannerTests
 
         var result = (await this.linuxScanner.ScanLinuxAsync("fake_hash", [new DockerLayer { LayerIndex = 0, DiffId = "sha256:81caca2c07d9859b258a9cdfb1b1ab9d063f30ab73a4de9ea2ae760fd175bac6" }], 0)).First().LinuxComponents;
 
-        result.Should().ContainSingle();
-        var package = result.First();
-        package.Name.Should().Be("busybox");
-        package.Version.Should().Be("1.35.0");
-        package.Release.Should().Be("2.0");
-        package.Distribution.Should().Be("mariner");
-        package.Author.Should().Be(null);
-        package.License.Should().Be(null);
+        result.Should().BeEmpty();
     }
 }


### PR DESCRIPTION
We cannot assume that multistage docker builds will pull in the rpm manifests from the mariner images, so Syft needs to just ignore all ELF package notes files for Mariner 2 images (reverting to previous Syft behavior).