### PR TITLE
Update framework package data

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/nuget/FrameworkPackages/FrameworkPackages.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/nuget/FrameworkPackages/FrameworkPackages.cs
@@ -217,8 +217,15 @@ internal sealed partial class FrameworkPackages : IEnumerable<KeyValuePair<strin
 
     private void Add(string id, string version)
     {
-        // intentionally redirect to indexer to allow for overwrite
-        this.Packages[id] = NuGetVersion.Parse(version);
+        if (string.IsNullOrEmpty(version))
+        {
+            this.Packages.Remove(id);
+        }
+        else
+        {
+            // intentionally redirect to indexer to allow for overwrite
+            this.Packages[id] = NuGetVersion.Parse(version);
+        }
     }
 
     public bool IsAFrameworkComponent(string id, NuGetVersion version) => this.Packages.TryGetValue(id, out var frameworkPackageVersion) && frameworkPackageVersion >= version;

--- a/src/Microsoft.ComponentDetection.Detectors/nuget/FrameworkPackages/FrameworkPackages.net5.0.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/nuget/FrameworkPackages/FrameworkPackages.net5.0.cs
@@ -18,7 +18,7 @@ internal partial class FrameworkPackages
             { "System.Formats.Asn1", "5.0.0" },
             { "System.IO.FileSystem.AccessControl", "5.0.0" },
             { "System.Net.Http.Json", "5.0.0" },
-            { "System.Reflection.DispatchProxy", "4.7.1" },
+            { "System.Reflection.DispatchProxy", "4.8.2" },
             { "System.Reflection.Metadata", "5.0.0" },
             { "System.Runtime.CompilerServices.Unsafe", "5.0.0" },
             { "System.Security.AccessControl", "5.0.0" },
@@ -29,6 +29,11 @@ internal partial class FrameworkPackages
             { "System.Text.Json", "5.0.0" },
             { "System.Threading.Channels", "5.0.0" },
             { "System.Threading.Tasks.Dataflow", "5.0.0" },
+
+            // removed packages
+            { "System.Runtime.InteropServices.WindowsRuntime", null },
+            { "System.Runtime.WindowsRuntime", null },
+            { "System.Runtime.WindowsRuntime.UI.Xaml", null },
         };
 
         internal static FrameworkPackages AspNetCore { get; } = new(Net50, FrameworkNames.AspNetCoreApp, NETCoreApp31.AspNetCore)
@@ -167,6 +172,10 @@ internal partial class FrameworkPackages
             { "System.Security.Permissions", "5.0.0" },
             { "System.Security.Principal.Windows", "5.0.0" },
             { "System.Windows.Extensions", "5.0.0" },
+
+            // removed packages
+            { "Microsoft.Win32.SystemEvents", null },
+            { "System.Drawing.Common", null },
         };
 
         internal static FrameworkPackages WindowsDesktop { get; } = new(Net50, FrameworkNames.WindowsDesktopApp, NETCoreApp31.WindowsDesktop)
@@ -194,6 +203,9 @@ internal partial class FrameworkPackages
             { "System.Security.Principal.Windows", "5.0.0" },
             { "System.Threading.AccessControl", "5.0.0" },
             { "System.Windows.Extensions", "5.0.0" },
+
+            // removed packages
+            { "System.Formats.Asn1", null },
         };
 
         internal static void Register() => FrameworkPackages.Register(Instance, AspNetCore, WindowsDesktop);

--- a/src/Microsoft.ComponentDetection.Detectors/nuget/FrameworkPackages/FrameworkPackages.net6.0.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/nuget/FrameworkPackages/FrameworkPackages.net6.0.cs
@@ -16,7 +16,7 @@ internal partial class FrameworkPackages
             { "System.Formats.Asn1", "6.0.0" },
             { "System.Net.Http.Json", "6.0.0" },
             { "System.Reflection.Metadata", "6.0.0" },
-            { "System.Runtime.CompilerServices.Unsafe", "6.0.0" },
+            { "System.Runtime.CompilerServices.Unsafe", "6.1.2" },
             { "System.Security.AccessControl", "6.0.0" },
             { "System.Text.Encoding.CodePages", "6.0.0" },
             { "System.Text.Encodings.Web", "6.0.0" },
@@ -157,6 +157,14 @@ internal partial class FrameworkPackages
             { "System.IO.Pipelines", "6.0.0" },
             { "System.Security.Cryptography.Pkcs", "6.0.0" },
             { "System.Security.Cryptography.Xml", "6.0.0" },
+
+            // removed packages
+            { "Microsoft.Win32.Registry", null },
+            { "System.Security.AccessControl", null },
+            { "System.Security.Cryptography.Cng", null },
+            { "System.Security.Permissions", null },
+            { "System.Security.Principal.Windows", null },
+            { "System.Windows.Extensions", null },
         };
 
         internal static FrameworkPackages WindowsDesktop { get; } = new(Net60, FrameworkNames.WindowsDesktopApp, NETCoreApp50.WindowsDesktop)
@@ -176,6 +184,14 @@ internal partial class FrameworkPackages
             { "System.Security.Permissions", "6.0.0" },
             { "System.Threading.AccessControl", "6.0.0" },
             { "System.Windows.Extensions", "6.0.0" },
+
+            // removed packages
+            { "Microsoft.Win32.Registry", null },
+            { "System.IO.FileSystem.AccessControl", null },
+            { "System.IO.Pipes.AccessControl", null },
+            { "System.Security.AccessControl", null },
+            { "System.Security.Cryptography.Cng", null },
+            { "System.Security.Principal.Windows", null },
         };
 
         internal static void Register() => FrameworkPackages.Register(Instance, AspNetCore, WindowsDesktop);

--- a/src/Microsoft.ComponentDetection.Detectors/nuget/FrameworkPackages/FrameworkPackages.net9.0.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/nuget/FrameworkPackages/FrameworkPackages.net9.0.cs
@@ -178,6 +178,9 @@ internal partial class FrameworkPackages
             { "System.Security.Cryptography.Pkcs", "8.0.1" },
             { "System.Security.Cryptography.Xml", "9.0.0" },
             { "System.Threading.RateLimiting", "9.0.0" },
+
+            // removed packages
+            { "System.IO.Pipelines", null },
         };
 
         internal static FrameworkPackages WindowsDesktop { get; } = new(Net90, FrameworkNames.WindowsDesktopApp, NETCoreApp80.WindowsDesktop)

--- a/src/Microsoft.ComponentDetection.Detectors/nuget/FrameworkPackages/FrameworkPackages.netcoreapp2.1.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/nuget/FrameworkPackages/FrameworkPackages.netcoreapp2.1.cs
@@ -15,14 +15,14 @@ internal partial class FrameworkPackages
             { "Microsoft.NETCore.App", "2.1.0" },
             { "Microsoft.VisualBasic", "10.3.0" },
             { "Microsoft.Win32.Registry", "4.5.0" },
-            { "System.Buffers", "4.5.0" },
+            { "System.Buffers", "4.6.1" },
             { "System.Collections.Immutable", "1.5.0" },
             { "System.ComponentModel.Annotations", "4.5.0" },
             { "System.Diagnostics.DiagnosticSource", "4.5.0" },
             { "System.IO.FileSystem.AccessControl", "4.5.0" },
             { "System.IO.Pipes.AccessControl", "4.5.0" },
-            { "System.Memory", "4.5.5" },
-            { "System.Numerics.Vectors", "4.5.0" },
+            { "System.Memory", "4.6.3" },
+            { "System.Numerics.Vectors", "4.6.1" },
             { "System.Reflection.DispatchProxy", "4.5.0" },
             { "System.Reflection.Metadata", "1.6.0" },
             { "System.Security.AccessControl", "4.5.0" },
@@ -30,8 +30,8 @@ internal partial class FrameworkPackages
             { "System.Security.Cryptography.OpenSsl", "4.5.0" },
             { "System.Security.Principal.Windows", "4.5.0" },
             { "System.Threading.Tasks.Dataflow", "4.9.0" },
-            { "System.Threading.Tasks.Extensions", "4.5.4" },
-            { "System.ValueTuple", "4.5.0" },
+            { "System.Threading.Tasks.Extensions", "4.6.3" },
+            { "System.ValueTuple", "4.6.1" },
         };
 
         internal static void Register() => FrameworkPackages.Register(Instance);

--- a/src/Microsoft.ComponentDetection.Detectors/nuget/FrameworkPackages/FrameworkPackages.netcoreapp3.0.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/nuget/FrameworkPackages/FrameworkPackages.netcoreapp3.0.cs
@@ -13,7 +13,7 @@ internal partial class FrameworkPackages
         {
             { "Microsoft.CSharp", "4.6.0" },
             { "Microsoft.Win32.Registry", "4.6.0" },
-            { "System.Buffers", "4.5.1" },
+            { "System.Buffers", "4.6.1" },
             { "System.Collections.Immutable", "1.6.0" },
             { "System.ComponentModel.Annotations", "4.6.0" },
             { "System.Data.DataSetExtensions", "4.5.0" },
@@ -28,7 +28,9 @@ internal partial class FrameworkPackages
             { "System.Security.AccessControl", "4.6.0" },
             { "System.Security.Cryptography.Cng", "4.6.0" },
             { "System.Security.Cryptography.OpenSsl", "4.6.0" },
-            { "System.Security.Cryptography.Xml", "4.4.0" },
+
+            // this package was listed in the package overrides.txt for netcoreapp3.0, but it is not actually in the targeting pack
+            // { "System.Security.Cryptography.Xml", "4.4.0" },
             { "System.Security.Principal.Windows", "4.6.0" },
             { "System.Text.Encoding.CodePages", "4.6.0" },
             { "System.Text.Encodings.Web", "4.6.0" },

--- a/src/Microsoft.ComponentDetection.Detectors/nuget/FrameworkPackages/FrameworkPackages.netcoreapp3.1.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/nuget/FrameworkPackages/FrameworkPackages.netcoreapp3.1.cs
@@ -17,7 +17,7 @@ internal partial class FrameworkPackages
             { "System.ComponentModel.Annotations", "4.7.0" },
             { "System.Diagnostics.DiagnosticSource", "4.7.0" },
             { "System.IO.FileSystem.AccessControl", "4.7.0" },
-            { "System.Reflection.DispatchProxy", "4.7.0" },
+            { "System.Reflection.DispatchProxy", "4.8.2" },
             { "System.Reflection.Metadata", "1.8.0" },
             { "System.Runtime.CompilerServices.Unsafe", "4.7.1" },
             { "System.Runtime.WindowsRuntime", "4.7.0" },

--- a/src/Microsoft.ComponentDetection.Detectors/nuget/FrameworkPackages/FrameworkPackages.netstandard2.0.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/nuget/FrameworkPackages/FrameworkPackages.netstandard2.0.cs
@@ -96,7 +96,7 @@ internal partial class FrameworkPackages
             { "System.Threading.Thread", "4.3.0" },
             { "System.Threading.ThreadPool", "4.3.0" },
             { "System.Threading.Timer", "4.3.0" },
-            { "System.ValueTuple", "4.4.0" },
+            { "System.ValueTuple", "4.6.1" },
             { "System.Xml.ReaderWriter", "4.3.1" },
             { "System.Xml.XDocument", "4.0.11" },
             { "System.Xml.XmlDocument", "4.3.0" },

--- a/src/Microsoft.ComponentDetection.Detectors/nuget/FrameworkPackages/FrameworkPackages.netstandard2.1.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/nuget/FrameworkPackages/FrameworkPackages.netstandard2.1.cs
@@ -11,7 +11,7 @@ internal partial class FrameworkPackages
     {
         internal static FrameworkPackages Instance { get; } = new(NetStandard21, FrameworkNames.NetStandardLibrary, NETStandard20.Instance)
         {
-            { "System.Buffers", "4.5.1" },
+            { "System.Buffers", "4.6.1" },
             { "System.Collections.Concurrent", "4.3.0" },
             { "System.Collections.Immutable", "1.4.0" },
             { "System.ComponentModel", "4.3.0" },
@@ -20,10 +20,10 @@ internal partial class FrameworkPackages
             { "System.Diagnostics.Contracts", "4.3.0" },
             { "System.Dynamic.Runtime", "4.3.0" },
             { "System.Linq.Queryable", "4.3.0" },
-            { "System.Memory", "4.5.5" },
+            { "System.Memory", "4.6.3" },
             { "System.Net.Requests", "4.3.0" },
             { "System.Net.WebHeaderCollection", "4.3.0" },
-            { "System.Numerics.Vectors", "4.5.0" },
+            { "System.Numerics.Vectors", "4.6.1" },
             { "System.ObjectModel", "4.3.0" },
             { "System.Private.DataContractSerialization", "4.3.0" },
             { "System.Reflection.DispatchProxy", "4.5.1" },
@@ -35,11 +35,13 @@ internal partial class FrameworkPackages
             { "System.Runtime.Numerics", "4.3.0" },
             { "System.Runtime.Serialization.Json", "4.3.0" },
             { "System.Security.AccessControl", "4.4.0" },
-            { "System.Security.Cryptography.Xml", "4.4.0" },
+
+            // this package was listed in the package overrides.txt for netstandard2.1, but it is not actually in the targeting pack
+            // { "System.Security.Cryptography.Xml", "4.4.0" },
             { "System.Security.Principal", "4.3.0" },
             { "System.Security.Principal.Windows", "4.4.0" },
             { "System.Threading", "4.3.0" },
-            { "System.Threading.Tasks.Extensions", "4.5.4" },
+            { "System.Threading.Tasks.Extensions", "4.6.3" },
             { "System.Threading.Tasks.Parallel", "4.3.0" },
             { "System.Xml.XDocument", "4.3.0" },
             { "System.Xml.XmlSerializer", "4.3.0" },


### PR DESCRIPTION
Porting changes from
https://github.com/dotnet/sdk/pull/49092
https://github.com/dotnet/sdk/pull/49882

These improve the accuracy of the FrameworkPackages -- accounting for some packages which were removed from the shared framework, and representing the latest version of packages which were absorbed into the framework.