### PR TITLE
Add `step-security/harden-runner`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,11 @@ jobs:
       MINVERBUILDMETADATA: build.${{github.run_number}}
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
+        with:
+          egress-policy: audit
+
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,11 +2,11 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
   schedule:
-    - cron: '27 10 * * 1'
+    - cron: "27 10 * * 1"
 
 permissions:
   contents: read
@@ -21,18 +21,23 @@ jobs:
       security-events: write
 
     steps:
-    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      with:
+      - name: Harden Runner
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
           fetch-depth: 0
 
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@014f16e7ab1402f30e7c3329d33797e7948572db # v4.31.3
-      with:
-        languages: 'csharp'
-        debug: true
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@014f16e7ab1402f30e7c3329d33797e7948572db # v4.31.3
+        with:
+          languages: "csharp"
+          debug: true
 
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@014f16e7ab1402f30e7c3329d33797e7948572db # v4.31.3
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@014f16e7ab1402f30e7c3329d33797e7948572db # v4.31.3
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@014f16e7ab1402f30e7c3329d33797e7948572db # v4.31.3
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@014f16e7ab1402f30e7c3329d33797e7948572db # v4.31.3

--- a/.github/workflows/detector-version-bump-reminder.yml
+++ b/.github/workflows/detector-version-bump-reminder.yml
@@ -2,8 +2,8 @@ name: "Detector version bump reminder"
 on:
   push:
     paths:
-      - 'src/Microsoft.ComponentDetection.Detectors/**'
-      
+      - "src/Microsoft.ComponentDetection.Detectors/**"
+
 permissions:
   pull-requests: write
 
@@ -11,6 +11,11 @@ jobs:
   comment:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
+        with:
+          egress-policy: audit
+
       - uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc # v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -20,5 +25,5 @@ jobs:
             * The detector detects more or fewer components than before
             * The detector generates different parent/child graph relationships than before
             * The detector generates different `devDependencies` values than before
-            
+
             If none of the above scenarios apply, feel free to ignore this comment 🙂

--- a/.github/workflows/gen-docs.yml
+++ b/.github/workflows/gen-docs.yml
@@ -1,11 +1,11 @@
-name: 'Generate docs'
+name: "Generate docs"
 
 on:
   push:
     branches:
       - main
     paths:
-      - 'src/Microsoft.ComponentDetection.Orchestrator/ArgumentSets/*.cs'
+      - "src/Microsoft.ComponentDetection.Orchestrator/ArgumentSets/*.cs"
 
 permissions:
   contents: read
@@ -13,9 +13,14 @@ permissions:
 jobs:
   gen-docs:
     permissions:
-      contents: write  # for stefanzweifel/git-auto-commit-action to push code in repo
+      contents: write # for stefanzweifel/git-auto-commit-action to push code in repo
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
@@ -27,12 +32,12 @@ jobs:
         run: |
           touch version.json
           touch version_dev.json
-          
+
           # Run CLI
           dotnet run -p src/Microsoft.ComponentDetection help scan 2> help.txt || true
           cat <<EOF > docs/detector-arguments.md
           # Detector arguments
-          
+
           \`\`\`shell
           dotnet run -p './src/Microsoft.ComponentDetection' help scan
           \`\`\`
@@ -45,5 +50,5 @@ jobs:
       - name: Commit
         uses: stefanzweifel/git-auto-commit-action@28e16e81777b558cc906c8750092100bbb34c5e3 # v7.0.0
         with:
-          commit_message: 'Update docs'
-          file_pattern: '*.md'
+          commit_message: "Update docs"
+          file_pattern: "*.md"

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -10,9 +10,9 @@ on:
   # To guarantee Maintained check is occasionally updated. See
   # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
   schedule:
-    - cron: '44 3 * * 5'
+    - cron: "44 3 * * 5"
   push:
-    branches: [ "main" ]
+    branches: ["main"]
 
 # Declare default permissions as read only.
 permissions: read-all
@@ -31,6 +31,11 @@ jobs:
       # actions: read
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
+        with:
+          egress-policy: audit
+
       - name: "Checkout code"
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -16,6 +16,11 @@ jobs:
       pull-requests: read
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
+        with:
+          egress-policy: audit
+
       - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6
         with:
           disable-autolabeler: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,11 @@ jobs:
       MINVERBUILDMETADATA: build.${{github.run_number}}
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
+        with:
+          egress-policy: audit
+
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -38,10 +38,15 @@ jobs:
       max-parallel: 4 # limit the total number of running jobs to avoid rate limiting
     name: ${{ matrix.language.name }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
+        with:
+          egress-policy: audit
+
       - name: Checkout Component Detection
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      - name: Prepare Dotnet 
+      - name: Prepare Dotnet
         run: |
           # When using a Vanilla Ubuntu image, GH Actions may not have access to the /usr/share/dotnet directory.
           sudo mkdir /usr/share/dotnet
@@ -85,6 +90,11 @@ jobs:
     permissions:
       issues: write
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
+        with:
+          egress-policy: audit
+
       - name: Create GitHub Issue
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:

--- a/.github/workflows/snapshot-publish.yml
+++ b/.github/workflows/snapshot-publish.yml
@@ -23,6 +23,11 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Setup .NET Core
@@ -33,7 +38,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6
         with:
-          python-version: '3.10'
+          python-version: "3.10"
 
       - name: Install Apache Ivy
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/snapshot-verify.yml
+++ b/.github/workflows/snapshot-verify.yml
@@ -19,6 +19,11 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Make release snapshot output directory
@@ -57,7 +62,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6
         with:
-          python-version: '3.10'
+          python-version: "3.10"
 
       - run: dotnet restore
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -15,6 +15,11 @@ jobs:
     permissions:
       security-events: write
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
+        with:
+          egress-policy: audit
+
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:


### PR DESCRIPTION
This pull request strengthens the security of all GitHub Actions workflows by adding the "Harden Runner" step, which uses the [`step-security/harden-runner` action][1] to audit outbound network traffic.

[1]: https://github.com/step-security/harden-runner