### PR TITLE
Fix integration tests with DotNet component type

### DIFF
--- a/src/Microsoft.ComponentDetection.Contracts/BcdeModels/TypedComponentConverter.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/BcdeModels/TypedComponentConverter.cs
@@ -27,6 +27,7 @@ public class TypedComponentConverter : JsonConverter
         { ComponentType.DockerReference, typeof(DockerReferenceComponent) },
         { ComponentType.Vcpkg, typeof(VcpkgComponent) },
         { ComponentType.Spdx, typeof(SpdxComponent) },
+        { ComponentType.DotNet, typeof(DotNetComponent) },
     };
 
     public override bool CanWrite


### PR DESCRIPTION
## Context
We recently promoted DotNet component detector. Out integration tests were broken but the PR wasn't blocked, we need to revisit if we are disabling them due to non-deterministic detectors or else, otherwise we should enforce those CI checks for PRs.