### PR TITLE
User/aamaini/go sort requests

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/go/GoComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/go/GoComponentDetector.cs
@@ -86,7 +86,7 @@ public class GoComponentDetector : FileComponentDetector
         // Sort by depth: shallow files (fewer directory segments) come first
         var sortedGoProcessRequests = filteredGoProcessRequests
             .OrderBy(pr => pr.ComponentStream.Location.Count(c => c == Path.DirectorySeparatorChar))
-            .ThenBy(pr => Path.GetFileName(pr.ComponentStream.Location))
+            .ThenBy(pr => pr.ComponentStream.Location)
             .ToList();
 
         return sortedGoProcessRequests.ToObservable();


### PR DESCRIPTION
Previous Go detector used to ignore child directories of already processed directories because `go list` in parents already accounted for children.
To keep parity with this behavior, Go Detector preprocesses go.mod, go.sum files in order of increasing depth and keeps track of already processed directories.

- `OnPrepareDetectionAsync` sorts all process requests in order of depth, fullname making it fully deterministic and stable sort.
- `OnFileFoundAsync` now tracks processed project roots if go.mod was successfully parsed and go version in it was >= 1.17
- Add UTs to verify detector skips child nested directories.