### PR TITLE
LinuxApplicationLayerExperiment adjustments.

### DIFF
--- a/src/Microsoft.ComponentDetection.Orchestrator/Experiments/Configs/LinuxApplicationLayerExperiment.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Experiments/Configs/LinuxApplicationLayerExperiment.cs
@@ -25,7 +25,8 @@ public class LinuxApplicationLayerExperiment : IExperimentConfiguration
                 or NpmLockfileDetectorBase
                 or PipReportComponentDetector
                 or NuGetComponentDetector
-                or NuGetProjectModelProjectCentricComponentDetector;
+                or NuGetProjectModelProjectCentricComponentDetector
+                or NuGetPackagesConfigDetector;
 
     /// <inheritdoc />
     public bool IsInExperimentGroup(IComponentDetector componentDetector) =>

--- a/test/Microsoft.ComponentDetection.Orchestrator.Tests/Experiments/LinuxApplicationLayerExperimentTests.cs
+++ b/test/Microsoft.ComponentDetection.Orchestrator.Tests/Experiments/LinuxApplicationLayerExperimentTests.cs
@@ -57,6 +57,13 @@ public class LinuxApplicationLayerExperimentTests
     }
 
     [TestMethod]
+    public void IsInControlGroup_NuGetPackagesConfigDetector_ReturnsTrue()
+    {
+        var nuGetPackagesConfigDetector = new NuGetPackagesConfigDetector(null, null, null);
+        this.experiment.IsInControlGroup(nuGetPackagesConfigDetector).Should().BeTrue();
+    }
+
+    [TestMethod]
     public void IsInControlGroup_PipReportComponentDetector_ReturnsTrue()
     {
         var pipDetector = new PipReportComponentDetector(
@@ -179,5 +186,8 @@ public class LinuxApplicationLayerExperimentTests
 
         var nuGetProjectCentricDetector = new NuGetProjectModelProjectCentricComponentDetector(null, null, null, null);
         this.experiment.ShouldRecord(nuGetProjectCentricDetector, 0).Should().BeTrue();
+
+        var nuGetPackagesConfigDetector = new NuGetPackagesConfigDetector(null, null, null);
+        this.experiment.ShouldRecord(nuGetPackagesConfigDetector, 0).Should().BeTrue();
     }
 }


### PR DESCRIPTION
Add NuGet to control group of the experiments. Support was already added here: https://github.com/microsoft/component-detection/pull/1548

Also changes logic to only report telemetry if something was found in the experiment group.