### PR TITLE
Migrate test serialization from `Newtonsoft.Json` to `System.Text.Json`

### DIFF
--- a/src/Microsoft.ComponentDetection.Contracts/TypedComponent/TypedComponent.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/TypedComponent/TypedComponent.cs
@@ -49,10 +49,8 @@ public abstract class TypedComponent
 
     /// <summary>Gets the type of the component, must be well known.</summary>
     [JsonConverter(typeof(StringEnumConverter))] // Newtonsoft.Json
-    [System.Text.Json.Serialization.JsonConverter(typeof(JsonStringEnumConverter))] // System.Text.Json
     [JsonProperty("type", Order = int.MinValue)] // Newtonsoft.Json
-    [JsonPropertyName("type")] // System.Text.Json
-    [JsonPropertyOrder(int.MinValue)] // System.Text.Json
+    [System.Text.Json.Serialization.JsonIgnore] // System.Text.Json - type is handled by [JsonPolymorphic] discriminator
     public abstract ComponentType Type { get; }
 
     /// <summary>Gets the id of the component.</summary>

--- a/test/Microsoft.ComponentDetection.Contracts.Tests/ScanResultSerializationTests.cs
+++ b/test/Microsoft.ComponentDetection.Contracts.Tests/ScanResultSerializationTests.cs
@@ -2,12 +2,12 @@
 namespace Microsoft.ComponentDetection.Contracts.Tests;
 
 using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using AwesomeAssertions;
 using Microsoft.ComponentDetection.Contracts.BcdeModels;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 [TestClass]
 [TestCategory("Governance/All")]
@@ -60,8 +60,8 @@ public class ScanResultSerializationTests
     [TestMethod]
     public void ScanResultSerialization_HappyPath()
     {
-        var serializedResult = JsonConvert.SerializeObject(this.scanResultUnderTest);
-        var actual = JsonConvert.DeserializeObject<ScanResult>(serializedResult);
+        var serializedResult = JsonSerializer.Serialize(this.scanResultUnderTest);
+        var actual = JsonSerializer.Deserialize<ScanResult>(serializedResult);
 
         actual.ResultCode.Should().Be(ProcessingResultCode.PartialSuccess);
         actual.SourceDirectory.Should().Be("D:\\test\\directory");
@@ -92,30 +92,30 @@ public class ScanResultSerializationTests
     [TestMethod]
     public void ScanResultSerialization_ExpectedJsonFormat()
     {
-        var serializedResult = JsonConvert.SerializeObject(this.scanResultUnderTest);
-        var json = JObject.Parse(serializedResult);
+        var serializedResult = JsonSerializer.Serialize(this.scanResultUnderTest);
+        var json = JsonNode.Parse(serializedResult);
 
-        json.Value<string>("resultCode").Should().Be("PartialSuccess");
-        json.Value<string>("sourceDirectory").Should().Be("D:\\test\\directory");
-        var foundComponent = json["componentsFound"].First();
+        json["resultCode"].GetValue<string>().Should().Be("PartialSuccess");
+        json["sourceDirectory"].GetValue<string>().Should().Be("D:\\test\\directory");
+        var foundComponent = json["componentsFound"][0];
 
-        foundComponent.Value<string>("detectorId").Should().Be("NpmDetectorId");
-        foundComponent.Value<bool>("isDevelopmentDependency").Should().Be(true);
-        foundComponent.Value<string>("dependencyScope").Should().Be("MavenCompile");
-        foundComponent["locationsFoundAt"].First().Value<string>().Should().Be("some/location");
-        foundComponent["component"].Value<string>("type").Should().Be("Npm");
-        foundComponent["component"].Value<string>("name").Should().Be("SampleNpmComponent");
-        foundComponent["component"].Value<string>("version").Should().Be("1.2.3");
+        foundComponent["detectorId"].GetValue<string>().Should().Be("NpmDetectorId");
+        foundComponent["isDevelopmentDependency"].GetValue<bool>().Should().Be(true);
+        foundComponent["dependencyScope"].GetValue<string>().Should().Be("MavenCompile");
+        foundComponent["locationsFoundAt"][0].GetValue<string>().Should().Be("some/location");
+        foundComponent["component"]["type"].GetValue<string>().Should().Be("Npm");
+        foundComponent["component"]["name"].GetValue<string>().Should().Be("SampleNpmComponent");
+        foundComponent["component"]["version"].GetValue<string>().Should().Be("1.2.3");
 
-        var rootComponent = foundComponent["topLevelReferrers"].First();
-        rootComponent.Value<string>("type").Should().Be("Npm");
-        rootComponent.Value<string>("name").Should().Be("RootNpmComponent");
-        rootComponent.Value<string>("version").Should().Be("4.5.6");
+        var rootComponent = foundComponent["topLevelReferrers"][0];
+        rootComponent["type"].GetValue<string>().Should().Be("Npm");
+        rootComponent["name"].GetValue<string>().Should().Be("RootNpmComponent");
+        rootComponent["version"].GetValue<string>().Should().Be("4.5.6");
 
-        var detector = json["detectorsInScan"].First();
-        detector.Value<string>("detectorId").Should().Be("NpmDetectorId");
-        detector.Value<int>("version").Should().Be(2);
-        detector.Value<bool>("isExperimental").Should().Be(true);
-        detector["supportedComponentTypes"].First().Value<string>().Should().Be("Npm");
+        var detector = json["detectorsInScan"][0];
+        detector["detectorId"].GetValue<string>().Should().Be("NpmDetectorId");
+        detector["version"].GetValue<int>().Should().Be(2);
+        detector["isExperimental"].GetValue<bool>().Should().Be(true);
+        detector["supportedComponentTypes"][0].GetValue<string>().Should().Be("Npm");
     }
 }

--- a/test/Microsoft.ComponentDetection.Contracts.Tests/TypedComponentSerializationTests.cs
+++ b/test/Microsoft.ComponentDetection.Contracts.Tests/TypedComponentSerializationTests.cs
@@ -2,11 +2,11 @@
 namespace Microsoft.ComponentDetection.Contracts.Tests;
 
 using System;
+using System.Text.Json;
 using AwesomeAssertions;
 using Microsoft.ComponentDetection.Contracts.Internal;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Newtonsoft.Json;
 
 [TestClass]
 [TestCategory("Governance/All")]
@@ -17,8 +17,8 @@ public class TypedComponentSerializationTests
     public void TypedComponent_Serialization_Other()
     {
         TypedComponent tc = new OtherComponent("SomeOtherComponent", "1.2.3", new Uri("https://sampleurl.com"), "SampleHash");
-        var result = JsonConvert.SerializeObject(tc);
-        var deserializedTC = JsonConvert.DeserializeObject<TypedComponent>(result);
+        var result = JsonSerializer.Serialize(tc);
+        var deserializedTC = JsonSerializer.Deserialize<TypedComponent>(result);
         deserializedTC.Should().BeOfType(typeof(OtherComponent));
         var otherComponent = (OtherComponent)deserializedTC;
         otherComponent.Name.Should().Be("SomeOtherComponent");
@@ -34,8 +34,8 @@ public class TypedComponentSerializationTests
         var testVersion = "1.2.3";
         string[] testAuthors = ["John Doe", "Jane Doe"];
         TypedComponent tc = new NuGetComponent(testComponentName, testVersion, testAuthors);
-        var result = JsonConvert.SerializeObject(tc);
-        var deserializedTC = JsonConvert.DeserializeObject<TypedComponent>(result);
+        var result = JsonSerializer.Serialize(tc);
+        var deserializedTC = JsonSerializer.Deserialize<TypedComponent>(result);
         deserializedTC.Should().BeOfType(typeof(NuGetComponent));
         var nugetComponent = (NuGetComponent)deserializedTC;
         nugetComponent.Name.Should().Be(testComponentName);
@@ -47,12 +47,12 @@ public class TypedComponentSerializationTests
     public void TypedComponent_Serialization_Npm()
     {
         var npmAuthor = new NpmAuthor("someAuthorName", "someAuthorEmail");
-        var npmCompObj = new NpmComponent("SomeNpmComponent", "1.2.3")
+        TypedComponent npmCompObj = new NpmComponent("SomeNpmComponent", "1.2.3")
         {
             Author = npmAuthor,
         };
-        var result = JsonConvert.SerializeObject(npmCompObj);
-        var deserializedTC = JsonConvert.DeserializeObject<TypedComponent>(result);
+        var result = JsonSerializer.Serialize(npmCompObj);
+        var deserializedTC = JsonSerializer.Deserialize<TypedComponent>(result);
         deserializedTC.Should().BeOfType(typeof(NpmComponent));
         var npmComponent = (NpmComponent)deserializedTC;
         npmComponent.Name.Should().Be("SomeNpmComponent");
@@ -64,8 +64,8 @@ public class TypedComponentSerializationTests
     public void TypedComponent_Serialization_Npm_WithHash()
     {
         TypedComponent tc = new NpmComponent("SomeNpmComponent", "1.2.3", "sha1-placeholder");
-        var result = JsonConvert.SerializeObject(tc);
-        var deserializedTC = JsonConvert.DeserializeObject<TypedComponent>(result);
+        var result = JsonSerializer.Serialize(tc);
+        var deserializedTC = JsonSerializer.Deserialize<TypedComponent>(result);
         deserializedTC.Should().BeOfType(typeof(NpmComponent));
         var npmComponent = (NpmComponent)deserializedTC;
         npmComponent.Name.Should().Be("SomeNpmComponent");
@@ -77,8 +77,8 @@ public class TypedComponentSerializationTests
     public void TypedComponent_Serialization_Maven()
     {
         TypedComponent tc = new MavenComponent("SomeGroupId", "SomeArtifactId", "1.2.3");
-        var result = JsonConvert.SerializeObject(tc);
-        var deserializedTC = JsonConvert.DeserializeObject<TypedComponent>(result);
+        var result = JsonSerializer.Serialize(tc);
+        var deserializedTC = JsonSerializer.Deserialize<TypedComponent>(result);
         deserializedTC.Should().BeOfType(typeof(MavenComponent));
         var mavenComponent = (MavenComponent)deserializedTC;
         mavenComponent.GroupId.Should().Be("SomeGroupId");
@@ -90,8 +90,8 @@ public class TypedComponentSerializationTests
     public void TypedComponent_Serialization_Git()
     {
         TypedComponent tc = new GitComponent(new Uri("http://some.com/git/url.git"), "SomeHash");
-        var result = JsonConvert.SerializeObject(tc);
-        var deserializedTC = JsonConvert.DeserializeObject<TypedComponent>(result);
+        var result = JsonSerializer.Serialize(tc);
+        var deserializedTC = JsonSerializer.Deserialize<TypedComponent>(result);
         deserializedTC.Should().BeOfType(typeof(GitComponent));
         var gitComponent = (GitComponent)deserializedTC;
         gitComponent.RepositoryUrl.Should().Be(new Uri("http://some.com/git/url.git"));
@@ -102,8 +102,8 @@ public class TypedComponentSerializationTests
     public void TypedComponent_Serialization_RubyGems()
     {
         TypedComponent tc = new RubyGemsComponent("SomeGem", "1.2.3", "SampleSource");
-        var result = JsonConvert.SerializeObject(tc);
-        var deserializedTC = JsonConvert.DeserializeObject<TypedComponent>(result);
+        var result = JsonSerializer.Serialize(tc);
+        var deserializedTC = JsonSerializer.Deserialize<TypedComponent>(result);
         deserializedTC.Should().BeOfType(typeof(RubyGemsComponent));
         var rubyGemComponent = (RubyGemsComponent)deserializedTC;
         rubyGemComponent.Name.Should().Be("SomeGem");
@@ -115,8 +115,8 @@ public class TypedComponentSerializationTests
     public void TypedComponent_Serialization_Cargo()
     {
         TypedComponent tc = new CargoComponent("SomeCargoPackage", "1.2.3");
-        var result = JsonConvert.SerializeObject(tc);
-        var deserializedTC = JsonConvert.DeserializeObject<TypedComponent>(result);
+        var result = JsonSerializer.Serialize(tc);
+        var deserializedTC = JsonSerializer.Deserialize<TypedComponent>(result);
         deserializedTC.Should().BeOfType(typeof(CargoComponent));
         var cargoComponent = (CargoComponent)deserializedTC;
         cargoComponent.Name.Should().Be("SomeCargoPackage");
@@ -129,8 +129,8 @@ public class TypedComponentSerializationTests
         var md5 = Guid.NewGuid().ToString();
         var sha1Hash = Guid.NewGuid().ToString();
         TypedComponent tc = new ConanComponent("SomeConanPackage", "1.2.3", md5, sha1Hash);
-        var result = JsonConvert.SerializeObject(tc);
-        var deserializedTC = JsonConvert.DeserializeObject<TypedComponent>(result);
+        var result = JsonSerializer.Serialize(tc);
+        var deserializedTC = JsonSerializer.Deserialize<TypedComponent>(result);
         deserializedTC.Should().BeOfType(typeof(ConanComponent));
         var conanComponent = (ConanComponent)deserializedTC;
         conanComponent.Name.Should().Be("SomeConanPackage");
@@ -144,8 +144,8 @@ public class TypedComponentSerializationTests
     public void TypedComponent_Serialization_Pip()
     {
         TypedComponent tc = new PipComponent("SomePipPackage", "1.2.3");
-        var result = JsonConvert.SerializeObject(tc);
-        var deserializedTC = JsonConvert.DeserializeObject<TypedComponent>(result);
+        var result = JsonSerializer.Serialize(tc);
+        var deserializedTC = JsonSerializer.Deserialize<TypedComponent>(result);
         deserializedTC.Should().BeOfType(typeof(PipComponent));
         var pipComponent = (PipComponent)deserializedTC;
         pipComponent.Name.Should().Be("SomePipPackage");
@@ -156,8 +156,8 @@ public class TypedComponentSerializationTests
     public void TypedComponent_Serialization_Go()
     {
         TypedComponent tc = new GoComponent("SomeGoPackage", "1.2.3", "SomeHash");
-        var result = JsonConvert.SerializeObject(tc);
-        var deserializedTC = JsonConvert.DeserializeObject<TypedComponent>(result);
+        var result = JsonSerializer.Serialize(tc);
+        var deserializedTC = JsonSerializer.Deserialize<TypedComponent>(result);
         deserializedTC.Should().BeOfType(typeof(GoComponent));
         var goComponent = (GoComponent)deserializedTC;
         goComponent.Name.Should().Be("SomeGoPackage");
@@ -169,8 +169,8 @@ public class TypedComponentSerializationTests
     public void TypedComponent_Serialization_DockerImage()
     {
         TypedComponent tc = new DockerImageComponent("SomeImageHash", "SomeImageName", "SomeImageTag");
-        var result = JsonConvert.SerializeObject(tc);
-        var deserializedTC = JsonConvert.DeserializeObject<TypedComponent>(result);
+        var result = JsonSerializer.Serialize(tc);
+        var deserializedTC = JsonSerializer.Deserialize<TypedComponent>(result);
         deserializedTC.Should().BeOfType(typeof(DockerImageComponent));
         var dockerImageComponent = (DockerImageComponent)deserializedTC;
         dockerImageComponent.Digest.Should().Be("SomeImageHash");
@@ -182,8 +182,8 @@ public class TypedComponentSerializationTests
     public void TypedComponent_Serialization_PodComponent()
     {
         TypedComponent tc = new PodComponent("SomePodName", "SomePodVersion", "SomeSpecRepo");
-        var result = JsonConvert.SerializeObject(tc);
-        var deserializedTC = JsonConvert.DeserializeObject<TypedComponent>(result);
+        var result = JsonSerializer.Serialize(tc);
+        var deserializedTC = JsonSerializer.Deserialize<TypedComponent>(result);
         deserializedTC.Should().BeOfType(typeof(PodComponent));
         var podComponent = (PodComponent)deserializedTC;
         podComponent.Name.Should().Be("SomePodName");
@@ -195,8 +195,8 @@ public class TypedComponentSerializationTests
     public void TypedComponent_Serialization_LinuxComponent()
     {
         TypedComponent tc = new LinuxComponent("SomeLinuxDistribution", "SomeLinuxRelease", "SomeLinuxComponentName", "SomeLinuxComponentVersion");
-        var result = JsonConvert.SerializeObject(tc);
-        var deserializedTC = JsonConvert.DeserializeObject<TypedComponent>(result);
+        var result = JsonSerializer.Serialize(tc);
+        var deserializedTC = JsonSerializer.Deserialize<TypedComponent>(result);
         deserializedTC.Should().BeOfType(typeof(LinuxComponent));
         var linuxComponent = (LinuxComponent)deserializedTC;
         linuxComponent.Distribution.Should().Be("SomeLinuxDistribution");

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/Utilities/ComponentRecorderTestUtilities.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/Utilities/ComponentRecorderTestUtilities.cs
@@ -4,10 +4,10 @@ namespace Microsoft.ComponentDetection.Detectors.Tests.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
 using AwesomeAssertions;
 using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
-using Newtonsoft.Json;
 
 public static class ComponentRecorderTestUtilities
 {
@@ -154,12 +154,12 @@ public static class ComponentRecorderTestUtilities
 
             recordedDeps.Should().HaveCount(
                 expectedDeps.Length,
-                $"Count missmatch of expected dependencies ({JsonConvert.SerializeObject(expectedDeps)}) and recorded dependencies ({JsonConvert.SerializeObject(recordedDeps)}) for `{componentId}`!");
+                $"Count missmatch of expected dependencies ({JsonSerializer.Serialize(expectedDeps)}) and recorded dependencies ({JsonSerializer.Serialize(recordedDeps)}) for `{componentId}`!");
 
             foreach (var expectedDep in expectedDeps)
             {
                 recordedDeps.Should().Contain(
-                    expectedDep, $"Expected `{expectedDep}` in the list of dependencies for `{componentId}` but only recorded: {JsonConvert.SerializeObject(recordedDeps)}");
+                    expectedDep, $"Expected `{expectedDep}` in the list of dependencies for `{componentId}` but only recorded: {JsonSerializer.Serialize(recordedDeps)}");
             }
         }
     }


### PR DESCRIPTION
Continue the `Newtonsoft.Json` to `System.Text.Json` migration by updating test files in `Contracts.Tests` and `Detectors.Tests`:

- `ScanResultSerializationTests`: Replace `JsonConvert` and `JObject` with `JsonSerializer` and `JsonNode` for serialization/deserialization tests
- `TypedComponentSerializationTests`: Migrate all component roundtrip tests to use `System.Text.Json`
- `ComponentRecorderTestUtilities`: Replace `JsonConvert.SerializeObject` with `JsonSerializer.Serialize` in error message formatting

Also fix `TypedComponent` to avoid duplicate "type" property during `System.Text.Json` serialization - the `Type` property is now ignored since the `[JsonPolymorphic]` discriminator already handles type information.

Related to #231