### PR TITLE
Add support for NuGet components in containers

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/linux/Factories/DotnetComponentFactory.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/linux/Factories/DotnetComponentFactory.cs
@@ -1,0 +1,32 @@
+namespace Microsoft.ComponentDetection.Detectors.Linux.Factories;
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.ComponentDetection.Contracts.TypedComponent;
+using Microsoft.ComponentDetection.Detectors.Linux.Contracts;
+
+/// <summary>
+/// Factory for creating <see cref="NuGetComponent"/> instances from .NET package artifacts.
+/// </summary>
+public class DotnetComponentFactory : ArtifactComponentFactoryBase
+{
+    /// <inheritdoc/>
+    public override IEnumerable<string> SupportedArtifactTypes => ["dotnet"];
+
+    /// <inheritdoc/>
+    public override TypedComponent? CreateComponent([NotNull] ArtifactElement artifact, [NotNull] Distro distro)
+    {
+        if (string.IsNullOrWhiteSpace(artifact.Name) || string.IsNullOrWhiteSpace(artifact.Version))
+        {
+            return null;
+        }
+
+        var author = GetAuthorFromArtifact(artifact);
+        var authors = string.IsNullOrWhiteSpace(author) ? null : new[] { author };
+
+        return new NuGetComponent(
+            name: artifact.Name,
+            version: artifact.Version,
+            authors: authors);
+    }
+}

--- a/src/Microsoft.ComponentDetection.Detectors/linux/LinuxApplicationLayerDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/linux/LinuxApplicationLayerDetector.cs
@@ -30,13 +30,14 @@ public class LinuxApplicationLayerDetector(
             Enum.GetName(typeof(DetectorClass), DetectorClass.Linux),
             Enum.GetName(typeof(DetectorClass), DetectorClass.Npm),
             Enum.GetName(typeof(DetectorClass), DetectorClass.Pip),
+            Enum.GetName(typeof(DetectorClass), DetectorClass.NuGet),
         ];
 
     /// <inheritdoc/>
     public new IEnumerable<ComponentType> SupportedComponentTypes =>
-        [ComponentType.Linux, ComponentType.Npm, ComponentType.Pip];
+        [ComponentType.Linux, ComponentType.Npm, ComponentType.Pip, ComponentType.NuGet];
 
     /// <inheritdoc/>
     protected override ISet<ComponentType> GetEnabledComponentTypes() =>
-        new HashSet<ComponentType> { ComponentType.Linux, ComponentType.Npm, ComponentType.Pip };
+        new HashSet<ComponentType> { ComponentType.Linux, ComponentType.Npm, ComponentType.Pip, ComponentType.NuGet };
 }

--- a/src/Microsoft.ComponentDetection.Orchestrator/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Extensions/ServiceCollectionExtensions.cs
@@ -105,6 +105,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IArtifactComponentFactory, LinuxComponentFactory>();
         services.AddSingleton<IArtifactComponentFactory, NpmComponentFactory>();
         services.AddSingleton<IArtifactComponentFactory, PipComponentFactory>();
+        services.AddSingleton<IArtifactComponentFactory, DotnetComponentFactory>();
         services.AddSingleton<IArtifactFilter, Mariner2ArtifactFilter>();
         services.AddSingleton<IComponentDetector, LinuxContainerDetector>();
         services.AddSingleton<IComponentDetector, LinuxApplicationLayerDetector>();


### PR DESCRIPTION
This extends on the support added in #1529 to support detection of NuGet packages in containers.

As an example, I ran

```
$ dotnet run --project src/Microsoft.ComponentDetection -- scan \
        --SourceDirectory ~/src/scratch/empty-directory/ \
        --Output scan-output \
        --DockerImagesToScan mcr.microsoft.com/dotnet/sdk:10.0-azurelinux3.0
```

Which gave [the output here][1]

[1]: https://gist.github.com/JamieMagee/e1a29ad4ef0961a66775142e28c8e70c