### PR TITLE
Update LinuxApplicationLayerExperiment control group

### DIFF
--- a/test/Microsoft.ComponentDetection.Orchestrator.Tests/Experiments/LinuxApplicationLayerExperimentTests.cs
+++ b/test/Microsoft.ComponentDetection.Orchestrator.Tests/Experiments/LinuxApplicationLayerExperimentTests.cs
@@ -22,50 +22,17 @@ public class LinuxApplicationLayerExperimentTests
     }
 
     [TestMethod]
-    public void IsInControlGroup_NpmComponentDetector_ReturnsTrue()
+    public void IsInControlGroup_FileBasedDetectors_ReturnsTrue()
     {
         var npmDetector = new NpmComponentDetector(null, null, null);
         this.experiment.IsInControlGroup(npmDetector).Should().BeTrue();
-    }
 
-    [TestMethod]
-    public void IsInControlGroup_NpmLockfile3Detector_ReturnsTrue()
-    {
         var npmLockfile3Detector = new NpmLockfile3Detector(null, null, null, null);
         this.experiment.IsInControlGroup(npmLockfile3Detector).Should().BeTrue();
-    }
 
-    [TestMethod]
-    public void IsInControlGroup_NpmComponentDetectorWithRoots_ReturnsTrue()
-    {
         var npmDetectorWithRoots = new NpmComponentDetectorWithRoots(null, null, null, null);
         this.experiment.IsInControlGroup(npmDetectorWithRoots).Should().BeTrue();
-    }
 
-    [TestMethod]
-    public void IsInControlGroup_NuGetComponentDetector_ReturnsTrue()
-    {
-        var nuGetDetector = new NuGetComponentDetector(null, null, null);
-        this.experiment.IsInControlGroup(nuGetDetector).Should().BeTrue();
-    }
-
-    [TestMethod]
-    public void IsInControlGroup_NuGetProjectModelProjectCentricComponentDetector_ReturnsTrue()
-    {
-        var nuGetDetector = new NuGetProjectModelProjectCentricComponentDetector(null, null, null, null);
-        this.experiment.IsInControlGroup(nuGetDetector).Should().BeTrue();
-    }
-
-    [TestMethod]
-    public void IsInControlGroup_NuGetPackagesConfigDetector_ReturnsTrue()
-    {
-        var nuGetPackagesConfigDetector = new NuGetPackagesConfigDetector(null, null, null);
-        this.experiment.IsInControlGroup(nuGetPackagesConfigDetector).Should().BeTrue();
-    }
-
-    [TestMethod]
-    public void IsInControlGroup_PipReportComponentDetector_ReturnsTrue()
-    {
         var pipDetector = new PipReportComponentDetector(
             null,
             null,
@@ -77,8 +44,21 @@ public class LinuxApplicationLayerExperimentTests
             null,
             null
         );
-
         this.experiment.IsInControlGroup(pipDetector).Should().BeTrue();
+
+        var nuGetDetector = new NuGetComponentDetector(null, null, null);
+        this.experiment.IsInControlGroup(nuGetDetector).Should().BeTrue();
+
+        var nuGetProjectCentricDetector = new NuGetProjectModelProjectCentricComponentDetector(
+            null,
+            null,
+            null,
+            null
+        );
+        this.experiment.IsInControlGroup(nuGetProjectCentricDetector).Should().BeTrue();
+
+        var nuGetPackagesConfigDetector = new NuGetPackagesConfigDetector(null, null, null);
+        this.experiment.IsInControlGroup(nuGetPackagesConfigDetector).Should().BeTrue();
     }
 
     [TestMethod]
@@ -103,29 +83,17 @@ public class LinuxApplicationLayerExperimentTests
     }
 
     [TestMethod]
-    public void IsInExperimentGroup_NpmComponentDetector_ReturnsFalse()
+    public void IsInExperimentGroup_FileBasedDetectors_ReturnsTrue()
     {
         var npmDetector = new NpmComponentDetector(null, null, null);
-        this.experiment.IsInExperimentGroup(npmDetector).Should().BeFalse();
-    }
+        this.experiment.IsInExperimentGroup(npmDetector).Should().BeTrue();
 
-    [TestMethod]
-    public void IsInExperimentGroup_NpmLockfile3Detector_ReturnsFalse()
-    {
         var npmLockfile3Detector = new NpmLockfile3Detector(null, null, null, null);
-        this.experiment.IsInExperimentGroup(npmLockfile3Detector).Should().BeFalse();
-    }
+        this.experiment.IsInExperimentGroup(npmLockfile3Detector).Should().BeTrue();
 
-    [TestMethod]
-    public void IsInExperimentGroup_NpmComponentDetectorWithRoots_ReturnsFalse()
-    {
         var npmDetectorWithRoots = new NpmComponentDetectorWithRoots(null, null, null, null);
-        this.experiment.IsInExperimentGroup(npmDetectorWithRoots).Should().BeFalse();
-    }
+        this.experiment.IsInExperimentGroup(npmDetectorWithRoots).Should().BeTrue();
 
-    [TestMethod]
-    public void IsInExperimentGroup_PipReportComponentDetector_ReturnsFalse()
-    {
         var pipDetector = new PipReportComponentDetector(
             null,
             null,
@@ -137,22 +105,21 @@ public class LinuxApplicationLayerExperimentTests
             null,
             null
         );
+        this.experiment.IsInExperimentGroup(pipDetector).Should().BeTrue();
 
-        this.experiment.IsInExperimentGroup(pipDetector).Should().BeFalse();
-    }
-
-    [TestMethod]
-    public void IsInExperimentGroup_NuGetComponentDetector_ReturnsFalse()
-    {
         var nuGetDetector = new NuGetComponentDetector(null, null, null);
-        this.experiment.IsInExperimentGroup(nuGetDetector).Should().BeFalse();
-    }
+        this.experiment.IsInExperimentGroup(nuGetDetector).Should().BeTrue();
 
-    [TestMethod]
-    public void IsInExperimentGroup_NuGetProjectModelProjectCentricComponentDetector_ReturnsFalse()
-    {
-        var nuGetDetector = new NuGetProjectModelProjectCentricComponentDetector(null, null, null, null);
-        this.experiment.IsInExperimentGroup(nuGetDetector).Should().BeFalse();
+        var nuGetProjectCentricDetector = new NuGetProjectModelProjectCentricComponentDetector(
+            null,
+            null,
+            null,
+            null
+        );
+        this.experiment.IsInExperimentGroup(nuGetProjectCentricDetector).Should().BeTrue();
+
+        var nuGetPackagesConfigDetector = new NuGetPackagesConfigDetector(null, null, null);
+        this.experiment.IsInExperimentGroup(nuGetPackagesConfigDetector).Should().BeTrue();
     }
 
     [TestMethod]
@@ -170,21 +137,47 @@ public class LinuxApplicationLayerExperimentTests
     }
 
     [TestMethod]
-    public void ShouldRecord_ControlGroup_AlwaysReturnsTrue()
+    public void ShouldRecord_ControlGroup_ReturnsTrue_WhenNumComponentsGreaterThanZero()
     {
         var linuxDetector = new LinuxContainerDetector(null, null, null);
-        this.experiment.ShouldRecord(linuxDetector, 0).Should().BeTrue();
+        this.experiment.ShouldRecord(linuxDetector, 1).Should().BeTrue();
+    }
 
+    [TestMethod]
+    public void ShouldRecord_ControlGroup_ReturnsFalse_WhenNumComponentsIsZero()
+    {
+        var linuxDetector = new LinuxContainerDetector(null, null, null);
+        this.experiment.ShouldRecord(linuxDetector, 0).Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void ShouldRecord_FileBasedDetectors_AlwaysReturnsTrue()
+    {
         var npmDetector = new NpmComponentDetector(null, null, null);
         this.experiment.ShouldRecord(npmDetector, 0).Should().BeTrue();
 
-        var pipDetector = new PipReportComponentDetector(null, null, null, null, null, null, null, null, null);
+        var pipDetector = new PipReportComponentDetector(
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        );
         this.experiment.ShouldRecord(pipDetector, 0).Should().BeTrue();
 
         var nuGetDetector = new NuGetComponentDetector(null, null, null);
         this.experiment.ShouldRecord(nuGetDetector, 0).Should().BeTrue();
 
-        var nuGetProjectCentricDetector = new NuGetProjectModelProjectCentricComponentDetector(null, null, null, null);
+        var nuGetProjectCentricDetector = new NuGetProjectModelProjectCentricComponentDetector(
+            null,
+            null,
+            null,
+            null
+        );
         this.experiment.ShouldRecord(nuGetProjectCentricDetector, 0).Should().BeTrue();
 
         var nuGetPackagesConfigDetector = new NuGetPackagesConfigDetector(null, null, null);


### PR DESCRIPTION
Updates the `LinuxApplicationLayerExperiment` to correctly measure net-new application packages found exclusively inside containers (e.g., packages installed via RUN npm add lodash).

## Changes
### Experiment Configuration:
  - Control Group: File-based detectors + LinuxContainerDetector (system packages)
  - Experiment Group: File-based detectors + LinuxApplicationLayerDetector (system + application packages)

This setup ensures:
- Components from manifest files (e.g., package.json) cancel out in both groups
- System packages detected by LinuxContainerDetector cancel out with those from LinuxApplicationLayerDetector
- The diff shows only application packages installed inside containers that weren't in manifest files

### ShouldRecord Logic:
- Returns false when LinuxContainerDetector finds 0 components (no containers scanned)
- Returns true for file-based detectors to avoid prematurely removing the experiment before container detectors run