### PR TITLE
Fix pnpm 9 link dependency bug in detector

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/pnpm/Pnpm9Detector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pnpm/Pnpm9Detector.cs
@@ -72,13 +72,20 @@ public class Pnpm9Detector : IPnpmDetector
         foreach (var (name, dep) in dependencies ?? Enumerable.Empty<KeyValuePair<string, PnpmYamlV9Dependency>>())
         {
             var pnpmDependencyPath = this.pnpmParsingUtilities.ReconstructPnpmDependencyPath(name, dep.Version);
-            var (component, package) = components[pnpmDependencyPath];
             var (_, packageVersion) = this.pnpmParsingUtilities.ExtractNameAndVersionFromPnpmPackagePath(pnpmDependencyPath);
+            var isFileOrLink = this.IsFileOrLink(packageVersion);
+
+            if (isFileOrLink && !components.ContainsKey(pnpmDependencyPath))
+            {
+                // Link dependencies are not present in the snapshots section of the lockfile. If that's the case here, skip it.
+                continue;
+            }
+
+            var (component, package) = components[pnpmDependencyPath];
 
             // Lockfile v9 apparently removed the tagging of dev dependencies in the lockfile, so we revert to using the dependency tree to establish dev dependency state.
             // At this point, the root dependencies are marked according to which dependency group they are declared in the lockfile itself.
             // Ignore "file:" and "link:" as these are local packages.
-            var isFileOrLink = this.IsFileOrLink(packageVersion);
             if (!isFileOrLink)
             {
                 singleFileComponentRecorder.RegisterUsage(component, isExplicitReferencedDependency: true, isDevelopmentDependency: isDevelopmentDependency);

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/PnpmDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/PnpmDetectorTests.cs
@@ -803,6 +803,10 @@ importers:
       SampleLinkDependency:
         specifier: workspace:*
         version: link:SampleLinkDependency
+    devDependencies:
+      sampleDevDependency:
+        specifier: ^4.4.4
+        version: 4.4.4
 packages:
   sampleDependency@1.1.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
@@ -812,7 +816,12 @@ packages:
   sampleIndirectDependency@3.3.3:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
-
+  sampleDevDependency@4.4.4:
+    resolution: {integrity: sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==}
+  sampleIndirectDevDependency@5.5.5:
+    resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
+    engines: {node: '>=0.4.0'}
+  
 snapshots:
   sampleDependency@1.1.1:
     dependencies:
@@ -822,6 +831,10 @@ snapshots:
   sampleIndirectDependency2@2.2.2: {}
   sampleIndirectDependency@3.3.3: {}
   sampleFileDependency@file:../test': {}
+  sampleDevDependency@4.4.4:
+    dependencies:
+      sampleIndirectDevDependency: 5.5.5
+  sampleIndirectDevDependency@5.5.5: {}
 ";
 
         var (scanResult, componentRecorder) = await this.DetectorTestUtility
@@ -831,25 +844,40 @@ snapshots:
         scanResult.ResultCode.Should().Be(ProcessingResultCode.Success);
 
         var detectedComponents = componentRecorder.GetDetectedComponents();
-        detectedComponents.Should().HaveCount(3);
+        detectedComponents.Should().HaveCount(5);
         var npmComponents = detectedComponents.Select(x => new { Component = x.Component as NpmComponent, DetectedComponent = x });
         npmComponents.Should().Contain(x => x.Component.Name == "sampleDependency" && x.Component.Version == "1.1.1");
         npmComponents.Should().Contain(x => x.Component.Name == "sampleIndirectDependency2" && x.Component.Version == "2.2.2");
         npmComponents.Should().Contain(x => x.Component.Name == "sampleIndirectDependency" && x.Component.Version == "3.3.3");
+        npmComponents.Should().Contain(x => x.Component.Name == "sampleDevDependency" && x.Component.Version == "4.4.4");
+        npmComponents.Should().Contain(x => x.Component.Name == "sampleIndirectDevDependency" && x.Component.Version == "5.5.5");
 
         var noDevDependencyComponent = npmComponents.First(x => x.Component.Name == "sampleDependency");
         var indirectDependencyComponent2 = npmComponents.First(x => x.Component.Name == "sampleIndirectDependency2");
         var indirectDependencyComponent = npmComponents.First(x => x.Component.Name == "sampleIndirectDependency");
+        var devDependencyComponent = npmComponents.First(x => x.Component.Name == "sampleDevDependency");
+        var indirectDevDependencyComponent = npmComponents.First(x => x.Component.Name == "sampleIndirectDevDependency");
 
         componentRecorder.GetEffectiveDevDependencyValue(noDevDependencyComponent.Component.Id).Should().BeFalse();
         componentRecorder.GetEffectiveDevDependencyValue(indirectDependencyComponent2.Component.Id).Should().BeFalse();
         componentRecorder.GetEffectiveDevDependencyValue(indirectDependencyComponent.Component.Id).Should().BeFalse();
+        componentRecorder.GetEffectiveDevDependencyValue(devDependencyComponent.Component.Id).Should().BeTrue();
+        componentRecorder.GetEffectiveDevDependencyValue(indirectDevDependencyComponent.Component.Id).Should().BeTrue();
         componentRecorder.AssertAllExplicitlyReferencedComponents<NpmComponent>(
             indirectDependencyComponent.Component.Id,
             parentComponent => parentComponent.Name == "sampleDependency");
         componentRecorder.AssertAllExplicitlyReferencedComponents<NpmComponent>(
             indirectDependencyComponent2.Component.Id,
             parentComponent => parentComponent.Name == "sampleDependency");
+        componentRecorder.AssertAllExplicitlyReferencedComponents<NpmComponent>(
+            indirectDevDependencyComponent.Component.Id,
+            parentComponent => parentComponent.Name == "sampleDevDependency");
+
+        var dependencyGraph = componentRecorder.GetDependencyGraphsByLocation().Values.First();
+        var allExplicitlyReferenced = dependencyGraph.GetAllExplicitlyReferencedComponents();
+        allExplicitlyReferenced.Should().HaveCount(2);
+        allExplicitlyReferenced.Should().Contain(noDevDependencyComponent.Component.Id);
+        allExplicitlyReferenced.Should().Contain(devDependencyComponent.Component.Id);
     }
 
     [TestMethod]


### PR DESCRIPTION
I noticed that some pnpm dependencies were being incorrectly marked as root dependencies from a v9 lockfile.

After debugging, I realized the problem was that local dependencies referenced with `workspace:`/`link:` do not appear in the `snapshots` section of the lockfile. As a result, when the detector tries to look them up in the `components` dictionary, an exception is thrown and the rest of the file stops being processed. Because of this, the detector was unable to finish building the dependency graph and incorrectly assumed many dependencies were root dependencies because their ancestor information was never populated.

In order to expose this case in the existing unit test for link dependencies, I added another dependency after `SampleLinkDependency`. Prior to this change, the detector would throw when processing `SampleLinkDependency` and then be unable to mark `sampleDevDependency` as an ancestor of `sampleIndirectDevDependency`.