### PR TITLE
Allow for `null` resolved version in `package-lock.json`

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/npm/NpmComponentUtilities.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/npm/NpmComponentUtilities.cs
@@ -43,7 +43,7 @@ public static class NpmComponentUtilities
     {
         var name = GetModuleName(currentDependency.Name);
 
-        var version = currentDependency.Value["version"].ToString();
+        var version = currentDependency.Value["version"]?.ToString();
         var hash = currentDependency.Value["integrity"]?.ToString(); // https://docs.npmjs.com/configuring-npm/package-lock-json.html#integrity
 
         if (!IsPackageNameValid(name))


### PR DESCRIPTION
When attempting to scan projects that use npm workspaces[^1] there will not be a resolved version in `package-lock.json`. Currently we throw a `NullReferenceException` as we attempt to call `ToString` on this `null` object. An example of how this appears in the `package-lock.json` is:

```json
"node_modules/example": {
  "resolved": "scripts",
  "link": true
}
```

From the npm documentation[^2]:

> `link`: A flag to indicate that this is a symbolic link. If this is present, no other fields are specified, since the link target will also be included in the lockfile.

After this change, we will log that the version is `null`, and continue parsing:

```
[13:51:57 INF] Version string null for component example is invalid or unsupported and a component will not be recorded.
```

[^1]: https://docs.npmjs.com/cli/v11/using-npm/workspaces
[^2]: https://docs.npmjs.com/cli/v11/configuring-npm/package-lock-json#packages