### PR TITLE
User/aamaini/2281511

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/go/Go117ComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/go/Go117ComponentDetector.cs
@@ -48,7 +48,7 @@ public class Go117ComponentDetector : FileComponentDetector, IExperimentalDetect
 
     public override IEnumerable<ComponentType> SupportedComponentTypes { get; } = [ComponentType.Go];
 
-    public override int Version => 1;
+    public override int Version => 2;
 
     protected override Task<IObservable<ProcessRequest>> OnPrepareDetectionAsync(
         IObservable<ProcessRequest> processRequests,

--- a/src/Microsoft.ComponentDetection.Detectors/go/Go117ComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/go/Go117ComponentDetector.cs
@@ -143,6 +143,10 @@ public class Go117ComponentDetector : FileComponentDetector, IExperimentalDetect
                     this.Logger.LogDebug("Go CLI scan when considering {GoSumLocation} was not successful. Falling back to scanning go.sum", file.Location);
                     await this.goParserFactory.CreateParser(GoParserType.GoSum, this.Logger).ParseAsync(singleFileComponentRecorder, file, record);
                 }
+                else
+                {
+                    this.projectRoots.Add(projectRootDirectory.FullName);
+                }
 
                 break;
             }

--- a/src/Microsoft.ComponentDetection.Detectors/go/Go117ComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/go/Go117ComponentDetector.cs
@@ -75,7 +75,7 @@ public class Go117ComponentDetector : FileComponentDetector, IExperimentalDetect
                     return true;
                 }
 
-                return GoDetectorUtils.ShouldRemoveGoSumFromDetection(goSumFilePath: processRequest.ComponentStream.Location, goModFile, this.Logger);
+                return GoDetectorUtils.ShouldIncludeGoSumFromDetection(goSumFilePath: processRequest.ComponentStream.Location, goModFile, this.Logger);
             }
             finally
             {

--- a/src/Microsoft.ComponentDetection.Detectors/go/GoComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/go/GoComponentDetector.cs
@@ -94,7 +94,7 @@ public class GoComponentDetector : FileComponentDetector
                     return true;
                 }
 
-                return GoDetectorUtils.ShouldRemoveGoSumFromDetection(goSumFilePath: processRequest.ComponentStream.Location, goModFile, this.Logger);
+                return GoDetectorUtils.ShouldIncludeGoSumFromDetection(goSumFilePath: processRequest.ComponentStream.Location, goModFile, this.Logger);
             }
             finally
             {

--- a/src/Microsoft.ComponentDetection.Detectors/go/Utils/GoDetectorUtils.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/go/Utils/GoDetectorUtils.cs
@@ -15,7 +15,7 @@ public static class GoDetectorUtils
     /// <param name="adjacentGoModFile">Component stream representing the adjacent go.mod file.</param>
     /// <param name="logger">The logger to use for logging messages.</param>
     /// <returns>True if the adjacent go.mod file is present and has a go version >= 1.17.</returns>
-    public static bool ShouldRemoveGoSumFromDetection(string goSumFilePath, ComponentStream adjacentGoModFile, ILogger logger)
+    public static bool ShouldIncludeGoSumFromDetection(string goSumFilePath, ComponentStream adjacentGoModFile, ILogger logger)
     {
         using var reader = new StreamReader(adjacentGoModFile.Stream);
         var goModFileContents = reader.ReadToEnd();


### PR DESCRIPTION
Existing implementation of Go117 detector parses go.sum when go version in go.mod < 1.17. This leads to overreporting. 
- The change wires the detector to use go cli's `go list` command if available/enabled
- If `go list` fails, detector falls back to parsing `go.sum` file.
-  At UTs to test that detectors doesn't parse `go.sum` if cli scan succeeded.

This will reduce the divergence between reports from Go117 and Go detector since Go detector used Go CLI if available.

Tests:
- All unit tests pass
- Comparison of detectors on a couple test repos with over-reporting shows that the new behavior doesn't over-report:


|Repo (Found from Go117 experiment) | Go | Go117 (at main) | Go117 (at feature) |
|----------------------------------------|-----|---|--|
|  Repo-1 | 280 components | 863 components | 280 components |
| Repo-2 | 49 components | 60 components | 49 components | 
| Repo-3 | 21 components | 47 components | 21 components | 

So, Go, Go117 (in feature) branch are in parity w.r.t `#components` reported.

