### PR TITLE
Fix snapshot verify workflow on Windows

### DIFF
--- a/.github/workflows/snapshot-verify.yml
+++ b/.github/workflows/snapshot-verify.yml
@@ -53,6 +53,7 @@ jobs:
 
       - name: Download latest release snapshot
         working-directory: ${{ github.workspace }}/release-output
+        shell: bash
         env:
           DOWNLOAD_URL: ${{ steps.download-latest-release-snapshot.outputs.result }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The "Download latest release snapshot" step in `snapshot-verify.yml` doesn't specify a shell, so on Windows it runs under PowerShell. PowerShell treats `$GH_TOKEN` and `$DOWNLOAD_URL` as its own (undefined) variables, which means `curl` gets blank arguments and the download fails. Ubuntu and macOS default to bash, so they're unaffected.

This adds `shell: bash` to that step — the same fix already used by the Windows Ivy install step a few lines below.

Fixes the error:
```
curl: option : blank argument where content is expected
```