### PR TITLE
Pass `CancellationToken` from commands

### DIFF
--- a/src/Microsoft.ComponentDetection.Orchestrator/Commands/ListDetectorsCommand.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Commands/ListDetectorsCommand.cs
@@ -9,24 +9,12 @@ using Spectre.Console.Cli;
 /// <summary>
 /// Lists available detectors.
 /// </summary>
-public sealed class ListDetectorsCommand : Command<ListDetectorsSettings>
+/// <param name="detectors">The detectors.</param>
+/// <param name="console">The console.</param>
+public sealed class ListDetectorsCommand(
+    IEnumerable<IComponentDetector> detectors,
+    IAnsiConsole console) : Command<ListDetectorsSettings>
 {
-    private readonly IEnumerable<IComponentDetector> detectors;
-    private readonly IAnsiConsole console;
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="ListDetectorsCommand"/> class.
-    /// </summary>
-    /// <param name="detectors">The detectors.</param>
-    /// <param name="console">The console.</param>
-    public ListDetectorsCommand(
-        IEnumerable<IComponentDetector> detectors,
-        IAnsiConsole console)
-    {
-        this.detectors = detectors;
-        this.console = console;
-    }
-
     /// <inheritdoc/>
     public override int Execute(
         CommandContext context,
@@ -36,12 +24,12 @@ public sealed class ListDetectorsCommand : Command<ListDetectorsSettings>
         var table = new Table();
         table.AddColumn("Name");
 
-        foreach (var detector in this.detectors)
+        foreach (var detector in detectors)
         {
             table.AddRow(detector.Id);
         }
 
-        this.console.Write(table);
+        console.Write(table);
 
         return (int)ProcessingResultCode.Success;
     }

--- a/src/Microsoft.ComponentDetection.Orchestrator/Commands/ListDetectorsSettings.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Commands/ListDetectorsSettings.cs
@@ -3,6 +3,4 @@ namespace Microsoft.ComponentDetection.Orchestrator.Commands;
 /// <summary>
 /// Settings for the ListDetectors command.
 /// </summary>
-public class ListDetectorsSettings : BaseSettings
-{
-}
+public class ListDetectorsSettings : BaseSettings;

--- a/src/Microsoft.ComponentDetection.Orchestrator/Commands/ScanCommand.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Commands/ScanCommand.cs
@@ -44,7 +44,7 @@ public sealed class ScanCommand : AsyncCommand<ScanSettings>
         CancellationToken cancellationToken)
     {
         this.fileWritingService.Init(settings.Output);
-        var result = await this.scanExecutionService.ExecuteScanAsync(settings);
+        var result = await this.scanExecutionService.ExecuteScanAsync(settings, cancellationToken);
         this.WriteComponentManifest(settings, result);
         return 0;
     }
@@ -53,11 +53,12 @@ public sealed class ScanCommand : AsyncCommand<ScanSettings>
     /// Method to provide a way to execute the scan command and obtain the ScanResult object.
     /// </summary>
     /// <param name="settings">ScanSettings object specifying the parameters for the scan execution.</param>
+    /// <param name="cancellationToken">CancellationToken to monitor for cancellation requests.</param>
     /// <returns>A ScanResult object.</returns>
-    public async Task<ScanResult> ExecuteScanCommandAsync(ScanSettings settings)
+    public async Task<ScanResult> ExecuteScanCommandAsync(ScanSettings settings, CancellationToken cancellationToken = default)
     {
         this.fileWritingService.Init(settings.Output);
-        var result = await this.scanExecutionService.ExecuteScanAsync(settings);
+        var result = await this.scanExecutionService.ExecuteScanAsync(settings, cancellationToken);
         this.WriteComponentManifest(settings, result);
         return result;
     }

--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/DetectorProcessingService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/DetectorProcessingService.cs
@@ -41,10 +41,12 @@ public class DetectorProcessingService : IDetectorProcessingService
         this.logger = logger;
     }
 
+    /// <inheritdoc/>
     public async Task<DetectorProcessingResult> ProcessDetectorsAsync(
         ScanSettings settings,
         IEnumerable<IComponentDetector> detectors,
-        DetectorRestrictions detectorRestrictions)
+        DetectorRestrictions detectorRestrictions,
+        CancellationToken cancellationToken = default)
     {
         using var scope = this.logger.BeginScope("Processing detectors");
         this.logger.LogInformation($"Finding components...");

--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/IDetectorProcessingService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/IDetectorProcessingService.cs
@@ -1,14 +1,27 @@
 namespace Microsoft.ComponentDetection.Orchestrator.Services;
 
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Orchestrator.Commands;
 
+/// <summary>
+/// Defines a service for processing component detectors during a scan operation.
+/// </summary>
 public interface IDetectorProcessingService
 {
-    Task<DetectorProcessingResult> ProcessDetectorsAsync(
+    /// <summary>
+    /// Processes the specified detectors asynchronously based on the provided scan settings and detector restrictions.
+    /// </summary>
+    /// <param name="settings">The scan settings that configure how the detection process should be executed.</param>
+    /// <param name="detectors">The collection of component detectors to be processed.</param>
+    /// <param name="detectorRestrictions">The restrictions that determine which detectors should be included or excluded from processing.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the <see cref="DetectorProcessingResult"/> with information about the detection process outcome.</returns>
+    public Task<DetectorProcessingResult> ProcessDetectorsAsync(
         ScanSettings settings,
         IEnumerable<IComponentDetector> detectors,
-        DetectorRestrictions detectorRestrictions);
+        DetectorRestrictions detectorRestrictions,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/IScanExecutionService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/IScanExecutionService.cs
@@ -1,10 +1,20 @@
 namespace Microsoft.ComponentDetection.Orchestrator.Services;
 
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.ComponentDetection.Contracts.BcdeModels;
 using Microsoft.ComponentDetection.Orchestrator.Commands;
 
+/// <summary>
+/// Defines a service responsible for executing component detection scans.
+/// </summary>
 public interface IScanExecutionService
 {
-    Task<ScanResult> ExecuteScanAsync(ScanSettings settings);
+    /// <summary>
+    /// Executes a scan asynchronously based on the provided scan settings.
+    /// </summary>
+    /// <param name="settings">The scan settings that configure how the scan should be executed.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>A task that represents the asynchronous scan operation. The task result contains the <see cref="ScanResult"/> with information about the scan execution.</returns>
+    public Task<ScanResult> ExecuteScanAsync(ScanSettings settings, CancellationToken cancellationToken = default);
 }

--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/ScanExecutionService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/ScanExecutionService.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Contracts.BcdeModels;
@@ -33,7 +34,8 @@ public class ScanExecutionService : IScanExecutionService
         this.logger = logger;
     }
 
-    public async Task<ScanResult> ExecuteScanAsync(ScanSettings settings)
+    /// <inheritdoc />
+    public async Task<ScanResult> ExecuteScanAsync(ScanSettings settings, CancellationToken cancellationToken = default)
     {
         using var scope = this.logger.BeginScope("Executing BCDE scan");
 
@@ -44,7 +46,7 @@ public class ScanExecutionService : IScanExecutionService
 
         this.logger.LogDebug("Finished applying restrictions to detectors.");
 
-        var processingResult = await this.detectorProcessingService.ProcessDetectorsAsync(settings, detectorsWithAppliedRestrictions, detectorRestrictions);
+        var processingResult = await this.detectorProcessingService.ProcessDetectorsAsync(settings, detectorsWithAppliedRestrictions, detectorRestrictions, cancellationToken);
         var scanResult = this.graphTranslationService.GenerateScanResultFromProcessingResult(processingResult, settings);
 
         scanResult.DetectorsInScan = detectorsWithAppliedRestrictions.Select(ConvertToContract).ToList();

--- a/test/Microsoft.ComponentDetection.Orchestrator.Tests/Commands/ScanCommandTests.cs
+++ b/test/Microsoft.ComponentDetection.Orchestrator.Tests/Commands/ScanCommandTests.cs
@@ -44,7 +44,7 @@ public class ScanCommandTests
         var result = await this.command.ExecuteAsync(null, settings, CancellationToken.None);
 
         this.fileWritingServiceMock.Verify(x => x.Init(settings.Output), Times.Once);
-        this.scanExecutionServiceMock.Verify(x => x.ExecuteScanAsync(settings), Times.Once);
+        this.scanExecutionServiceMock.Verify(x => x.ExecuteScanAsync(settings, CancellationToken.None), Times.Once);
         this.fileWritingServiceMock.Verify(x => x.ResolveFilePath(It.IsAny<string>()), Times.Once);
         this.fileWritingServiceMock.Verify(x => x.AppendToFile(It.IsAny<string>(), It.IsAny<ScanResult>()));
         result.Should().Be(0);
@@ -58,7 +58,7 @@ public class ScanCommandTests
         var result = await this.command.ExecuteAsync(null, settings, CancellationToken.None);
 
         this.fileWritingServiceMock.Verify(x => x.Init(settings.Output), Times.Once);
-        this.scanExecutionServiceMock.Verify(x => x.ExecuteScanAsync(settings), Times.Once);
+        this.scanExecutionServiceMock.Verify(x => x.ExecuteScanAsync(settings, CancellationToken.None), Times.Once);
         this.fileWritingServiceMock.Verify(x => x.WriteFile(It.Is<FileInfo>(x => x == settings.ManifestFile), It.IsAny<ScanResult>()));
 
         result.Should().Be(0);
@@ -75,7 +75,7 @@ public class ScanCommandTests
         var result = await this.command.ExecuteAsync(null, settings, CancellationToken.None);
 
         this.fileWritingServiceMock.Verify(x => x.Init(settings.Output), Times.Once);
-        this.scanExecutionServiceMock.Verify(x => x.ExecuteScanAsync(settings), Times.Once);
+        this.scanExecutionServiceMock.Verify(x => x.ExecuteScanAsync(settings, CancellationToken.None), Times.Once);
         this.fileWritingServiceMock.Verify(x => x.ResolveFilePath(It.IsAny<string>()), Times.Once);
         this.fileWritingServiceMock.Verify(x => x.AppendToFile(It.IsAny<string>(), It.IsAny<ScanResult>()));
 
@@ -95,7 +95,7 @@ public class ScanCommandTests
         var result = await this.command.ExecuteScanCommandAsync(settings);
 
         this.fileWritingServiceMock.Verify(x => x.Init(settings.Output), Times.Once);
-        this.scanExecutionServiceMock.Verify(x => x.ExecuteScanAsync(settings), Times.Once);
+        this.scanExecutionServiceMock.Verify(x => x.ExecuteScanAsync(settings, CancellationToken.None), Times.Once);
         this.fileWritingServiceMock.Verify(x => x.ResolveFilePath(It.IsAny<string>()), Times.Once);
         this.fileWritingServiceMock.Verify(x => x.AppendToFile(It.IsAny<string>(), It.IsAny<ScanResult>()));
 
@@ -111,7 +111,7 @@ public class ScanCommandTests
         var result = await this.command.ExecuteScanCommandAsync(settings);
 
         this.fileWritingServiceMock.Verify(x => x.Init(settings.Output), Times.Once);
-        this.scanExecutionServiceMock.Verify(x => x.ExecuteScanAsync(settings), Times.Once);
+        this.scanExecutionServiceMock.Verify(x => x.ExecuteScanAsync(settings, CancellationToken.None), Times.Once);
         this.fileWritingServiceMock.Verify(x => x.WriteFile(It.Is<FileInfo>(x => x == settings.ManifestFile), It.IsAny<ScanResult>()));
     }
 }

--- a/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/BcdeScanExecutionServiceTests.cs
+++ b/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/BcdeScanExecutionServiceTests.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using AwesomeAssertions;
 using Microsoft.ComponentDetection.Common.DependencyGraph;
@@ -765,10 +766,11 @@ public class BcdeScanExecutionServiceTests
                 x.ProcessDetectorsAsync(
                     settings,
                     It.Is<IEnumerable<IComponentDetector>>(inputDetectors => restrictedDetectors.Intersect(inputDetectors).Count() == restrictedDetectors.Length),
-                    Match.Create<DetectorRestrictions>(restriction => true)))
+                    Match.Create<DetectorRestrictions>(restriction => true),
+                    CancellationToken.None))
             .ReturnsAsync(processingResult);
 
-        var result = await this.serviceUnderTest.ExecuteScanAsync(settings);
+        var result = await this.serviceUnderTest.ExecuteScanAsync(settings, CancellationToken.None);
         result.ResultCode.Should().Be(ProcessingResultCode.Success);
         result.SourceDirectory.Should().NotBeNull();
         result.SourceDirectory.Should().Be(settings.SourceDirectory.ToString());
@@ -824,10 +826,11 @@ public class BcdeScanExecutionServiceTests
                 x.ProcessDetectorsAsync(
                     settings,
                     It.Is<IEnumerable<IComponentDetector>>(inputDetectors => restrictedDetectors.Intersect(inputDetectors).Count() == restrictedDetectors.Length),
-                    Match.Create<DetectorRestrictions>(restriction => true)))
+                    Match.Create<DetectorRestrictions>(restriction => true),
+                    CancellationToken.None))
             .ReturnsAsync(processingResult);
 
-        var result = await this.serviceUnderTest.ExecuteScanAsync(settings);
+        var result = await this.serviceUnderTest.ExecuteScanAsync(settings, CancellationToken.None);
         result.ResultCode.Should().Be(ProcessingResultCode.Success);
         result.SourceDirectory.Should().NotBeNull();
         result.SourceDirectory.Should().Be(settings.SourceDirectory.ToString());
@@ -880,10 +883,11 @@ public class BcdeScanExecutionServiceTests
                 x.ProcessDetectorsAsync(
                     settings,
                     It.Is<IEnumerable<IComponentDetector>>(inputDetectors => restrictedDetectors.Intersect(inputDetectors).Count() == restrictedDetectors.Length),
-                    Match.Create<DetectorRestrictions>(restriction => true)))
+                    Match.Create<DetectorRestrictions>(restriction => true),
+                    CancellationToken.None))
             .ReturnsAsync(processingResult);
 
-        var result = await this.serviceUnderTest.ExecuteScanAsync(settings);
+        var result = await this.serviceUnderTest.ExecuteScanAsync(settings, CancellationToken.None);
         result.ResultCode.Should().Be(ProcessingResultCode.Success);
         result.SourceDirectory.Should().NotBeNull();
         result.SourceDirectory.Should().Be(settings.SourceDirectory.ToString());


### PR DESCRIPTION
One of the new features in `Spectre.Console.Cli` was support for top-level `CancellationToken` support. This means, that we will be able to pipe cancellation support the entire way through Component Detection. This is a first trial run, passing the `CancellationToken` through to `ScanExecutionService` and `DetectorProcessingService`.

Additionally, I added XML documentation and migrated to primary constructors.