### PR TITLE
Reintroduce CargoSBOM detector experiments

### DIFF
--- a/src/Microsoft.ComponentDetection.Orchestrator/Experiments/Configs/RustSbomVsCliExperiment.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Experiments/Configs/RustSbomVsCliExperiment.cs
@@ -1,0 +1,22 @@
+namespace Microsoft.ComponentDetection.Orchestrator.Experiments.Configs;
+
+using Microsoft.ComponentDetection.Contracts;
+using Microsoft.ComponentDetection.Detectors.Rust;
+
+/// <summary>
+/// Validating the Rust SBOM detector against the Rust CLI detector.
+/// </summary>
+public class RustSbomVsCliExperiment : IExperimentConfiguration
+{
+    /// <inheritdoc />
+    public string Name => "RustSbomVsCliExperiment";
+
+    /// <inheritdoc/>
+    public bool IsInControlGroup(IComponentDetector componentDetector) => componentDetector is RustCliDetector;
+
+    /// <inheritdoc/>
+    public bool IsInExperimentGroup(IComponentDetector componentDetector) => componentDetector is RustSbomDetector;
+
+    /// <inheritdoc />
+    public bool ShouldRecord(IComponentDetector componentDetector, int numComponents) => true;
+}

--- a/src/Microsoft.ComponentDetection.Orchestrator/Experiments/Configs/RustSbomVsCrateExperiment.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Experiments/Configs/RustSbomVsCrateExperiment.cs
@@ -1,0 +1,22 @@
+namespace Microsoft.ComponentDetection.Orchestrator.Experiments.Configs;
+
+using Microsoft.ComponentDetection.Contracts;
+using Microsoft.ComponentDetection.Detectors.Rust;
+
+/// <summary>
+/// Validating the Rust SBOM detector against the Rust crate detector.
+/// </summary>
+public class RustSbomVsCrateExperiment : IExperimentConfiguration
+{
+    /// <inheritdoc />
+    public string Name => "RustSbomVsCrateExperiment";
+
+    /// <inheritdoc/>
+    public bool IsInControlGroup(IComponentDetector componentDetector) => componentDetector is RustCrateDetector;
+
+    /// <inheritdoc/>
+    public bool IsInExperimentGroup(IComponentDetector componentDetector) => componentDetector is RustSbomDetector;
+
+    /// <inheritdoc />
+    public bool ShouldRecord(IComponentDetector componentDetector, int numComponents) => true;
+}

--- a/src/Microsoft.ComponentDetection.Orchestrator/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Extensions/ServiceCollectionExtensions.cs
@@ -65,6 +65,8 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IExperimentService, ExperimentService>();
         services.AddSingleton<IExperimentProcessor, DefaultExperimentProcessor>();
         services.AddSingleton<IExperimentConfiguration, SimplePipExperiment>();
+        services.AddSingleton<IExperimentConfiguration, RustSbomVsCliExperiment>();
+        services.AddSingleton<IExperimentConfiguration, RustSbomVsCrateExperiment>();
         services.AddSingleton<IExperimentConfiguration, UvLockDetectorExperiment>();
 
         // Detectors


### PR DESCRIPTION
# Context
We recently removed a legacy Cargo experiment and by mistake we removed new ones dedicated for CargoSBOM detector in https://github.com/microsoft/component-detection/pull/1449.

We are still analyzing CargoSBOM performance and output vs the other detectors. We will be iterating on it over the next few weeks with plans to rolling out the SBOM detector as a primary one in October.
