### PR TITLE
Migrate `ComponentDetectionIntegrationTests` exclusively to `System.Text.Json`

### DIFF
--- a/test/Microsoft.ComponentDetection.VerificationTests/ComponentDetectionIntegrationTests.cs
+++ b/test/Microsoft.ComponentDetection.VerificationTests/ComponentDetectionIntegrationTests.cs
@@ -5,12 +5,12 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using AwesomeAssertions;
 using AwesomeAssertions.Execution;
 using Microsoft.ComponentDetection.Contracts.BcdeModels;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Newtonsoft.Json;
 
 [TestClass]
 public class ComponentDetectionIntegrationTests
@@ -283,11 +283,11 @@ public class ComponentDetectionIntegrationTests
     {
         var oldGithubDirectory = new DirectoryInfo(oldGithubArtifactsDir);
         this.oldLogFileContents = this.GetFileTextWithPattern("GovCompDisc_Log*.log", oldGithubDirectory);
-        this.oldScanResult = JsonConvert.DeserializeObject<DefaultGraphScanResult>(this.GetFileTextWithPattern("ScanManifest*.json", oldGithubDirectory));
+        this.oldScanResult = JsonSerializer.Deserialize<DefaultGraphScanResult>(this.GetFileTextWithPattern("ScanManifest*.json", oldGithubDirectory));
 
         var newGithubDirectory = new DirectoryInfo(newGithubArtifactsDir);
         this.newLogFileContents = this.GetFileTextWithPattern("GovCompDisc_Log*.log", newGithubDirectory);
-        this.newScanResult = System.Text.Json.JsonSerializer.Deserialize<DefaultGraphScanResult>(this.GetFileTextWithPattern("ScanManifest*.json", newGithubDirectory));
+        this.newScanResult = JsonSerializer.Deserialize<DefaultGraphScanResult>(this.GetFileTextWithPattern("ScanManifest*.json", newGithubDirectory));
     }
 
     private string GetFileTextWithPattern(string pattern, DirectoryInfo directory)


### PR DESCRIPTION
In #1523 we added the `[JsonProperty(Order = int.MinValue]` `Newtonsoft.Json` attribute to the `Type` property of the `TypedComponent` class to ensure that `"type"` would appear first in the serialized object. This is because `System.Text.Json` requires the type discriminator to be the first property of the object[^1]. `System.Text.Json` `9.0.0` and later does support the `JsonSerializerOptions.AllowOutOfOrder` option[^2], but as we're targeting .NET 8, we don't have access to that.

[^1]: https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/polymorphism#polymorphic-type-discriminators
[^2]: https://learn.microsoft.com/en-us/dotnet/api/system.text.json.jsonserializeroptions.allowoutofordermetadataproperties?view=net-10.0#system-text-json-jsonserializeroptions-allowoutofordermetadataproperties