### PR TITLE
Allow for trailing comma in global.json parsing

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/dotnet/DotNetComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/dotnet/DotNetComponentDetector.cs
@@ -25,7 +25,9 @@ public class DotNetComponentDetector : FileComponentDetector
     private readonly IPathUtilityService pathUtilityService;
     private readonly LockFileFormat lockFileFormat = new();
     private readonly ConcurrentDictionary<string, string?> sdkVersionCache = [];
-    private readonly JsonDocumentOptions jsonDocumentOptions = new() { CommentHandling = JsonCommentHandling.Skip };
+    private readonly JsonDocumentOptions jsonDocumentOptions =
+        new() { CommentHandling = JsonCommentHandling.Skip, AllowTrailingCommas = true };
+
     private string? sourceDirectory;
     private string? sourceFileRootDirectory;
 


### PR DESCRIPTION
Currently the DotNetComponentDetector fails for trailing commas parsing global.json. An example I hit:

```json
{
  // Defines version of MSBuild project SDKs to use
  // https://docs.microsoft.com/en-us/visualstudio/msbuild/how-to-use-project-sdk?view=vs-2017#how-project-sdks-are-resolved
  // https://docs.microsoft.com/en-us/dotnet/core/tools/global-json#globaljson-schema
  "msbuild-sdks": {
    "Microsoft.Build.Traversal": "4.1.82",
    "Microsoft.Build.NoTargets": "3.7.134"
  },
}
```