### PR TITLE
Update smoke test workflow to install all requirements manually on new vanilla ubuntu image

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -53,8 +53,9 @@ jobs:
 
       - name: Install Apache Ivy
         run: |
-          sudo apt update
-          sudo apt install ant
+          # Install Ant package non-interactively
+          sudo apt install -y ant
+          # Download and install Ivy plugin
           curl https://downloads.apache.org/ant/ivy/2.5.2/apache-ivy-2.5.2-bin.tar.gz | tar xOz apache-ivy-2.5.2/ivy-2.5.2.jar > /usr/share/ant/lib/ivy.jar
 
       - name: Checkout Smoke Test Repo

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -53,9 +53,11 @@ jobs:
 
       - name: Install Apache Ivy
         run: |
-          # Install Ant package non-interactively
+          echo "Starting Apache Ant and Ivy installation..."
           sudo apt install -y ant
-          # Download and install Ivy plugin
+
+          echo "Ant installed successfully. Installing Ivy plugin..."
+          sudo chmod 777 /usr/share/ant/lib
           curl https://downloads.apache.org/ant/ivy/2.5.2/apache-ivy-2.5.2-bin.tar.gz | tar xOz apache-ivy-2.5.2/ivy-2.5.2.jar > /usr/share/ant/lib/ivy.jar
 
       - name: Checkout Smoke Test Repo

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
   schedule:
     - cron: "0 0 * * *" # every day at midnight
 

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -8,7 +8,6 @@ on:
     branches:
       - main
   pull_request:
-  workflow_dispatch:
   schedule:
     - cron: "0 0 * * *" # every day at midnight
 

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -41,6 +41,12 @@ jobs:
       - name: Checkout Component Detection
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - name: Prepare Dotnet 
+        run: |
+          # When using a Vanilla Ubuntu image, GH Actions may not have access to the /usr/share/dotnet directory.
+          sudo mkdir /usr/share/dotnet
+          sudo chmod 777 /usr/share/dotnet
+
       - name: Setup .NET
         uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
 

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -52,7 +52,10 @@ jobs:
         uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
 
       - name: Install Apache Ivy
-        run: curl https://downloads.apache.org/ant/ivy/2.5.2/apache-ivy-2.5.2-bin.tar.gz | tar xOz apache-ivy-2.5.2/ivy-2.5.2.jar > /usr/share/ant/lib/ivy.jar
+        run: |
+          sudo mkdir /usr/share/ant
+          sudo chmod 777 /usr/share/ant
+          curl https://downloads.apache.org/ant/ivy/2.5.2/apache-ivy-2.5.2-bin.tar.gz | tar xOz apache-ivy-2.5.2/ivy-2.5.2.jar > /usr/share/ant/lib/ivy.jar
 
       - name: Checkout Smoke Test Repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -53,8 +53,8 @@ jobs:
 
       - name: Install Apache Ivy
         run: |
-          sudo mkdir /usr/share/ant
-          sudo chmod 777 /usr/share/ant
+          sudo apt update
+          sudo apt install ant
           curl https://downloads.apache.org/ant/ivy/2.5.2/apache-ivy-2.5.2-bin.tar.gz | tar xOz apache-ivy-2.5.2/ivy-2.5.2.jar > /usr/share/ant/lib/ivy.jar
 
       - name: Checkout Smoke Test Repo


### PR DESCRIPTION
## Context
We need to upgrade VM image to a newer/patched version in this agent. This new image also has less preinstalled software which requires us to install whatever we need for the job to run.

Based on our first executions, dotnet is not coming preinstalled and GitHub Actions seems to not have access to that directory when trying to create it.

The custom agent pool is mostly necessary to try to reproduce concurrency bug that once hit caused an outage when running at scale + we need these tests to run faster than what default agents offer, see https://github.com/microsoft/component-detection/pull/543 for more context.
