### PR TITLE
Fix Docker image ID test for Docker 29

### DIFF
--- a/test/Microsoft.ComponentDetection.Common.Tests/DockerServiceTests.cs
+++ b/test/Microsoft.ComponentDetection.Common.Tests/DockerServiceTests.cs
@@ -65,12 +65,17 @@ public class DockerServiceTests
 
         details.Should().NotBeNull();
         details.Tags.Should().Contain("governancecontainerregistry.azurecr.io/testcontainers/dockertags_test:testtag");
-        var expectedImageId = "sha256:5edc12e9a797b59b9209354ff99d8550e7a1f90ca924c103fa3358e1a9ce15fe";
         var expectedCreatedAt = DateTime.Parse("2021-09-23T23:47:57.442225064Z").ToUniversalTime();
 
         details.Should().NotBeNull();
         details.Id.Should().BePositive();
-        details.ImageId.Should().BeEquivalentTo(expectedImageId);
+
+        // The image ID depends on the Docker storage backend:
+        // - Legacy graphdriver: returns the config digest
+        // - containerd image store (default since Docker 29): returns the manifest digest
+        var configDigest = "sha256:5edc12e9a797b59b9209354ff99d8550e7a1f90ca924c103fa3358e1a9ce15fe";
+        var manifestDigest = "sha256:144c8d7e446fa9da415418ef7844ab87ad8fd93a0ca48919c29cf82150c81982";
+        details.ImageId.Should().BeOneOf(configDigest, manifestDigest);
         details.CreatedAt.ToUniversalTime().Should().Be(expectedCreatedAt);
         details.BaseImageDigest.Should().Be("sha256:feb5d9fea6a5e9606aa995e879d862b825965ba48de054caab5ef356dc6b3412");
         details.BaseImageRef.Should().Be("docker.io/library/hello-world:latest");


### PR DESCRIPTION
GitHub Actions runners were [updated to Docker 29.1.x on February 9](https://github.com/actions/runner-images/issues/13474). Docker 29 [makes the containerd image store the default](https://docs.docker.com/engine/release-notes/29/#2900) for fresh installs, which changes how image IDs are reported.

With the legacy graphdriver, `docker inspect` returned the **config digest** as the image ID. With the containerd image store, it returns the **manifest digest** instead. The test image hasn't changed -- both digests are valid for it -- but `DockerService_PopulatesBaseImageAndLayerDetailsAsync` was hardcoded to expect only the config digest.

This updates the assertion to accept either digest, so the test passes on both old and new Docker versions.