### PR TITLE
Migrate to file-scoped namespaces

### DIFF
--- a/docs/creating-a-new-service.md
+++ b/docs/creating-a-new-service.md
@@ -7,13 +7,12 @@ Component Detection uses standard .NET dependency injection for service registra
 1. **Create your service interface** in `src/Microsoft.ComponentDetection.Contracts/IMyNewService.cs`
 
 ```c#
-namespace Microsoft.ComponentDetection.Contracts
+namespace Microsoft.ComponentDetection.Contracts;
+
+public interface IMyNewService
 {
-    public interface IMyNewService
-    {
-        // Define your service methods
-        string DoSomething();
-    }
+    // Define your service methods
+    string DoSomething();
 }
 ```
 
@@ -22,20 +21,19 @@ namespace Microsoft.ComponentDetection.Contracts
 ```c#
 using Microsoft.ComponentDetection.Contracts;
 
-namespace Microsoft.ComponentDetection.Common
-{
-    public class MyNewService : IMyNewService
-    {
-        // Inject any dependencies your service needs
-        public MyNewService(ILogger<MyNewService> logger)
-        {
-            // Constructor injection
-        }
+namespace Microsoft.ComponentDetection.Common;
 
-        public string DoSomething()
-        {
-            // Implementation
-        }
+public class MyNewService : IMyNewService
+{
+    // Inject any dependencies your service needs
+    public MyNewService(ILogger<MyNewService> logger)
+    {
+        // Constructor injection
+    }
+
+    public string DoSomething()
+    {
+        // Implementation
     }
 }
 ```

--- a/src/Microsoft.ComponentDetection.Detectors/uv/UvDependency.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/uv/UvDependency.cs
@@ -1,9 +1,8 @@
-namespace Microsoft.ComponentDetection.Detectors.Uv
-{
-    public class UvDependency
-    {
-        public required string Name { get; init; }
+namespace Microsoft.ComponentDetection.Detectors.Uv;
 
-        public string? Specifier { get; set; }
-    }
+public class UvDependency
+{
+    public required string Name { get; init; }
+
+    public string? Specifier { get; set; }
 }

--- a/src/Microsoft.ComponentDetection.Detectors/uv/UvLock.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/uv/UvLock.cs
@@ -1,142 +1,141 @@
-namespace Microsoft.ComponentDetection.Detectors.Uv
+namespace Microsoft.ComponentDetection.Detectors.Uv;
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Tomlyn;
+using Tomlyn.Model;
+
+public class UvLock
 {
-    using System;
-    using System.Collections.Generic;
-    using System.IO;
-    using Tomlyn;
-    using Tomlyn.Model;
+    // a list of packages with their dependencies
+    public List<UvPackage> Packages { get; set; } = [];
 
-    public class UvLock
+    // static method to parse the TOML stream into a UvLock model
+    public static UvLock Parse(Stream tomlStream)
     {
-        // a list of packages with their dependencies
-        public List<UvPackage> Packages { get; set; } = [];
-
-        // static method to parse the TOML stream into a UvLock model
-        public static UvLock Parse(Stream tomlStream)
+        using var reader = new StreamReader(tomlStream);
+        var tomlContent = reader.ReadToEnd();
+        var model = Toml.ToModel(tomlContent);
+        return new UvLock
         {
-            using var reader = new StreamReader(tomlStream);
-            var tomlContent = reader.ReadToEnd();
-            var model = Toml.ToModel(tomlContent);
-            return new UvLock
-            {
-                Packages = ParsePackagesFromModel(model),
-            };
+            Packages = ParsePackagesFromModel(model),
+        };
+    }
+
+    internal static List<UvPackage> ParsePackagesFromModel(object? model)
+    {
+        if (model is not TomlTable table)
+        {
+            throw new InvalidOperationException("TOML root is not a table");
         }
 
-        internal static List<UvPackage> ParsePackagesFromModel(object? model)
+        if (!table.TryGetValue("package", out var packagesObj) || packagesObj is not TomlTableArray packages)
         {
-            if (model is not TomlTable table)
-            {
-                throw new InvalidOperationException("TOML root is not a table");
-            }
-
-            if (!table.TryGetValue("package", out var packagesObj) || packagesObj is not TomlTableArray packages)
-            {
-                return [];
-            }
-
-            var result = new List<UvPackage>();
-            foreach (var pkg in packages)
-            {
-                var parsed = ParsePackage(pkg);
-                if (parsed is not null)
-                {
-                    result.Add(parsed);
-                }
-            }
-
-            return result;
+            return [];
         }
 
-        internal static UvPackage? ParsePackage(object? pkg)
+        var result = new List<UvPackage>();
+        foreach (var pkg in packages)
         {
-            if (pkg is not TomlTable pkgTable)
+            var parsed = ParsePackage(pkg);
+            if (parsed is not null)
             {
-                return null;
+                result.Add(parsed);
             }
+        }
 
-            if (pkgTable.TryGetValue("name", out var nameObj) && nameObj is string name &&
-                pkgTable.TryGetValue("version", out var versionObj) && versionObj is string version)
-            {
-                var uvPackage = new UvPackage
-                {
-                    Name = name,
-                    Version = version,
-                    Dependencies = [],
-                    MetadataRequiresDist = [],
-                    MetadataRequiresDev = [],
-                };
+        return result;
+    }
 
-                if (pkgTable.TryGetValue("dependencies", out var depsObj) && depsObj is TomlArray depsArray)
-                {
-                    uvPackage.Dependencies = ParseDependenciesArray(depsArray);
-                }
-
-                if (pkgTable.TryGetValue("metadata", out var metadataObj) && metadataObj is TomlTable metadataTable)
-                {
-                    ParseMetadata(metadataTable, uvPackage);
-                }
-
-                // Parse source
-                if (pkgTable.TryGetValue("source", out var sourceObj) && sourceObj is TomlTable sourceTable)
-                {
-                    var source = new UvSource
-                    {
-                        Registry = sourceTable.TryGetValue("registry", out var regObj) && regObj is string reg ? reg : null,
-                        Virtual = sourceTable.TryGetValue("virtual", out var virtObj) && virtObj is string virt ? virt : null,
-                    };
-                    uvPackage.Source = source;
-                }
-
-                return uvPackage;
-            }
-
+    internal static UvPackage? ParsePackage(object? pkg)
+    {
+        if (pkg is not TomlTable pkgTable)
+        {
             return null;
         }
 
-        internal static List<UvDependency> ParseDependenciesArray(TomlArray? depsArray)
+        if (pkgTable.TryGetValue("name", out var nameObj) && nameObj is string name &&
+            pkgTable.TryGetValue("version", out var versionObj) && versionObj is string version)
         {
-            var deps = new List<UvDependency>();
-            if (depsArray is null)
+            var uvPackage = new UvPackage
             {
-                return deps;
+                Name = name,
+                Version = version,
+                Dependencies = [],
+                MetadataRequiresDist = [],
+                MetadataRequiresDev = [],
+            };
+
+            if (pkgTable.TryGetValue("dependencies", out var depsObj) && depsObj is TomlArray depsArray)
+            {
+                uvPackage.Dependencies = ParseDependenciesArray(depsArray);
             }
 
-            foreach (var dep in depsArray)
+            if (pkgTable.TryGetValue("metadata", out var metadataObj) && metadataObj is TomlTable metadataTable)
             {
-                if (dep is TomlTable depTable &&
-                    depTable.TryGetValue("name", out var depNameObj) && depNameObj is string depName)
+                ParseMetadata(metadataTable, uvPackage);
+            }
+
+            // Parse source
+            if (pkgTable.TryGetValue("source", out var sourceObj) && sourceObj is TomlTable sourceTable)
+            {
+                var source = new UvSource
                 {
-                    var depSpec = depTable.TryGetValue("specifier", out var specObj) && specObj is string s ? s : null;
-                    deps.Add(new UvDependency
-                    {
-                        Name = depName,
-                        Specifier = depSpec,
-                    });
-                }
+                    Registry = sourceTable.TryGetValue("registry", out var regObj) && regObj is string reg ? reg : null,
+                    Virtual = sourceTable.TryGetValue("virtual", out var virtObj) && virtObj is string virt ? virt : null,
+                };
+                uvPackage.Source = source;
             }
 
+            return uvPackage;
+        }
+
+        return null;
+    }
+
+    internal static List<UvDependency> ParseDependenciesArray(TomlArray? depsArray)
+    {
+        var deps = new List<UvDependency>();
+        if (depsArray is null)
+        {
             return deps;
         }
 
-        internal static void ParseMetadata(TomlTable? metadataTable, UvPackage uvPackage)
+        foreach (var dep in depsArray)
         {
-            if (metadataTable is null)
+            if (dep is TomlTable depTable &&
+                depTable.TryGetValue("name", out var depNameObj) && depNameObj is string depName)
             {
-                return;
-            }
-
-            if (metadataTable.TryGetValue("requires-dist", out var requiresDistObj) && requiresDistObj is TomlArray requiresDistArr)
-            {
-                uvPackage.MetadataRequiresDist = ParseDependenciesArray(requiresDistArr);
-            }
-
-            if (metadataTable.TryGetValue("requires-dev", out var requiresDevObj) && requiresDevObj is TomlTable requiresDevTable)
-            {
-                if (requiresDevTable.TryGetValue("dev", out var devObj) && devObj is TomlArray devArr)
+                var depSpec = depTable.TryGetValue("specifier", out var specObj) && specObj is string s ? s : null;
+                deps.Add(new UvDependency
                 {
-                    uvPackage.MetadataRequiresDev = ParseDependenciesArray(devArr);
-                }
+                    Name = depName,
+                    Specifier = depSpec,
+                });
+            }
+        }
+
+        return deps;
+    }
+
+    internal static void ParseMetadata(TomlTable? metadataTable, UvPackage uvPackage)
+    {
+        if (metadataTable is null)
+        {
+            return;
+        }
+
+        if (metadataTable.TryGetValue("requires-dist", out var requiresDistObj) && requiresDistObj is TomlArray requiresDistArr)
+        {
+            uvPackage.MetadataRequiresDist = ParseDependenciesArray(requiresDistArr);
+        }
+
+        if (metadataTable.TryGetValue("requires-dev", out var requiresDevObj) && requiresDevObj is TomlTable requiresDevTable)
+        {
+            if (requiresDevTable.TryGetValue("dev", out var devObj) && devObj is TomlArray devArr)
+            {
+                uvPackage.MetadataRequiresDev = ParseDependenciesArray(devArr);
             }
         }
     }

--- a/src/Microsoft.ComponentDetection.Detectors/uv/UvLockComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/uv/UvLockComponentDetector.cs
@@ -1,104 +1,103 @@
-namespace Microsoft.ComponentDetection.Detectors.Uv
+namespace Microsoft.ComponentDetection.Detectors.Uv;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.ComponentDetection.Contracts;
+using Microsoft.ComponentDetection.Contracts.Internal;
+using Microsoft.ComponentDetection.Contracts.TypedComponent;
+using Microsoft.Extensions.Logging;
+
+public class UvLockComponentDetector : FileComponentDetector, IExperimentalDetector
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using Microsoft.ComponentDetection.Contracts;
-    using Microsoft.ComponentDetection.Contracts.Internal;
-    using Microsoft.ComponentDetection.Contracts.TypedComponent;
-    using Microsoft.Extensions.Logging;
-
-    public class UvLockComponentDetector : FileComponentDetector, IExperimentalDetector
+    public UvLockComponentDetector(
+        IComponentStreamEnumerableFactory componentStreamEnumerableFactory,
+        IObservableDirectoryWalkerFactory walkerFactory,
+        ILogger<UvLockComponentDetector> logger)
     {
-        public UvLockComponentDetector(
-            IComponentStreamEnumerableFactory componentStreamEnumerableFactory,
-            IObservableDirectoryWalkerFactory walkerFactory,
-            ILogger<UvLockComponentDetector> logger)
+        this.ComponentStreamEnumerableFactory = componentStreamEnumerableFactory;
+        this.Scanner = walkerFactory;
+        this.Logger = logger;
+    }
+
+    public override string Id => "UvLock";
+
+    public override IList<string> SearchPatterns { get; } = ["uv.lock"];
+
+    public override IEnumerable<ComponentType> SupportedComponentTypes => [ComponentType.Pip];
+
+    public override int Version => 1;
+
+    public override IEnumerable<string> Categories => ["Python"];
+
+    internal static bool IsRootPackage(UvPackage pck)
+    {
+        return pck.Source?.Virtual != null;
+    }
+
+    protected override Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs, CancellationToken cancellationToken = default)
+    {
+        var singleFileComponentRecorder = processRequest.SingleFileComponentRecorder;
+        var file = processRequest.ComponentStream;
+
+        try
         {
-            this.ComponentStreamEnumerableFactory = componentStreamEnumerableFactory;
-            this.Scanner = walkerFactory;
-            this.Logger = logger;
-        }
+            // Parse the file stream into a UvLock model
+            file.Stream.Position = 0; // Ensure stream is at the beginning
+            var uvLock = UvLock.Parse(file.Stream);
 
-        public override string Id => "UvLock";
+            var rootPackage = uvLock.Packages.FirstOrDefault(IsRootPackage);
+            var explicitPackages = new HashSet<string>();
+            var devPackages = new HashSet<string>();
 
-        public override IList<string> SearchPatterns { get; } = ["uv.lock"];
-
-        public override IEnumerable<ComponentType> SupportedComponentTypes => [ComponentType.Pip];
-
-        public override int Version => 1;
-
-        public override IEnumerable<string> Categories => ["Python"];
-
-        internal static bool IsRootPackage(UvPackage pck)
-        {
-            return pck.Source?.Virtual != null;
-        }
-
-        protected override Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs, CancellationToken cancellationToken = default)
-        {
-            var singleFileComponentRecorder = processRequest.SingleFileComponentRecorder;
-            var file = processRequest.ComponentStream;
-
-            try
+            if (rootPackage != null)
             {
-                // Parse the file stream into a UvLock model
-                file.Stream.Position = 0; // Ensure stream is at the beginning
-                var uvLock = UvLock.Parse(file.Stream);
-
-                var rootPackage = uvLock.Packages.FirstOrDefault(IsRootPackage);
-                var explicitPackages = new HashSet<string>();
-                var devPackages = new HashSet<string>();
-
-                if (rootPackage != null)
+                foreach (var dep in rootPackage.MetadataRequiresDist)
                 {
-                    foreach (var dep in rootPackage.MetadataRequiresDist)
-                    {
-                        explicitPackages.Add(dep.Name);
-                    }
-
-                    foreach (var devDep in rootPackage.MetadataRequiresDev)
-                    {
-                        devPackages.Add(devDep.Name);
-                    }
+                    explicitPackages.Add(dep.Name);
                 }
 
-                foreach (var pkg in uvLock.Packages)
+                foreach (var devDep in rootPackage.MetadataRequiresDev)
                 {
-                    if (IsRootPackage(pkg))
+                    devPackages.Add(devDep.Name);
+                }
+            }
+
+            foreach (var pkg in uvLock.Packages)
+            {
+                if (IsRootPackage(pkg))
+                {
+                    continue;
+                }
+
+                var pipComponent = new PipComponent(pkg.Name, pkg.Version);
+                var isExplicit = explicitPackages.Contains(pkg.Name);
+                var isDev = devPackages.Contains(pkg.Name);
+                var detectedComponent = new DetectedComponent(pipComponent);
+                singleFileComponentRecorder.RegisterUsage(detectedComponent, isDevelopmentDependency: isDev, isExplicitReferencedDependency: isExplicit);
+
+                foreach (var dep in pkg.Dependencies)
+                {
+                    var depPkg = uvLock.Packages.FirstOrDefault(p => p.Name.Equals(dep.Name, StringComparison.OrdinalIgnoreCase));
+                    if (depPkg != null)
                     {
-                        continue;
+                        var depComponentWithVersion = new PipComponent(depPkg.Name, depPkg.Version);
+                        singleFileComponentRecorder.RegisterUsage(new DetectedComponent(depComponentWithVersion), parentComponentId: pipComponent.Id);
                     }
-
-                    var pipComponent = new PipComponent(pkg.Name, pkg.Version);
-                    var isExplicit = explicitPackages.Contains(pkg.Name);
-                    var isDev = devPackages.Contains(pkg.Name);
-                    var detectedComponent = new DetectedComponent(pipComponent);
-                    singleFileComponentRecorder.RegisterUsage(detectedComponent, isDevelopmentDependency: isDev, isExplicitReferencedDependency: isExplicit);
-
-                    foreach (var dep in pkg.Dependencies)
+                    else
                     {
-                        var depPkg = uvLock.Packages.FirstOrDefault(p => p.Name.Equals(dep.Name, StringComparison.OrdinalIgnoreCase));
-                        if (depPkg != null)
-                        {
-                            var depComponentWithVersion = new PipComponent(depPkg.Name, depPkg.Version);
-                            singleFileComponentRecorder.RegisterUsage(new DetectedComponent(depComponentWithVersion), parentComponentId: pipComponent.Id);
-                        }
-                        else
-                        {
-                            this.Logger.LogWarning("Dependency {DependencyName} not found in uv.lock packages", dep.Name);
-                        }
+                        this.Logger.LogWarning("Dependency {DependencyName} not found in uv.lock packages", dep.Name);
                     }
                 }
             }
-            catch (Exception ex)
-            {
-                this.Logger.LogError(ex, "Failed to parse uv.lock file {File}", file.Location);
-            }
-
-            return Task.CompletedTask;
         }
+        catch (Exception ex)
+        {
+            this.Logger.LogError(ex, "Failed to parse uv.lock file {File}", file.Location);
+        }
+
+        return Task.CompletedTask;
     }
 }

--- a/src/Microsoft.ComponentDetection.Detectors/uv/UvPackage.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/uv/UvPackage.cs
@@ -1,22 +1,21 @@
-namespace Microsoft.ComponentDetection.Detectors.Uv
+namespace Microsoft.ComponentDetection.Detectors.Uv;
+
+using System.Collections.Generic;
+
+public class UvPackage
 {
-    using System.Collections.Generic;
+    public required string Name { get; init; }
 
-    public class UvPackage
-    {
-        public required string Name { get; init; }
+    public required string Version { get; init; }
 
-        public required string Version { get; init; }
+    public List<UvDependency> Dependencies { get; set; } = [];
 
-        public List<UvDependency> Dependencies { get; set; } = [];
+    // Metadata dependencies (requires-dist)
+    public List<UvDependency> MetadataRequiresDist { get; set; } = [];
 
-        // Metadata dependencies (requires-dist)
-        public List<UvDependency> MetadataRequiresDist { get; set; } = [];
+    // Metadata dev dependencies (requires-dev)
+    public List<UvDependency> MetadataRequiresDev { get; set; } = [];
 
-        // Metadata dev dependencies (requires-dev)
-        public List<UvDependency> MetadataRequiresDev { get; set; } = [];
-
-        // Source property for uv.lock
-        public UvSource? Source { get; set; }
-    }
+    // Source property for uv.lock
+    public UvSource? Source { get; set; }
 }

--- a/src/Microsoft.ComponentDetection.Detectors/uv/UvSource.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/uv/UvSource.cs
@@ -1,9 +1,8 @@
-namespace Microsoft.ComponentDetection.Detectors.Uv
-{
-    public class UvSource
-    {
-        public string? Registry { get; set; }
+namespace Microsoft.ComponentDetection.Detectors.Uv;
 
-        public string? Virtual { get; set; }
-    }
+public class UvSource
+{
+    public string? Registry { get; set; }
+
+    public string? Virtual { get; set; }
 }

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/UvLockTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/UvLockTests.cs
@@ -1,22 +1,22 @@
 #nullable disable
-namespace Microsoft.ComponentDetection.Detectors.Tests
-{
-    using System;
-    using System.IO;
-    using System.Linq;
-    using System.Text;
-    using AwesomeAssertions;
-    using Microsoft.ComponentDetection.Detectors.Uv;
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
-    using Tomlyn.Model;
+namespace Microsoft.ComponentDetection.Detectors.Tests;
 
-    [TestClass]
-    public class UvLockTests
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using AwesomeAssertions;
+using Microsoft.ComponentDetection.Detectors.Uv;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Tomlyn.Model;
+
+[TestClass]
+public class UvLockTests
+{
+    [TestMethod]
+    public void Parse_ParsesMetadataRequiresDistAndDev()
     {
-        [TestMethod]
-        public void Parse_ParsesMetadataRequiresDistAndDev()
-        {
-            var toml = """
+        var toml = """
 [[package]]
 name = "component-detection"
 version = "0.0.0"
@@ -35,35 +35,35 @@ dev = [
     { name = "pytest-env", specifier = ">=1.1.5" },
 ]
 """;
-            using var ms = new MemoryStream(Encoding.UTF8.GetBytes(toml));
-            var uvLock = UvLock.Parse(ms);
-            uvLock.Packages.Should().ContainSingle();
+        using var ms = new MemoryStream(Encoding.UTF8.GetBytes(toml));
+        var uvLock = UvLock.Parse(ms);
+        uvLock.Packages.Should().ContainSingle();
 
-            var package = uvLock.Packages.First();
-            package.Name.Should().Be("component-detection");
-            package.Version.Should().Be("0.0.0");
+        var package = uvLock.Packages.First();
+        package.Name.Should().Be("component-detection");
+        package.Version.Should().Be("0.0.0");
 
-            package.MetadataRequiresDist.Should().BeEquivalentTo(
-                [
-                    new UvDependency { Name = "azure-identity", Specifier = "==1.17.1" },
-                    new UvDependency { Name = "flask", Specifier = ">2,<3" },
-                    new UvDependency { Name = "requests", Specifier = ">=2.32.0" },
-                ],
-                options => options.ComparingByMembers<UvDependency>());
+        package.MetadataRequiresDist.Should().BeEquivalentTo(
+            [
+                new UvDependency { Name = "azure-identity", Specifier = "==1.17.1" },
+                new UvDependency { Name = "flask", Specifier = ">2,<3" },
+                new UvDependency { Name = "requests", Specifier = ">=2.32.0" },
+            ],
+            options => options.ComparingByMembers<UvDependency>());
 
-            package.MetadataRequiresDev.Should().BeEquivalentTo(
-                [
-                    new UvDependency { Name = "pytest", Specifier = ">=8.3.4" },
-                    new UvDependency { Name = "pytest-cov", Specifier = ">=6.0.0" },
-                    new UvDependency { Name = "pytest-env", Specifier = ">=1.1.5" },
-                ],
-                options => options.ComparingByMembers<UvDependency>());
-        }
+        package.MetadataRequiresDev.Should().BeEquivalentTo(
+            [
+                new UvDependency { Name = "pytest", Specifier = ">=8.3.4" },
+                new UvDependency { Name = "pytest-cov", Specifier = ">=6.0.0" },
+                new UvDependency { Name = "pytest-env", Specifier = ">=1.1.5" },
+            ],
+            options => options.ComparingByMembers<UvDependency>());
+    }
 
-        [TestMethod]
-        public void Parse_ParsesPackagesAndDependencies()
-        {
-            var toml = @"
+    [TestMethod]
+    public void Parse_ParsesPackagesAndDependencies()
+    {
+        var toml = @"
 [[package]]
 name = 'foo'
 version = '1.2.3'
@@ -74,82 +74,82 @@ dependencies = [
 name = 'bar'
 version = '2.0.0'
 ";
-            using var ms = new MemoryStream(Encoding.UTF8.GetBytes(toml));
-            var uvLock = UvLock.Parse(ms);
-            uvLock.Packages.Should().HaveCount(2);
-            uvLock.Packages.First().Name.Should().Be("foo");
-            uvLock.Packages.First().Dependencies.Should().ContainSingle(d => d.Name == "bar" && d.Specifier == ">=2.0.0");
-        }
+        using var ms = new MemoryStream(Encoding.UTF8.GetBytes(toml));
+        var uvLock = UvLock.Parse(ms);
+        uvLock.Packages.Should().HaveCount(2);
+        uvLock.Packages.First().Name.Should().Be("foo");
+        uvLock.Packages.First().Dependencies.Should().ContainSingle(d => d.Name == "bar" && d.Specifier == ">=2.0.0");
+    }
 
-        [TestMethod]
-        public void Parse_EmptyStream_ReturnsNoPackages()
-        {
-            using var ms = new MemoryStream([]);
-            var uvLock = UvLock.Parse(ms);
-            uvLock.Packages.Should().BeEmpty();
-        }
+    [TestMethod]
+    public void Parse_EmptyStream_ReturnsNoPackages()
+    {
+        using var ms = new MemoryStream([]);
+        var uvLock = UvLock.Parse(ms);
+        uvLock.Packages.Should().BeEmpty();
+    }
 
-        [TestMethod]
-        public void Parse_TomlNotATable_ThrowsException()
-        {
-            var toml = "42";
-            using var ms = new MemoryStream(Encoding.UTF8.GetBytes(toml));
-            FluentActions.Invoking(() => UvLock.Parse(ms))
-                .Should().Throw<Exception>();
-        }
+    [TestMethod]
+    public void Parse_TomlNotATable_ThrowsException()
+    {
+        var toml = "42";
+        using var ms = new MemoryStream(Encoding.UTF8.GetBytes(toml));
+        FluentActions.Invoking(() => UvLock.Parse(ms))
+            .Should().Throw<Exception>();
+    }
 
-        [TestMethod]
-        public void Parse_NoPackageKey_ReturnsNoPackages()
-        {
-            var toml = "[metadata]\nversion = '1'";
-            using var ms = new MemoryStream(Encoding.UTF8.GetBytes(toml));
-            var uvLock = UvLock.Parse(ms);
-            uvLock.Packages.Should().BeEmpty();
-        }
+    [TestMethod]
+    public void Parse_NoPackageKey_ReturnsNoPackages()
+    {
+        var toml = "[metadata]\nversion = '1'";
+        using var ms = new MemoryStream(Encoding.UTF8.GetBytes(toml));
+        var uvLock = UvLock.Parse(ms);
+        uvLock.Packages.Should().BeEmpty();
+    }
 
-        [TestMethod]
-        public void Parse_PackageKeyNotArray_ReturnsNoPackages()
-        {
-            var toml = "package = 42";
-            using var ms = new MemoryStream(Encoding.UTF8.GetBytes(toml));
-            var uvLock = UvLock.Parse(ms);
-            uvLock.Packages.Should().BeEmpty();
-        }
+    [TestMethod]
+    public void Parse_PackageKeyNotArray_ReturnsNoPackages()
+    {
+        var toml = "package = 42";
+        using var ms = new MemoryStream(Encoding.UTF8.GetBytes(toml));
+        var uvLock = UvLock.Parse(ms);
+        uvLock.Packages.Should().BeEmpty();
+    }
 
-        [TestMethod]
-        public void Parse_PackageMissingNameOrVersion_IgnoresPackage()
-        {
-            var toml = @"
+    [TestMethod]
+    public void Parse_PackageMissingNameOrVersion_IgnoresPackage()
+    {
+        var toml = @"
 [[package]]
 version = '1.2.3'
 [[package]]
 name = 'foo'
 ";
-            using var ms = new MemoryStream(Encoding.UTF8.GetBytes(toml));
-            var uvLock = UvLock.Parse(ms);
-            uvLock.Packages.Should().BeEmpty();
-        }
+        using var ms = new MemoryStream(Encoding.UTF8.GetBytes(toml));
+        var uvLock = UvLock.Parse(ms);
+        uvLock.Packages.Should().BeEmpty();
+    }
 
-        [TestMethod]
-        public void Parse_PackageWithMalformedDependencies_IgnoresMalformed()
-        {
-            var toml = @"
+    [TestMethod]
+    public void Parse_PackageWithMalformedDependencies_IgnoresMalformed()
+    {
+        var toml = @"
 [[package]]
 name = 'foo'
 version = '1.2.3'
 dependencies = [42, { name = 'bar' }]
 ";
-            using var ms = new MemoryStream(Encoding.UTF8.GetBytes(toml));
-            var uvLock = UvLock.Parse(ms);
-            uvLock.Packages.Should().ContainSingle();
-            var pkg = uvLock.Packages.First();
-            pkg.Dependencies.Should().ContainSingle(d => d.Name == "bar");
-        }
+        using var ms = new MemoryStream(Encoding.UTF8.GetBytes(toml));
+        var uvLock = UvLock.Parse(ms);
+        uvLock.Packages.Should().ContainSingle();
+        var pkg = uvLock.Packages.First();
+        pkg.Dependencies.Should().ContainSingle(d => d.Name == "bar");
+    }
 
-        [TestMethod]
-        public void Parse_PackageWithMalformedMetadata_IgnoresMalformed()
-        {
-            var toml = @"
+    [TestMethod]
+    public void Parse_PackageWithMalformedMetadata_IgnoresMalformed()
+    {
+        var toml = @"
 [[package]]
 name = 'foo'
 version = '1.2.3'
@@ -158,239 +158,238 @@ requires-dist = [42, { name = 'bar' }]
 [package.metadata.requires-dev]
 dev = [42, { name = 'baz' }]
 ";
-            using var ms = new MemoryStream(Encoding.UTF8.GetBytes(toml));
-            var uvLock = UvLock.Parse(ms);
-            uvLock.Packages.Should().ContainSingle();
-            var pkg = uvLock.Packages.First();
-            pkg.MetadataRequiresDist.Should().ContainSingle(d => d.Name == "bar");
-            pkg.MetadataRequiresDev.Should().ContainSingle(d => d.Name == "baz");
-        }
+        using var ms = new MemoryStream(Encoding.UTF8.GetBytes(toml));
+        var uvLock = UvLock.Parse(ms);
+        uvLock.Packages.Should().ContainSingle();
+        var pkg = uvLock.Packages.First();
+        pkg.MetadataRequiresDist.Should().ContainSingle(d => d.Name == "bar");
+        pkg.MetadataRequiresDev.Should().ContainSingle(d => d.Name == "baz");
+    }
 
-        [TestMethod]
-        public void ParsePackagesFromModel_InvalidRoot_Throws()
+    [TestMethod]
+    public void ParsePackagesFromModel_InvalidRoot_Throws()
+    {
+        Action act = () => UvLock.ParsePackagesFromModel(42);
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [TestMethod]
+    public void ParsePackagesFromModel_NoPackages_ReturnsEmpty()
+    {
+        var table = new TomlTable();
+        var result = UvLock.ParsePackagesFromModel(table);
+        result.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public void ParsePackage_ValidPackage_ParsesCorrectly()
+    {
+        var pkg = new TomlTable
         {
-            Action act = () => UvLock.ParsePackagesFromModel(42);
-            act.Should().Throw<InvalidOperationException>();
-        }
+            ["name"] = "foo",
+            ["version"] = "1.0.0",
+            ["dependencies"] = new TomlArray { new TomlTable { ["name"] = "bar", ["specifier"] = ">=2.0.0" } },
+        };
+        var result = UvLock.ParsePackage(pkg);
+        result.Should().NotBeNull();
+        result.Name.Should().Be("foo");
+        result.Version.Should().Be("1.0.0");
+        result.Dependencies.Should().ContainSingle(d => d.Name == "bar" && d.Specifier == ">=2.0.0");
+    }
 
-        [TestMethod]
-        public void ParsePackagesFromModel_NoPackages_ReturnsEmpty()
+    [TestMethod]
+    public void ParsePackage_MissingNameOrVersion_ReturnsNull()
+    {
+        var pkg1 = new TomlTable { ["version"] = "1.0.0" };
+        var pkg2 = new TomlTable { ["name"] = "foo" };
+        UvLock.ParsePackage(pkg1).Should().BeNull();
+        UvLock.ParsePackage(pkg2).Should().BeNull();
+    }
+
+    [TestMethod]
+    public void ParsePackage_NullOrNonTable_ReturnsNull()
+    {
+        UvLock.ParsePackage(null).Should().BeNull();
+        UvLock.ParsePackage(42).Should().BeNull();
+    }
+
+    [TestMethod]
+    public void ParsePackage_BranchCoverage_AllPaths()
+    {
+        // Path: pkg is TomlTable, but missing name
+        var pkgMissingName = new TomlTable { ["version"] = "1.0.0" };
+        UvLock.ParsePackage(pkgMissingName).Should().BeNull();
+
+        // Path: pkg is TomlTable, but missing version
+        var pkgMissingVersion = new TomlTable { ["name"] = "foo" };
+        UvLock.ParsePackage(pkgMissingVersion).Should().BeNull();
+    }
+
+    [TestMethod]
+    public void ParseDependenciesArray_ParsesValidDepsAndSkipsMalformed()
+    {
+        var arr = new TomlArray { 42, new TomlTable { ["name"] = "bar", ["specifier"] = "==1.2.3" }, new TomlTable { ["name"] = "baz" } };
+        var result = UvLock.ParseDependenciesArray(arr);
+        result.Should().Contain(d => d.Name == "bar" && d.Specifier == "==1.2.3");
+        result.Should().Contain(d => d.Name == "baz" && d.Specifier == null);
+        result.Should().HaveCount(2);
+    }
+
+    [TestMethod]
+    public void ParseDependenciesArray_NullOrNoValidDeps_ReturnsEmpty()
+    {
+        UvLock.ParseDependenciesArray(null).Should().BeEmpty();
+        var arr = new TomlArray { 42, "foo", 3.14 };
+        UvLock.ParseDependenciesArray(arr).Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public void ParseDependenciesArray_BranchCoverage_AllPaths()
+    {
+        // Path: dep is TomlTable but missing name
+        var arr = new TomlArray { new TomlTable { ["specifier"] = "==1.2.3" } };
+        UvLock.ParseDependenciesArray(arr).Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public void ParseMetadata_ParsesRequiresDistAndDev()
+    {
+        var pkg = new UvPackage { Name = "foo", Version = "1.0.0" };
+        var metadata = new TomlTable
         {
-            var table = new TomlTable();
-            var result = UvLock.ParsePackagesFromModel(table);
-            result.Should().BeEmpty();
-        }
+            ["requires-dist"] = new TomlArray { new TomlTable { ["name"] = "bar", ["specifier"] = ">=2.0.0" } },
+            ["requires-dev"] = new TomlTable { ["dev"] = new TomlArray { new TomlTable { ["name"] = "baz" } } },
+        };
+        UvLock.ParseMetadata(metadata, pkg);
+        pkg.MetadataRequiresDist.Should().ContainSingle(d => d.Name == "bar" && d.Specifier == ">=2.0.0");
+        pkg.MetadataRequiresDev.Should().ContainSingle(d => d.Name == "baz" && d.Specifier == null);
+    }
 
-        [TestMethod]
-        public void ParsePackage_ValidPackage_ParsesCorrectly()
+    [TestMethod]
+    public void ParseMetadata_NullOrNoRelevantKeys_DoesNothing()
+    {
+        var pkg = new UvPackage { Name = "foo", Version = "1.0.0" };
+        UvLock.ParseMetadata(null, pkg); // Should not throw
+        var emptyTable = new TomlTable();
+        UvLock.ParseMetadata(emptyTable, pkg); // Should not throw or set anything
+        pkg.MetadataRequiresDist.Should().BeEmpty();
+        pkg.MetadataRequiresDev.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public void ParseMetadata_BranchCoverage_RequiresDistOnly()
+    {
+        var pkg = new UvPackage { Name = "foo", Version = "1.0.0" };
+        var metadata = new TomlTable
         {
-            var pkg = new TomlTable
-            {
-                ["name"] = "foo",
-                ["version"] = "1.0.0",
-                ["dependencies"] = new TomlArray { new TomlTable { ["name"] = "bar", ["specifier"] = ">=2.0.0" } },
-            };
-            var result = UvLock.ParsePackage(pkg);
-            result.Should().NotBeNull();
-            result.Name.Should().Be("foo");
-            result.Version.Should().Be("1.0.0");
-            result.Dependencies.Should().ContainSingle(d => d.Name == "bar" && d.Specifier == ">=2.0.0");
-        }
+            ["requires-dist"] = new TomlArray { new TomlTable { ["name"] = "bar" } },
+        };
+        UvLock.ParseMetadata(metadata, pkg);
+        pkg.MetadataRequiresDist.Should().ContainSingle(d => d.Name == "bar");
+        pkg.MetadataRequiresDev.Should().BeEmpty();
+    }
 
-        [TestMethod]
-        public void ParsePackage_MissingNameOrVersion_ReturnsNull()
+    [TestMethod]
+    public void ParseMetadata_BranchCoverage_RequiresDevOnly()
+    {
+        var pkg = new UvPackage { Name = "foo", Version = "1.0.0" };
+        var metadata = new TomlTable
         {
-            var pkg1 = new TomlTable { ["version"] = "1.0.0" };
-            var pkg2 = new TomlTable { ["name"] = "foo" };
-            UvLock.ParsePackage(pkg1).Should().BeNull();
-            UvLock.ParsePackage(pkg2).Should().BeNull();
-        }
+            ["requires-dev"] = new TomlTable { ["dev"] = new TomlArray { new TomlTable { ["name"] = "baz" } } },
+        };
+        UvLock.ParseMetadata(metadata, pkg);
+        pkg.MetadataRequiresDist.Should().BeEmpty();
+        pkg.MetadataRequiresDev.Should().ContainSingle(d => d.Name == "baz");
+    }
 
-        [TestMethod]
-        public void ParsePackage_NullOrNonTable_ReturnsNull()
+    [TestMethod]
+    public void ParseMetadata_RequiresDevTableWithoutDevArray_DoesNotThrowOrSet()
+    {
+        var pkg = new UvPackage { Name = "foo", Version = "1.0.0" };
+
+        // requires-dev exists but no "dev" key
+        var metadata = new TomlTable
         {
-            UvLock.ParsePackage(null).Should().BeNull();
-            UvLock.ParsePackage(42).Should().BeNull();
-        }
+            ["requires-dev"] = new TomlTable { ["notdev"] = 42 },
+        };
+        UvLock.ParseMetadata(metadata, pkg);
+        pkg.MetadataRequiresDev.Should().BeEmpty();
 
-        [TestMethod]
-        public void ParsePackage_BranchCoverage_AllPaths()
+        // requires-dev exists, "dev" is not a TomlArray
+        metadata = new TomlTable
         {
-            // Path: pkg is TomlTable, but missing name
-            var pkgMissingName = new TomlTable { ["version"] = "1.0.0" };
-            UvLock.ParsePackage(pkgMissingName).Should().BeNull();
+            ["requires-dev"] = new TomlTable { ["dev"] = 42 },
+        };
+        UvLock.ParseMetadata(metadata, pkg);
+        pkg.MetadataRequiresDev.Should().BeEmpty();
+    }
 
-            // Path: pkg is TomlTable, but missing version
-            var pkgMissingVersion = new TomlTable { ["name"] = "foo" };
-            UvLock.ParsePackage(pkgMissingVersion).Should().BeNull();
-        }
-
-        [TestMethod]
-        public void ParseDependenciesArray_ParsesValidDepsAndSkipsMalformed()
-        {
-            var arr = new TomlArray { 42, new TomlTable { ["name"] = "bar", ["specifier"] = "==1.2.3" }, new TomlTable { ["name"] = "baz" } };
-            var result = UvLock.ParseDependenciesArray(arr);
-            result.Should().Contain(d => d.Name == "bar" && d.Specifier == "==1.2.3");
-            result.Should().Contain(d => d.Name == "baz" && d.Specifier == null);
-            result.Should().HaveCount(2);
-        }
-
-        [TestMethod]
-        public void ParseDependenciesArray_NullOrNoValidDeps_ReturnsEmpty()
-        {
-            UvLock.ParseDependenciesArray(null).Should().BeEmpty();
-            var arr = new TomlArray { 42, "foo", 3.14 };
-            UvLock.ParseDependenciesArray(arr).Should().BeEmpty();
-        }
-
-        [TestMethod]
-        public void ParseDependenciesArray_BranchCoverage_AllPaths()
-        {
-            // Path: dep is TomlTable but missing name
-            var arr = new TomlArray { new TomlTable { ["specifier"] = "==1.2.3" } };
-            UvLock.ParseDependenciesArray(arr).Should().BeEmpty();
-        }
-
-        [TestMethod]
-        public void ParseMetadata_ParsesRequiresDistAndDev()
-        {
-            var pkg = new UvPackage { Name = "foo", Version = "1.0.0" };
-            var metadata = new TomlTable
-            {
-                ["requires-dist"] = new TomlArray { new TomlTable { ["name"] = "bar", ["specifier"] = ">=2.0.0" } },
-                ["requires-dev"] = new TomlTable { ["dev"] = new TomlArray { new TomlTable { ["name"] = "baz" } } },
-            };
-            UvLock.ParseMetadata(metadata, pkg);
-            pkg.MetadataRequiresDist.Should().ContainSingle(d => d.Name == "bar" && d.Specifier == ">=2.0.0");
-            pkg.MetadataRequiresDev.Should().ContainSingle(d => d.Name == "baz" && d.Specifier == null);
-        }
-
-        [TestMethod]
-        public void ParseMetadata_NullOrNoRelevantKeys_DoesNothing()
-        {
-            var pkg = new UvPackage { Name = "foo", Version = "1.0.0" };
-            UvLock.ParseMetadata(null, pkg); // Should not throw
-            var emptyTable = new TomlTable();
-            UvLock.ParseMetadata(emptyTable, pkg); // Should not throw or set anything
-            pkg.MetadataRequiresDist.Should().BeEmpty();
-            pkg.MetadataRequiresDev.Should().BeEmpty();
-        }
-
-        [TestMethod]
-        public void ParseMetadata_BranchCoverage_RequiresDistOnly()
-        {
-            var pkg = new UvPackage { Name = "foo", Version = "1.0.0" };
-            var metadata = new TomlTable
-            {
-                ["requires-dist"] = new TomlArray { new TomlTable { ["name"] = "bar" } },
-            };
-            UvLock.ParseMetadata(metadata, pkg);
-            pkg.MetadataRequiresDist.Should().ContainSingle(d => d.Name == "bar");
-            pkg.MetadataRequiresDev.Should().BeEmpty();
-        }
-
-        [TestMethod]
-        public void ParseMetadata_BranchCoverage_RequiresDevOnly()
-        {
-            var pkg = new UvPackage { Name = "foo", Version = "1.0.0" };
-            var metadata = new TomlTable
-            {
-                ["requires-dev"] = new TomlTable { ["dev"] = new TomlArray { new TomlTable { ["name"] = "baz" } } },
-            };
-            UvLock.ParseMetadata(metadata, pkg);
-            pkg.MetadataRequiresDist.Should().BeEmpty();
-            pkg.MetadataRequiresDev.Should().ContainSingle(d => d.Name == "baz");
-        }
-
-        [TestMethod]
-        public void ParseMetadata_RequiresDevTableWithoutDevArray_DoesNotThrowOrSet()
-        {
-            var pkg = new UvPackage { Name = "foo", Version = "1.0.0" };
-
-            // requires-dev exists but no "dev" key
-            var metadata = new TomlTable
-            {
-                ["requires-dev"] = new TomlTable { ["notdev"] = 42 },
-            };
-            UvLock.ParseMetadata(metadata, pkg);
-            pkg.MetadataRequiresDev.Should().BeEmpty();
-
-            // requires-dev exists, "dev" is not a TomlArray
-            metadata = new TomlTable
-            {
-                ["requires-dev"] = new TomlTable { ["dev"] = 42 },
-            };
-            UvLock.ParseMetadata(metadata, pkg);
-            pkg.MetadataRequiresDev.Should().BeEmpty();
-        }
-
-        [TestMethod]
-        public void ParsePackage_ParsesSourceRegistryAndVirtual()
-        {
-            var toml = """
+    [TestMethod]
+    public void ParsePackage_ParsesSourceRegistryAndVirtual()
+    {
+        var toml = """
 [[package]]
 name = 'foo'
 version = '1.0.0'
 source = { registry = 'https://example.com/', virtual = '.' }
 """;
-            using var ms = new MemoryStream(Encoding.UTF8.GetBytes(toml));
-            var uvLock = UvLock.Parse(ms);
-            uvLock.Packages.Should().ContainSingle();
-            var pkg = uvLock.Packages.First();
-            pkg.Source.Should().NotBeNull();
-            pkg.Source!.Registry.Should().Be("https://example.com/");
-            pkg.Source.Virtual.Should().Be(".");
-        }
+        using var ms = new MemoryStream(Encoding.UTF8.GetBytes(toml));
+        var uvLock = UvLock.Parse(ms);
+        uvLock.Packages.Should().ContainSingle();
+        var pkg = uvLock.Packages.First();
+        pkg.Source.Should().NotBeNull();
+        pkg.Source!.Registry.Should().Be("https://example.com/");
+        pkg.Source.Virtual.Should().Be(".");
+    }
 
-        [TestMethod]
-        public void ParsePackage_ParsesSource_RegistryOnly()
-        {
-            var toml = """
+    [TestMethod]
+    public void ParsePackage_ParsesSource_RegistryOnly()
+    {
+        var toml = """
 [[package]]
 name = 'foo'
 version = '1.0.0'
 source = { registry = 'https://example.com/' }
 """;
-            using var ms = new MemoryStream(Encoding.UTF8.GetBytes(toml));
-            var uvLock = UvLock.Parse(ms);
-            uvLock.Packages.Should().ContainSingle();
-            var pkg = uvLock.Packages.First();
-            pkg.Source.Should().NotBeNull();
-            pkg.Source!.Registry.Should().Be("https://example.com/");
-            pkg.Source.Virtual.Should().BeNull();
-        }
+        using var ms = new MemoryStream(Encoding.UTF8.GetBytes(toml));
+        var uvLock = UvLock.Parse(ms);
+        uvLock.Packages.Should().ContainSingle();
+        var pkg = uvLock.Packages.First();
+        pkg.Source.Should().NotBeNull();
+        pkg.Source!.Registry.Should().Be("https://example.com/");
+        pkg.Source.Virtual.Should().BeNull();
+    }
 
-        [TestMethod]
-        public void ParsePackage_ParsesSource_VirtualOnly()
-        {
-            var toml = """
+    [TestMethod]
+    public void ParsePackage_ParsesSource_VirtualOnly()
+    {
+        var toml = """
 [[package]]
 name = 'foo'
 version = '1.0.0'
 source = { virtual = '.' }
 """;
-            using var ms = new MemoryStream(Encoding.UTF8.GetBytes(toml));
-            var uvLock = UvLock.Parse(ms);
-            uvLock.Packages.Should().ContainSingle();
-            var pkg = uvLock.Packages.First();
-            pkg.Source.Should().NotBeNull();
-            pkg.Source!.Registry.Should().BeNull();
-            pkg.Source.Virtual.Should().Be(".");
-        }
+        using var ms = new MemoryStream(Encoding.UTF8.GetBytes(toml));
+        var uvLock = UvLock.Parse(ms);
+        uvLock.Packages.Should().ContainSingle();
+        var pkg = uvLock.Packages.First();
+        pkg.Source.Should().NotBeNull();
+        pkg.Source!.Registry.Should().BeNull();
+        pkg.Source.Virtual.Should().Be(".");
+    }
 
-        [TestMethod]
-        public void ParsePackage_ParsesSource_Missing()
-        {
-            var toml = """
+    [TestMethod]
+    public void ParsePackage_ParsesSource_Missing()
+    {
+        var toml = """
 [[package]]
 name = 'foo'
 version = '1.0.0'
 """;
-            using var ms = new MemoryStream(Encoding.UTF8.GetBytes(toml));
-            var uvLock = UvLock.Parse(ms);
-            uvLock.Packages.Should().ContainSingle();
-            var pkg = uvLock.Packages.First();
-            pkg.Source.Should().BeNull();
-        }
+        using var ms = new MemoryStream(Encoding.UTF8.GetBytes(toml));
+        var uvLock = UvLock.Parse(ms);
+        uvLock.Packages.Should().ContainSingle();
+        var pkg = uvLock.Packages.First();
+        pkg.Source.Should().BeNull();
     }
 }


### PR DESCRIPTION
We performed this migration in #398, but this code was added later in #1425.

This also updates our documentation to show file-scoped namespaces.

See https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-10.0/file-scoped-namespaces