### PR TITLE
Migrate Swift, Ivy, and pip detectors from `Newtonsoft.Json` to `System.Text.Json`

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/pip/Contracts/PythonProject.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/Contracts/PythonProject.cs
@@ -2,14 +2,17 @@
 namespace Microsoft.ComponentDetection.Detectors.Pip;
 
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 /// <summary>
 /// A project on pypi.
 /// </summary>
 public class PythonProject
 {
+    [JsonPropertyName("releases")]
     public SortedDictionary<string, IList<PythonProjectRelease>> Releases { get; set; }
 
 #nullable enable
+    [JsonPropertyName("info")]
     public PythonProjectInfo? Info { get; set; }
 }

--- a/src/Microsoft.ComponentDetection.Detectors/pip/Contracts/PythonProjectInfo.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/Contracts/PythonProjectInfo.cs
@@ -3,14 +3,12 @@ namespace Microsoft.ComponentDetection.Detectors.Pip;
 
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
-using Newtonsoft.Json;
 
 public class PythonProjectInfo
 {
     [JsonPropertyName("author")]
     public string Author { get; set; }
 
-    [JsonProperty("author_email")]
     [JsonPropertyName("author_email")]
     public string AuthorEmail { get; set; }
 
@@ -23,7 +21,6 @@ public class PythonProjectInfo
     [JsonPropertyName("maintainer")]
     public string Maintainer { get; set; }
 
-    [JsonProperty("maintainer_email")]
     [JsonPropertyName("maintainer_email")]
     public string MaintainerEmail { get; set; }
 

--- a/src/Microsoft.ComponentDetection.Detectors/pip/Contracts/PythonProjectRelease.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/Contracts/PythonProjectRelease.cs
@@ -3,7 +3,6 @@ namespace Microsoft.ComponentDetection.Detectors.Pip;
 
 using System;
 using System.Text.Json.Serialization;
-using Newtonsoft.Json;
 
 /// <summary>
 /// A specific release of a project on pypy.
@@ -13,7 +12,6 @@ public class PythonProjectRelease
     [JsonPropertyName("packagetype")]
     public string PackageType { get; set; }
 
-    [JsonProperty("python_version")]
     [JsonPropertyName("python_version")]
     public string PythonVersion { get; set; }
 

--- a/src/Microsoft.ComponentDetection.Detectors/pip/PythonResolver.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/PythonResolver.cs
@@ -4,15 +4,21 @@ namespace Microsoft.ComponentDetection.Detectors.Pip;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Encodings.Web;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.Extensions.Logging;
 using MoreLinq;
-using Newtonsoft.Json;
 
 public class PythonResolver : PythonResolverBase, IPythonResolver
 {
+    private static readonly JsonSerializerOptions JsonSerializerOptions = new()
+    {
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+    };
+
     private readonly IPyPiClient pypiClient;
     private readonly ILogger<PythonResolver> logger;
     private readonly Dictionary<string, string> pythonEnvironmentVariables = [];
@@ -69,7 +75,7 @@ public class PythonResolver : PythonResolverBase, IPythonResolver
                     this.logger.LogWarning(
                         "Unable to resolve root dependency {PackageName} with version specifiers {PackageVersions} from pypi possibly due to computed version constraints. Skipping package.",
                         rootPackage.Name,
-                        JsonConvert.SerializeObject(rootPackage.DependencySpecifiers));
+                        JsonSerializer.Serialize(rootPackage.DependencySpecifiers, JsonSerializerOptions));
                     singleFileComponentRecorder.RegisterPackageParseFailure(rootPackage.Name);
                 }
             }
@@ -136,7 +142,7 @@ public class PythonResolver : PythonResolverBase, IPythonResolver
                             this.logger.LogWarning(
                                 "Unable to resolve non-root dependency {PackageName} with version specifiers {PackageVersions} from pypi possibly due to computed version constraints. Skipping package.",
                                 dependencyNode.Name,
-                                JsonConvert.SerializeObject(dependencyNode.DependencySpecifiers));
+                                JsonSerializer.Serialize(dependencyNode.DependencySpecifiers, JsonSerializerOptions));
                             singleFileComponentRecorder.RegisterPackageParseFailure(dependencyNode.Name);
                         }
                     }

--- a/src/Microsoft.ComponentDetection.Detectors/pip/PythonResolverBase.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/PythonResolverBase.cs
@@ -3,14 +3,20 @@ namespace Microsoft.ComponentDetection.Detectors.Pip;
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Encodings.Web;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.Extensions.Logging;
 using MoreLinq;
-using Newtonsoft.Json;
 
 public abstract class PythonResolverBase
 {
+    private static readonly JsonSerializerOptions JsonSerializerOptions = new()
+    {
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+    };
+
     private readonly ILogger logger;
 
     internal PythonResolverBase(ILogger logger) => this.logger = logger;
@@ -93,8 +99,8 @@ public abstract class PythonResolverBase
                     "Duplicate package dependencies entry for component:{ComponentName} with dependency:{DependencyName}. Existing dependency specifiers: {ExistingSpecifiers}. New dependency specifiers: {NewSpecifiers}.",
                     component.Name,
                     d.Name,
-                    JsonConvert.SerializeObject(dependencies[d.Name].DependencySpecifiers),
-                    JsonConvert.SerializeObject(d.DependencySpecifiers));
+                    JsonSerializer.Serialize(dependencies[d.Name].DependencySpecifiers, JsonSerializerOptions),
+                    JsonSerializer.Serialize(d.DependencySpecifiers, JsonSerializerOptions));
                 dependencies[d.Name] = d;
             }
         });

--- a/src/Microsoft.ComponentDetection.Detectors/swiftpm/Contracts/SwiftResolvedFile.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/swiftpm/Contracts/SwiftResolvedFile.cs
@@ -3,58 +3,48 @@ namespace Microsoft.ComponentDetection.Contracts.TypedComponent;
 
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
-using Newtonsoft.Json;
 
 /// <summary>
 /// Represents a Swift Package Manager component.
 /// </summary>
 public class SwiftResolvedFile
 {
-    [JsonProperty("pins")]
     [JsonPropertyName("pins")]
     public IList<SwiftDependency> Pins { get; set; }
 
-    [JsonProperty("version")]
     [JsonPropertyName("version")]
     public int Version { get; set; }
 
     public class SwiftDependency
     {
         // The name of the package
-        [JsonProperty("identity")]
         [JsonPropertyName("identity")]
         public string Identity { get; set; }
 
         // How the package is imported. Example: "remoteSourceControl"
         // This is not an enum because the Swift contract does not specify the possible values.
-        [JsonProperty("kind")]
         [JsonPropertyName("kind")]
         public string Kind { get; set; }
 
         // The unique path to the repository where the package is located. Example: Git repo URL.
-        [JsonProperty("location")]
         [JsonPropertyName("location")]
         public string Location { get; set; }
 
         // Data about the package version and commit hash.
-        [JsonProperty("state")]
         [JsonPropertyName("state")]
         public SwiftState State { get; set; }
 
         public class SwiftState
         {
             // The commit hash of the package.
-            [JsonProperty("revision")]
             [JsonPropertyName("revision")]
             public string Revision { get; set; }
 
             // The version of the package. Might be missing.
-            [JsonProperty("version")]
             [JsonPropertyName("version")]
             public string Version { get; set; }
 
             // The branch of the package. Might be missing.
-            [JsonProperty("branch")]
             [JsonPropertyName("branch")]
             public string Branch { get; set; }
         }

--- a/src/Microsoft.ComponentDetection.Detectors/swiftpm/SwiftResolvedComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/swiftpm/SwiftResolvedComponentDetector.cs
@@ -4,13 +4,13 @@ namespace Microsoft.ComponentDetection.Detectors.Swift;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Contracts.Internal;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 
 /// <summary>
 /// Detects Swift Package Manager components.
@@ -109,6 +109,6 @@ public class SwiftResolvedComponentDetector : FileComponentDetector, IDefaultOff
             resolvedFile = reader.ReadToEnd();
         }
 
-        return JsonConvert.DeserializeObject<SwiftResolvedFile>(resolvedFile);
+        return JsonSerializer.Deserialize<SwiftResolvedFile>(resolvedFile);
     }
 }

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/IvyDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/IvyDetectorTests.cs
@@ -47,7 +47,7 @@ public class IvyDetectorTests : BaseDetectorTest<IvyDetector>
                                    "{ \"gav\": { \"g\": \"d0g\", \"a\": \"d0a\", \"v\": \"0.0.0\"}, \"DevelopmentDependency\": false, \"resolved\": false},\n" +
                                    "{ \"gav\": { \"g\": \"d1g\", \"a\": \"d1a\", \"v\": \"1.1.1\"}, \"DevelopmentDependency\": true, \"resolved\": true},\n" +
                                    "{ \"gav\": { \"g\": \"d2g\", \"a\": \"d2a\", \"v\": \"2.2.2\"}, \"DevelopmentDependency\": false, \"resolved\": true},\n" +
-                                   "{ \"gav\": { \"g\": \"d3g\", \"a\": \"d3a\", \"v\": \"3.3.3\"}, \"DevelopmentDependency\": false, \"resolved\": true, \"parent_gav\": { \"g\": \"d2g\", \"a\": \"d2a\", \"v\": \"2.2.2\"}},\n" +
+                                   "{ \"gav\": { \"g\": \"d3g\", \"a\": \"d3a\", \"v\": \"3.3.3\"}, \"DevelopmentDependency\": false, \"resolved\": true, \"parent_gav\": { \"g\": \"d2g\", \"a\": \"d2a\", \"v\": \"2.2.2\"}}\n" +
                                    "]}";
 
         this.IvyHappyPath(content: registerUsageContent);
@@ -93,7 +93,7 @@ public class IvyDetectorTests : BaseDetectorTest<IvyDetector>
                                    "{ \"gav\": { \"g\": \"d0g\", \"a\": \"d0a\", \"v\": \"0.0.0\"}, \"DevelopmentDependency\": false, \"resolved\": false},\n" +
                                    "{ \"gav\": { \"g\": \"d1g\", \"a\": \"d1a\", \"v\": \"1.1.1\"}, \"DevelopmentDependency\": true, \"resolved\": true},\n" +
                                    "{ \"gav\": { \"g\": \"d2g\", \"a\": \"d2a\", \"v\": \"2.2.2\"}, \"DevelopmentDependency\": false, \"resolved\": true},\n" +
-                                   "{ \"gav\": { \"g\": \"d3g\", \"a\": \"d3a\", \"v\": \"3.3.3\"}, \"DevelopmentDependency\": false, \"resolved\": true, \"parent_gav\": { \"g\": \"d2g\", \"a\": \"d2a\", \"v\": \"2.2.2\"}},\n" +
+                                   "{ \"gav\": { \"g\": \"d3g\", \"a\": \"d3a\", \"v\": \"3.3.3\"}, \"DevelopmentDependency\": false, \"resolved\": true, \"parent_gav\": { \"g\": \"d2g\", \"a\": \"d2a\", \"v\": \"2.2.2\"}}\n" +
                                    "]}";
 
         var d1Id = "d1g d1a 1.1.1 - Maven";


### PR DESCRIPTION
Part of the ongoing migration from `Newtonsoft.Json` to `System.Text.Json`. See #231.

This change migrates the lower-risk detector files that don't affect output contracts:

- `SwiftResolvedComponentDetector`: `JsonConvert.DeserializeObject` → `JsonSerializer.Deserialize`
- `SwiftResolvedFile`: Remove duplicate `[JsonProperty]` attributes
- `IvyDetector`: `JObject`/`JToken` → `JsonNode`/`JsonArray`
- `PythonProjectInfo`, `PythonProjectRelease`: Remove `[JsonProperty]` attributes
- `PythonResolver`, `SimplePythonResolver`, `PythonResolverBase`, `PyPiClient`:  `JsonConvert.SerializeObject` → `JsonSerializer.Serialize`