### PR TITLE
Fix zizmor workflow security findings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Setup .NET

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,6 +28,7 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Initialize CodeQL

--- a/.github/workflows/gen-docs.yml
+++ b/.github/workflows/gen-docs.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 0
+          fetch-depth: 0 # zizmor: ignore[artipacked] git-auto-commit-action needs credentials to push
 
       - name: Setup .NET Core
         uses: actions/setup-dotnet@baa11fbfe1d6520db94683bd5c7a3818018e4309 # v5.1.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Setup .NET

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -45,6 +45,8 @@ jobs:
 
       - name: Checkout Component Detection
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Prepare Dotnet
         run: |
@@ -67,6 +69,7 @@ jobs:
       - name: Checkout Smoke Test Repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           repository: ${{ matrix.language.repo }}
           path: smoke-test-repo
 

--- a/.github/workflows/snapshot-publish.yml
+++ b/.github/workflows/snapshot-publish.yml
@@ -29,6 +29,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup .NET Core
         uses: actions/setup-dotnet@baa11fbfe1d6520db94683bd5c7a3818018e4309 # v5.1.0

--- a/.github/workflows/snapshot-verify.yml
+++ b/.github/workflows/snapshot-verify.yml
@@ -25,6 +25,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Make release snapshot output directory
         run: mkdir ${{ github.workspace }}/release-output
@@ -51,8 +53,11 @@ jobs:
 
       - name: Download latest release snapshot
         working-directory: ${{ github.workspace }}/release-output
+        env:
+          DOWNLOAD_URL: ${{ steps.download-latest-release-snapshot.outputs.result }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          curl -v -L -u octocat:${{ secrets.GITHUB_TOKEN }} -o output.zip "${{ steps.download-latest-release-snapshot.outputs.result }}"
+          curl -v -L -u "octocat:$GH_TOKEN" -o output.zip "$DOWNLOAD_URL"
           unzip output.zip
           rm output.zip
 


### PR DESCRIPTION
Resolves the medium-severity findings from zizmor:

- Add `persist-credentials: false` to `actions/checkout` in 6 workflows (build, codeql, release, smoke-test, snapshot-publish, snapshot-verify) to avoid persisting credentials in artifacts.
- Move secrets and step outputs in snapshot-verify into `env:` instead of inline `${{ }}` expressions to prevent template injection.
- Suppress the artipacked finding in gen-docs, where `git-auto-commit-action` needs credentials to push.

One informational `use-trusted-publishing` finding remains in release.yml. That would require configuring OIDC trusted publishing on the GitHub Packages side and isn't a workflow-only change.