### PR TITLE
don't throw if `engines` property is a string array

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/npm/NpmComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/npm/NpmComponentDetector.cs
@@ -111,10 +111,6 @@ public class NpmComponentDetector : FileComponentDetector
                     containsVsCodeEngine = true;
                 }
             }
-            else
-            {
-                throw new NotImplementedException($"Unsupported engines token type {enginesToken}");
-            }
 
             if (containsVsCodeEngine)
             {

--- a/src/Microsoft.ComponentDetection.Detectors/npm/NpmComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/npm/NpmComponentDetector.cs
@@ -89,9 +89,9 @@ public class NpmComponentDetector : FileComponentDetector
             return false;
         }
 
+        var containsVsCodeEngine = false;
         if (enginesToken != null)
         {
-            var containsVsCodeEngine = false;
             if (enginesToken.Type == JTokenType.Array)
             {
                 var engineStrings = enginesToken
@@ -111,12 +111,12 @@ public class NpmComponentDetector : FileComponentDetector
                     containsVsCodeEngine = true;
                 }
             }
+        }
 
-            if (containsVsCodeEngine)
-            {
-                this.Logger.LogInformation("{NpmPackageName} found at path {NpmPackageLocation} represents a built-in VS Code extension. This package will not be registered.", name, filePath);
-                return false;
-            }
+        if (containsVsCodeEngine)
+        {
+            this.Logger.LogInformation("{NpmPackageName} found at path {NpmPackageLocation} represents a built-in VS Code extension. This package will not be registered.", name, filePath);
+            return false;
         }
 
         var npmComponent = new NpmComponent(name, version, author: this.GetAuthor(authorToken, name, filePath));

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/NpmDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/NpmDetectorTests.cs
@@ -239,6 +239,44 @@ public class NpmDetectorTests : BaseDetectorTest<NpmComponentDetector>
         detectedComponents.Should().BeEmpty();
     }
 
+    [TestMethod]
+    public async Task TestNpmDetector_EnginesAsArray_VSCodeEngine()
+    {
+        var packageName = GetRandomString();
+        var packageVersion = NewRandomVersion();
+        var engineText = "vscode >= 6.0";
+        var (packageJsonName, packageJsonContents, packageJsonPath) =
+            NpmTestUtilities.GetPackageJsonNoDependenciesForNameAndVersionWithEngiesAsArray(packageName, packageVersion, engineText);
+
+        var (scanResult, componentRecorder) = await this.DetectorTestUtility
+            .WithFile(packageJsonName, packageJsonContents, this.packageJsonSearchPattern, fileLocation: packageJsonPath)
+            .ExecuteDetectorAsync();
+        scanResult.ResultCode.Should().Be(ProcessingResultCode.Success);
+        var detectedComponents = componentRecorder.GetDetectedComponents();
+        detectedComponents.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task TestNpmDetector_EnginesAsArray_NodeEngine()
+    {
+        var packageName = GetRandomString();
+        var packageVersion = NewRandomVersion();
+        var engineText = "node >= 6.0";
+        var (packageJsonName, packageJsonContents, packageJsonPath) =
+            NpmTestUtilities.GetPackageJsonNoDependenciesForNameAndVersionWithEngiesAsArray(packageName, packageVersion, engineText);
+
+        var (scanResult, componentRecorder) = await this.DetectorTestUtility
+            .WithFile(packageJsonName, packageJsonContents, this.packageJsonSearchPattern, fileLocation: packageJsonPath)
+            .ExecuteDetectorAsync();
+        scanResult.ResultCode.Should().Be(ProcessingResultCode.Success);
+        var detectedComponents = componentRecorder.GetDetectedComponents();
+        detectedComponents.Should().HaveCount(1);
+        detectedComponents.Single().Component.Type.Should().Be(ComponentType.Npm);
+        var detectedNpmComponent = (NpmComponent)detectedComponents.Single().Component;
+        detectedNpmComponent.Name.Should().Be(packageName);
+        detectedNpmComponent.Version.Should().Be(packageVersion);
+    }
+
     private static void AssertDetectedComponentCount(IEnumerable<DetectedComponent> detectedComponents, int expectedCount)
     {
         detectedComponents.Should().HaveCount(expectedCount);

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/NpmDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/NpmDetectorTests.cs
@@ -270,7 +270,7 @@ public class NpmDetectorTests : BaseDetectorTest<NpmComponentDetector>
             .ExecuteDetectorAsync();
         scanResult.ResultCode.Should().Be(ProcessingResultCode.Success);
         var detectedComponents = componentRecorder.GetDetectedComponents();
-        detectedComponents.Should().HaveCount(1);
+        detectedComponents.Should().ContainSingle();
         detectedComponents.Single().Component.Type.Should().Be(ComponentType.Npm);
         var detectedNpmComponent = (NpmComponent)detectedComponents.Single().Component;
         detectedNpmComponent.Name.Should().Be(packageName);

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/NpmTestUtilities.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/NpmTestUtilities.cs
@@ -143,6 +143,19 @@ public static class NpmTestUtilities
         return ("package.json", packageJsonTemplate, Path.Combine(Path.GetTempPath(), "package.json"));
     }
 
+    public static (string PackageJsonName, string PackageJsonContents, string PackageJsonPath) GetPackageJsonNoDependenciesForNameAndVersionWithEngiesAsArray(string packageName, string packageVersion, string engineText)
+    {
+        var packagejson = @"{{
+                ""name"": ""{0}"",
+                ""version"": ""{1}"",
+                ""engines"": [
+                    ""{2}""
+                ]
+            }}";
+        var packageJsonTemplate = string.Format(packagejson, packageName, packageVersion, engineText);
+        return ("package.json", packageJsonTemplate, Path.Combine(Path.GetTempPath(), "package.json"));
+    }
+
     public static (string PackageJsonName, string PackageJsonContents, string PackageJsonPath) GetPackageJsonNoDependenciesForAuthorAndEmailInJsonFormat(
         string authorName, string authorEmail = null)
     {


### PR DESCRIPTION
`package.json` files seen in the wild have had a string array instead of an object for the `engines` property (example [here](https://github.com/Tjatse/ansi-html/blob/25ffe44357aa8f28d00239af61b74baced7510e4/package.json#L29)).  Because of this, anything that pulls in one of these variant packages will fail to generate components.

While `engines` should be an object, this PR allows for this alternate form to allow detection to continue.

Fixes #1385