### PR TITLE
refactor: make Common implementation details internal

### DIFF
--- a/src/Microsoft.ComponentDetection.Common/Column.cs
+++ b/src/Microsoft.ComponentDetection.Common/Column.cs
@@ -1,7 +1,7 @@
 #nullable disable
 namespace Microsoft.ComponentDetection.Common;
 
-public class Column
+internal class Column
 {
     public int Width { get; set; }
 

--- a/src/Microsoft.ComponentDetection.Common/CommandLineInvocationService.cs
+++ b/src/Microsoft.ComponentDetection.Common/CommandLineInvocationService.cs
@@ -14,7 +14,7 @@ using Microsoft.ComponentDetection.Common.Telemetry.Records;
 using Microsoft.ComponentDetection.Contracts;
 
 /// <inheritdoc/>
-public class CommandLineInvocationService : ICommandLineInvocationService
+internal class CommandLineInvocationService : ICommandLineInvocationService
 {
     private readonly IDictionary<string, string> commandLocatableCache = new ConcurrentDictionary<string, string>();
 

--- a/src/Microsoft.ComponentDetection.Common/ComponentComparer.cs
+++ b/src/Microsoft.ComponentDetection.Common/ComponentComparer.cs
@@ -7,7 +7,7 @@ using Microsoft.ComponentDetection.Contracts.TypedComponent;
 /// <summary>
 /// Compares two <see cref="TypedComponent"/>s by their <see cref="TypedComponent.Id"/>.
 /// </summary>
-public class ComponentComparer : EqualityComparer<TypedComponent>
+internal class ComponentComparer : EqualityComparer<TypedComponent>
 {
     /// <summary>
     /// Determines whether the specified objects are equal.

--- a/src/Microsoft.ComponentDetection.Common/ComponentStreamEnumerableFactory.cs
+++ b/src/Microsoft.ComponentDetection.Common/ComponentStreamEnumerableFactory.cs
@@ -7,7 +7,7 @@ using Microsoft.ComponentDetection.Contracts;
 using Microsoft.Extensions.Logging;
 
 /// <inheritdoc />
-public class ComponentStreamEnumerableFactory : IComponentStreamEnumerableFactory
+internal class ComponentStreamEnumerableFactory : IComponentStreamEnumerableFactory
 {
     private readonly IPathUtilityService pathUtilityService;
     private readonly ILogger<ComponentStreamEnumerable> logger;

--- a/src/Microsoft.ComponentDetection.Common/ConsoleWritingService.cs
+++ b/src/Microsoft.ComponentDetection.Common/ConsoleWritingService.cs
@@ -2,7 +2,7 @@ namespace Microsoft.ComponentDetection.Common;
 
 using System;
 
-public class ConsoleWritingService : IConsoleWritingService
+internal class ConsoleWritingService : IConsoleWritingService
 {
     public void Write(string content)
     {

--- a/src/Microsoft.ComponentDetection.Common/DependencyScopeComparer.cs
+++ b/src/Microsoft.ComponentDetection.Common/DependencyScopeComparer.cs
@@ -6,7 +6,7 @@ using Microsoft.ComponentDetection.Contracts.BcdeModels;
 /// Merges dependnecy Scope in their order of Priority.
 /// Higher priority scope, as indicated by its lower enum value is given precendence.
 /// </summary>
-public static class DependencyScopeComparer
+internal static class DependencyScopeComparer
 {
     public static DependencyScope? GetMergedDependencyScope(DependencyScope? scope1, DependencyScope? scope2)
     {

--- a/src/Microsoft.ComponentDetection.Common/DirectoryItemFacade.cs
+++ b/src/Microsoft.ComponentDetection.Common/DirectoryItemFacade.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 using Microsoft.ComponentDetection.Contracts;
 
 [DebuggerDisplay("{Name}")]
-public class DirectoryItemFacade
+internal class DirectoryItemFacade
 {
     public string Name { get; set; }
 

--- a/src/Microsoft.ComponentDetection.Common/DirectoryItemFacadeOptimized.cs
+++ b/src/Microsoft.ComponentDetection.Common/DirectoryItemFacadeOptimized.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 
 [DebuggerDisplay("{Name}")]
-public class DirectoryItemFacadeOptimized
+internal class DirectoryItemFacadeOptimized
 {
     public string Name { get; set; }
 

--- a/src/Microsoft.ComponentDetection.Common/DirectoryUtilityService.cs
+++ b/src/Microsoft.ComponentDetection.Common/DirectoryUtilityService.cs
@@ -5,7 +5,7 @@ using System.IO;
 using Microsoft.ComponentDetection.Contracts;
 
 /// <inheritdoc />
-public class DirectoryUtilityService : IDirectoryUtilityService
+internal class DirectoryUtilityService : IDirectoryUtilityService
 {
     /// <inheritdoc />
     public void Delete(string path, bool recursive) => Directory.Delete(path, recursive);

--- a/src/Microsoft.ComponentDetection.Common/DockerReference/DockerReferenceException.cs
+++ b/src/Microsoft.ComponentDetection.Common/DockerReference/DockerReferenceException.cs
@@ -3,7 +3,7 @@ namespace Microsoft.ComponentDetection.Common;
 
 using System;
 
-public class DockerReferenceException : Exception
+internal class DockerReferenceException : Exception
 {
     public DockerReferenceException(string reference, string exceptionErrorMessage)
         : base($"Error while parsing docker reference {reference} : {exceptionErrorMessage}")
@@ -26,7 +26,7 @@ public class DockerReferenceException : Exception
 }
 
 // ReferenceInvalidFormat represents an error while trying to parse a string as a reference.
-public class ReferenceInvalidFormatException : DockerReferenceException
+internal class ReferenceInvalidFormatException : DockerReferenceException
 {
     private const string ErrorMessage = "invalid reference format";
 
@@ -46,7 +46,7 @@ public class ReferenceInvalidFormatException : DockerReferenceException
 }
 
 // TagInvalidFormat represents an error while trying to parse a string as a tag.
-public class ReferenceTagInvalidFormatException : DockerReferenceException
+internal class ReferenceTagInvalidFormatException : DockerReferenceException
 {
     private const string ErrorMessage = "invalid tag format";
 
@@ -66,7 +66,7 @@ public class ReferenceTagInvalidFormatException : DockerReferenceException
 }
 
 // DigestInvalidFormat represents an error while trying to parse a string as a tag.
-public class ReferenceDigestInvalidFormatException : DockerReferenceException
+internal class ReferenceDigestInvalidFormatException : DockerReferenceException
 {
     private const string ErrorMessage = "invalid digest format";
 
@@ -86,7 +86,7 @@ public class ReferenceDigestInvalidFormatException : DockerReferenceException
 }
 
 // NameContainsUppercase is returned for invalid repository names that contain uppercase characters.
-public class ReferenceNameContainsUppercaseException : DockerReferenceException
+internal class ReferenceNameContainsUppercaseException : DockerReferenceException
 {
     private const string ErrorMessage = "repository name must be lowercase";
 
@@ -106,7 +106,7 @@ public class ReferenceNameContainsUppercaseException : DockerReferenceException
 }
 
 // NameEmpty is returned for empty, invalid repository names.
-public class ReferenceNameEmptyException : DockerReferenceException
+internal class ReferenceNameEmptyException : DockerReferenceException
 {
     private const string ErrorMessage = "repository name must have at least one component";
 
@@ -126,7 +126,7 @@ public class ReferenceNameEmptyException : DockerReferenceException
 }
 
 // ErrNameTooLong is returned when a repository name is longer than NameTotalLengthMax.
-public class ReferenceNameTooLongException : DockerReferenceException
+internal class ReferenceNameTooLongException : DockerReferenceException
 {
     private const string ErrorMessage = "repository name must not be more than 255 characters";
 
@@ -146,7 +146,7 @@ public class ReferenceNameTooLongException : DockerReferenceException
 }
 
 // ErrNameNotCanonical is returned when a name is not canonical.
-public class ReferenceNameNotCanonicalException : DockerReferenceException
+internal class ReferenceNameNotCanonicalException : DockerReferenceException
 {
     private const string ErrorMessage = "repository name must be canonical";
 
@@ -165,7 +165,7 @@ public class ReferenceNameNotCanonicalException : DockerReferenceException
     }
 }
 
-public class InvalidDigestFormatError : DockerReferenceException
+internal class InvalidDigestFormatError : DockerReferenceException
 {
     private const string ErrorMessage = "invalid digest format";
 
@@ -184,7 +184,7 @@ public class InvalidDigestFormatError : DockerReferenceException
     }
 }
 
-public class UnsupportedAlgorithmError : DockerReferenceException
+internal class UnsupportedAlgorithmError : DockerReferenceException
 {
     private const string ErrorMessage = "unsupported digest algorithm";
 
@@ -203,7 +203,7 @@ public class UnsupportedAlgorithmError : DockerReferenceException
     }
 }
 
-public class InvalidDigestLengthError : DockerReferenceException
+internal class InvalidDigestLengthError : DockerReferenceException
 {
     private const string ErrorMessage = "invalid checksum digest length";
 

--- a/src/Microsoft.ComponentDetection.Common/DockerService.cs
+++ b/src/Microsoft.ComponentDetection.Common/DockerService.cs
@@ -15,7 +15,7 @@ using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Contracts.BcdeModels;
 using Microsoft.Extensions.Logging;
 
-public class DockerService : IDockerService
+internal class DockerService : IDockerService
 {
     // Base image annotations from ADO dockerTask
     private const string BaseImageRefAnnotation = "image.base.ref.name";

--- a/src/Microsoft.ComponentDetection.Common/EnvironmentVariableService.cs
+++ b/src/Microsoft.ComponentDetection.Common/EnvironmentVariableService.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.ComponentDetection.Contracts;
 
-public class EnvironmentVariableService : IEnvironmentVariableService
+internal class EnvironmentVariableService : IEnvironmentVariableService
 {
     public bool DoesEnvironmentVariableExist(string name)
     {

--- a/src/Microsoft.ComponentDetection.Common/FastDirectoryWalkerFactory.cs
+++ b/src/Microsoft.ComponentDetection.Common/FastDirectoryWalkerFactory.cs
@@ -16,7 +16,7 @@ using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Contracts.Internal;
 using Microsoft.Extensions.Logging;
 
-public class FastDirectoryWalkerFactory : IObservableDirectoryWalkerFactory
+internal class FastDirectoryWalkerFactory : IObservableDirectoryWalkerFactory
 {
     private readonly ConcurrentDictionary<DirectoryInfo, Lazy<IObservable<FileSystemInfo>>> pendingScans = new ConcurrentDictionary<DirectoryInfo, Lazy<IObservable<FileSystemInfo>>>();
     private readonly IPathUtilityService pathUtilityService;

--- a/src/Microsoft.ComponentDetection.Common/FileUtilityService.cs
+++ b/src/Microsoft.ComponentDetection.Common/FileUtilityService.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.ComponentDetection.Contracts;
 
 /// <inheritdoc />
-public class FileUtilityService : IFileUtilityService
+internal class FileUtilityService : IFileUtilityService
 {
     /// <inheritdoc />
     public string ReadAllText(string filePath)

--- a/src/Microsoft.ComponentDetection.Common/Microsoft.ComponentDetection.Common.csproj
+++ b/src/Microsoft.ComponentDetection.Common/Microsoft.ComponentDetection.Common.csproj
@@ -5,6 +5,9 @@
         <InternalsVisibleTo Include="Microsoft.ComponentDetection.Orchestrator" />
         <InternalsVisibleTo Include="Microsoft.ComponentDetection.Detectors" />
         <InternalsVisibleTo Include="Microsoft.ComponentDetection.TestsUtilities" />
+        <InternalsVisibleTo Include="Microsoft.ComponentDetection.Detectors.Tests" />
+        <InternalsVisibleTo Include="Microsoft.ComponentDetection.Orchestrator.Tests" />
+        <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Microsoft.ComponentDetection.Common/PathUtilityService.cs
+++ b/src/Microsoft.ComponentDetection.Common/PathUtilityService.cs
@@ -8,7 +8,7 @@ using Microsoft.ComponentDetection.Contracts;
 using Microsoft.Extensions.Logging;
 
 // We may want to consider breaking this class into Win/Mac/Linux variants if it gets bigger
-public class PathUtilityService : IPathUtilityService
+internal class PathUtilityService : IPathUtilityService
 {
     public const uint CreationDispositionRead = 0x3;
 

--- a/src/Microsoft.ComponentDetection.Common/SafeFileEnumerableFactory.cs
+++ b/src/Microsoft.ComponentDetection.Common/SafeFileEnumerableFactory.cs
@@ -6,7 +6,7 @@ using System.IO;
 using Microsoft.ComponentDetection.Contracts;
 using Microsoft.Extensions.Logging;
 
-public class SafeFileEnumerableFactory : ISafeFileEnumerableFactory
+internal class SafeFileEnumerableFactory : ISafeFileEnumerableFactory
 {
     private readonly IPathUtilityService pathUtilityService;
     private readonly ILogger<SafeFileEnumerableFactory> logger;

--- a/src/Microsoft.ComponentDetection.Common/TabularStringFormat.cs
+++ b/src/Microsoft.ComponentDetection.Common/TabularStringFormat.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
-public class TabularStringFormat
+internal class TabularStringFormat
 {
     public const char DefaultVerticalLineChar = '|';
     public const char DefaultHorizontalLineChar = '_';

--- a/src/Microsoft.ComponentDetection.Common/Telemetry/Records/BcdeExecutionTelemetryRecord.cs
+++ b/src/Microsoft.ComponentDetection.Common/Telemetry/Records/BcdeExecutionTelemetryRecord.cs
@@ -5,7 +5,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-public class BcdeExecutionTelemetryRecord : BaseDetectionTelemetryRecord
+internal class BcdeExecutionTelemetryRecord : BaseDetectionTelemetryRecord
 {
     public override string RecordName => "BcdeExecution";
 

--- a/src/Microsoft.ComponentDetection.Common/Telemetry/Records/CommandLineInvocationTelemetryRecord.cs
+++ b/src/Microsoft.ComponentDetection.Common/Telemetry/Records/CommandLineInvocationTelemetryRecord.cs
@@ -3,7 +3,7 @@ namespace Microsoft.ComponentDetection.Common.Telemetry.Records;
 using System;
 using Microsoft.ComponentDetection.Contracts;
 
-public class CommandLineInvocationTelemetryRecord : BaseDetectionTelemetryRecord
+internal class CommandLineInvocationTelemetryRecord : BaseDetectionTelemetryRecord
 {
     public override string RecordName => "CommandLineInvocation";
 

--- a/src/Microsoft.ComponentDetection.Common/Telemetry/Records/DependencyGraphTranslationRecord.cs
+++ b/src/Microsoft.ComponentDetection.Common/Telemetry/Records/DependencyGraphTranslationRecord.cs
@@ -2,7 +2,7 @@ namespace Microsoft.ComponentDetection.Common.Telemetry.Records;
 
 using System;
 
-public class DependencyGraphTranslationRecord : BaseDetectionTelemetryRecord
+internal class DependencyGraphTranslationRecord : BaseDetectionTelemetryRecord
 {
     public override string RecordName => "DependencyGraphTranslationRecord";
 

--- a/src/Microsoft.ComponentDetection.Common/Telemetry/Records/DetectedComponentScopeRecord.cs
+++ b/src/Microsoft.ComponentDetection.Common/Telemetry/Records/DetectedComponentScopeRecord.cs
@@ -2,7 +2,7 @@ namespace Microsoft.ComponentDetection.Common.Telemetry.Records;
 
 using System.Runtime.CompilerServices;
 
-public class DetectedComponentScopeRecord : BaseDetectionTelemetryRecord
+internal class DetectedComponentScopeRecord : BaseDetectionTelemetryRecord
 {
     public override string RecordName => "ComponentScopeRecord";
 

--- a/src/Microsoft.ComponentDetection.Common/Telemetry/Records/DetectorExecutionTelemetryRecord.cs
+++ b/src/Microsoft.ComponentDetection.Common/Telemetry/Records/DetectorExecutionTelemetryRecord.cs
@@ -1,6 +1,6 @@
 namespace Microsoft.ComponentDetection.Common.Telemetry.Records;
 
-public class DetectorExecutionTelemetryRecord : BaseDetectionTelemetryRecord
+internal class DetectorExecutionTelemetryRecord : BaseDetectionTelemetryRecord
 {
     public override string RecordName => "DetectorExecution";
 

--- a/src/Microsoft.ComponentDetection.Common/Telemetry/Records/DockerServiceImageExistsLocallyTelemetryRecord.cs
+++ b/src/Microsoft.ComponentDetection.Common/Telemetry/Records/DockerServiceImageExistsLocallyTelemetryRecord.cs
@@ -1,6 +1,6 @@
 namespace Microsoft.ComponentDetection.Common.Telemetry.Records;
 
-public class DockerServiceImageExistsLocallyTelemetryRecord : BaseDetectionTelemetryRecord
+internal class DockerServiceImageExistsLocallyTelemetryRecord : BaseDetectionTelemetryRecord
 {
     public override string RecordName => "DockerServiceImageExistsLocally";
 

--- a/src/Microsoft.ComponentDetection.Common/Telemetry/Records/DockerServiceInspectImageTelemetryRecord.cs
+++ b/src/Microsoft.ComponentDetection.Common/Telemetry/Records/DockerServiceInspectImageTelemetryRecord.cs
@@ -1,6 +1,6 @@
 namespace Microsoft.ComponentDetection.Common.Telemetry.Records;
 
-public class DockerServiceInspectImageTelemetryRecord : BaseDetectionTelemetryRecord
+internal class DockerServiceInspectImageTelemetryRecord : BaseDetectionTelemetryRecord
 {
     public override string RecordName => "DockerServiceInspectImage";
 

--- a/src/Microsoft.ComponentDetection.Common/Telemetry/Records/DockerServiceSystemInfoTelemetryRecord.cs
+++ b/src/Microsoft.ComponentDetection.Common/Telemetry/Records/DockerServiceSystemInfoTelemetryRecord.cs
@@ -1,6 +1,6 @@
 namespace Microsoft.ComponentDetection.Common.Telemetry.Records;
 
-public class DockerServiceSystemInfoTelemetryRecord : BaseDetectionTelemetryRecord
+internal class DockerServiceSystemInfoTelemetryRecord : BaseDetectionTelemetryRecord
 {
     public override string RecordName => "DockerServiceSystemInfo";
 

--- a/src/Microsoft.ComponentDetection.Common/Telemetry/Records/DockerServiceTelemetryRecord.cs
+++ b/src/Microsoft.ComponentDetection.Common/Telemetry/Records/DockerServiceTelemetryRecord.cs
@@ -1,6 +1,6 @@
 namespace Microsoft.ComponentDetection.Common.Telemetry.Records;
 
-public class DockerServiceTelemetryRecord : BaseDetectionTelemetryRecord
+internal class DockerServiceTelemetryRecord : BaseDetectionTelemetryRecord
 {
     public override string RecordName => "DockerService";
 

--- a/src/Microsoft.ComponentDetection.Common/Telemetry/Records/DockerServiceTryPullImageTelemetryRecord.cs
+++ b/src/Microsoft.ComponentDetection.Common/Telemetry/Records/DockerServiceTryPullImageTelemetryRecord.cs
@@ -1,6 +1,6 @@
 namespace Microsoft.ComponentDetection.Common.Telemetry.Records;
 
-public class DockerServiceTryPullImageTelemetryRecord : BaseDetectionTelemetryRecord
+internal class DockerServiceTryPullImageTelemetryRecord : BaseDetectionTelemetryRecord
 {
     public override string RecordName => "DockerServiceTryPullImage";
 

--- a/src/Microsoft.ComponentDetection.Common/Telemetry/Records/FailedParsingFileRecord.cs
+++ b/src/Microsoft.ComponentDetection.Common/Telemetry/Records/FailedParsingFileRecord.cs
@@ -1,6 +1,6 @@
 namespace Microsoft.ComponentDetection.Common.Telemetry.Records;
 
-public class FailedParsingFileRecord : BaseDetectionTelemetryRecord
+internal class FailedParsingFileRecord : BaseDetectionTelemetryRecord
 {
     public override string RecordName => "FailedParsingFile";
 

--- a/src/Microsoft.ComponentDetection.Common/Telemetry/Records/GoReplaceTelemetryRecord.cs
+++ b/src/Microsoft.ComponentDetection.Common/Telemetry/Records/GoReplaceTelemetryRecord.cs
@@ -1,6 +1,6 @@
 namespace Microsoft.ComponentDetection.Common.Telemetry.Records;
 
-public class GoReplaceTelemetryRecord : BaseDetectionTelemetryRecord
+internal class GoReplaceTelemetryRecord : BaseDetectionTelemetryRecord
 {
     public override string RecordName => "GoReplace";
 

--- a/src/Microsoft.ComponentDetection.Common/Telemetry/Records/InvalidParseVersionTelemetryRecord.cs
+++ b/src/Microsoft.ComponentDetection.Common/Telemetry/Records/InvalidParseVersionTelemetryRecord.cs
@@ -1,6 +1,6 @@
 namespace Microsoft.ComponentDetection.Common.Telemetry.Records;
 
-public class InvalidParseVersionTelemetryRecord : BaseDetectionTelemetryRecord
+internal class InvalidParseVersionTelemetryRecord : BaseDetectionTelemetryRecord
 {
     public override string RecordName => "InvalidParseVersion";
 

--- a/src/Microsoft.ComponentDetection.Common/Telemetry/Records/LinuxContainerDetectorImageDetectionFailed.cs
+++ b/src/Microsoft.ComponentDetection.Common/Telemetry/Records/LinuxContainerDetectorImageDetectionFailed.cs
@@ -1,6 +1,6 @@
 namespace Microsoft.ComponentDetection.Common.Telemetry.Records;
 
-public class LinuxContainerDetectorImageDetectionFailed : BaseDetectionTelemetryRecord
+internal class LinuxContainerDetectorImageDetectionFailed : BaseDetectionTelemetryRecord
 {
     public override string RecordName => "LinuxContainerDetectorImageDetectionFailed";
 

--- a/src/Microsoft.ComponentDetection.Common/Telemetry/Records/LinuxContainerDetectorLayerAwareness.cs
+++ b/src/Microsoft.ComponentDetection.Common/Telemetry/Records/LinuxContainerDetectorLayerAwareness.cs
@@ -1,6 +1,6 @@
 namespace Microsoft.ComponentDetection.Common.Telemetry.Records;
 
-public class LinuxContainerDetectorLayerAwareness : BaseDetectionTelemetryRecord
+internal class LinuxContainerDetectorLayerAwareness : BaseDetectionTelemetryRecord
 {
     public override string RecordName => "LinuxContainerDetectorLayerAwareness";
 

--- a/src/Microsoft.ComponentDetection.Common/Telemetry/Records/LinuxContainerDetectorMissingRepoNameAndTagRecord.cs
+++ b/src/Microsoft.ComponentDetection.Common/Telemetry/Records/LinuxContainerDetectorMissingRepoNameAndTagRecord.cs
@@ -1,6 +1,6 @@
 namespace Microsoft.ComponentDetection.Common.Telemetry.Records;
 
-public class LinuxContainerDetectorMissingRepoNameAndTagRecord : BaseDetectionTelemetryRecord
+internal class LinuxContainerDetectorMissingRepoNameAndTagRecord : BaseDetectionTelemetryRecord
 {
     public override string RecordName => "MissingRepoNameAndTag";
 }

--- a/src/Microsoft.ComponentDetection.Common/Telemetry/Records/LinuxContainerDetectorMissingVersion.cs
+++ b/src/Microsoft.ComponentDetection.Common/Telemetry/Records/LinuxContainerDetectorMissingVersion.cs
@@ -1,6 +1,6 @@
 namespace Microsoft.ComponentDetection.Common.Telemetry.Records;
 
-public class LinuxContainerDetectorMissingVersion : BaseDetectionTelemetryRecord
+internal class LinuxContainerDetectorMissingVersion : BaseDetectionTelemetryRecord
 {
     public override string RecordName { get; } = "MissingVersion";
 

--- a/src/Microsoft.ComponentDetection.Common/Telemetry/Records/LinuxContainerDetectorTimeout.cs
+++ b/src/Microsoft.ComponentDetection.Common/Telemetry/Records/LinuxContainerDetectorTimeout.cs
@@ -1,6 +1,6 @@
 namespace Microsoft.ComponentDetection.Common.Telemetry.Records;
 
-public class LinuxContainerDetectorTimeout : BaseDetectionTelemetryRecord
+internal class LinuxContainerDetectorTimeout : BaseDetectionTelemetryRecord
 {
     public override string RecordName => "LinuxContainerDetectorTimeout";
 }

--- a/src/Microsoft.ComponentDetection.Common/Telemetry/Records/LinuxContainerDetectorUnsupportedOs.cs
+++ b/src/Microsoft.ComponentDetection.Common/Telemetry/Records/LinuxContainerDetectorUnsupportedOs.cs
@@ -1,6 +1,6 @@
 namespace Microsoft.ComponentDetection.Common.Telemetry.Records;
 
-public class LinuxContainerDetectorUnsupportedOs : BaseDetectionTelemetryRecord
+internal class LinuxContainerDetectorUnsupportedOs : BaseDetectionTelemetryRecord
 {
     public override string RecordName => "LinuxContainerDetectorUnsupportedOs";
 

--- a/src/Microsoft.ComponentDetection.Common/Telemetry/Records/LinuxScannerSyftTelemetryRecord.cs
+++ b/src/Microsoft.ComponentDetection.Common/Telemetry/Records/LinuxScannerSyftTelemetryRecord.cs
@@ -1,6 +1,6 @@
 namespace Microsoft.ComponentDetection.Common.Telemetry.Records;
 
-public class LinuxScannerSyftTelemetryRecord : BaseDetectionTelemetryRecord
+internal class LinuxScannerSyftTelemetryRecord : BaseDetectionTelemetryRecord
 {
     public override string RecordName => "LinuxScannerSyftTelemetry";
 

--- a/src/Microsoft.ComponentDetection.Common/Telemetry/Records/LinuxScannerTelemetryRecord.cs
+++ b/src/Microsoft.ComponentDetection.Common/Telemetry/Records/LinuxScannerTelemetryRecord.cs
@@ -1,6 +1,6 @@
 namespace Microsoft.ComponentDetection.Common.Telemetry.Records;
 
-public class LinuxScannerTelemetryRecord : BaseDetectionTelemetryRecord
+internal class LinuxScannerTelemetryRecord : BaseDetectionTelemetryRecord
 {
     public override string RecordName => "LinuxScannerTelemetry";
 

--- a/src/Microsoft.ComponentDetection.Common/Telemetry/Records/LoadComponentDetectorsTelemetryRecord.cs
+++ b/src/Microsoft.ComponentDetection.Common/Telemetry/Records/LoadComponentDetectorsTelemetryRecord.cs
@@ -1,6 +1,6 @@
 namespace Microsoft.ComponentDetection.Common.Telemetry.Records;
 
-public class LoadComponentDetectorsTelemetryRecord : BaseDetectionTelemetryRecord
+internal class LoadComponentDetectorsTelemetryRecord : BaseDetectionTelemetryRecord
 {
     public override string RecordName => "LoadComponentDetectors";
 

--- a/src/Microsoft.ComponentDetection.Common/Telemetry/Records/NuGetProjectAssetsTelemetryRecord.cs
+++ b/src/Microsoft.ComponentDetection.Common/Telemetry/Records/NuGetProjectAssetsTelemetryRecord.cs
@@ -2,7 +2,7 @@ namespace Microsoft.ComponentDetection.Common.Telemetry.Records;
 
 using System;
 
-public class NuGetProjectAssetsTelemetryRecord : IDetectionTelemetryRecord, IDisposable
+internal class NuGetProjectAssetsTelemetryRecord : IDetectionTelemetryRecord, IDisposable
 {
     private bool disposedValue;
 

--- a/src/Microsoft.ComponentDetection.Common/Telemetry/Records/PipReportFailureTelemetryRecord.cs
+++ b/src/Microsoft.ComponentDetection.Common/Telemetry/Records/PipReportFailureTelemetryRecord.cs
@@ -1,6 +1,6 @@
 namespace Microsoft.ComponentDetection.Common.Telemetry.Records;
 
-public class PipReportFailureTelemetryRecord : BaseDetectionTelemetryRecord
+internal class PipReportFailureTelemetryRecord : BaseDetectionTelemetryRecord
 {
     public override string RecordName => "PipReportFailure";
 

--- a/src/Microsoft.ComponentDetection.Common/Telemetry/Records/PipReportSkipTelemetryRecord.cs
+++ b/src/Microsoft.ComponentDetection.Common/Telemetry/Records/PipReportSkipTelemetryRecord.cs
@@ -1,6 +1,6 @@
 namespace Microsoft.ComponentDetection.Common.Telemetry.Records;
 
-public class PipReportSkipTelemetryRecord : BaseDetectionTelemetryRecord
+internal class PipReportSkipTelemetryRecord : BaseDetectionTelemetryRecord
 {
     public override string RecordName => "PipReportSkip";
 

--- a/src/Microsoft.ComponentDetection.Common/Telemetry/Records/PipReportTypeTelemetryRecord.cs
+++ b/src/Microsoft.ComponentDetection.Common/Telemetry/Records/PipReportTypeTelemetryRecord.cs
@@ -1,6 +1,6 @@
 namespace Microsoft.ComponentDetection.Common.Telemetry.Records;
 
-public class PipReportTypeTelemetryRecord : BaseDetectionTelemetryRecord
+internal class PipReportTypeTelemetryRecord : BaseDetectionTelemetryRecord
 {
     public override string RecordName => "PipReportType";
 

--- a/src/Microsoft.ComponentDetection.Common/Telemetry/Records/PyPiCacheTelemetryRecord.cs
+++ b/src/Microsoft.ComponentDetection.Common/Telemetry/Records/PyPiCacheTelemetryRecord.cs
@@ -1,6 +1,6 @@
 namespace Microsoft.ComponentDetection.Common.Telemetry.Records;
 
-public class PypiCacheTelemetryRecord : BaseDetectionTelemetryRecord
+internal class PypiCacheTelemetryRecord : BaseDetectionTelemetryRecord
 {
     public override string RecordName => "PyPiCache";
 

--- a/src/Microsoft.ComponentDetection.Common/Telemetry/Records/PypiFailureTelemetryRecord.cs
+++ b/src/Microsoft.ComponentDetection.Common/Telemetry/Records/PypiFailureTelemetryRecord.cs
@@ -2,7 +2,7 @@ namespace Microsoft.ComponentDetection.Common.Telemetry.Records;
 
 using System.Net;
 
-public class PypiFailureTelemetryRecord : BaseDetectionTelemetryRecord
+internal class PypiFailureTelemetryRecord : BaseDetectionTelemetryRecord
 {
     public override string RecordName => "PypiFailure";
 

--- a/src/Microsoft.ComponentDetection.Common/Telemetry/Records/PypiMaxRetriesReachedTelemetryRecord.cs
+++ b/src/Microsoft.ComponentDetection.Common/Telemetry/Records/PypiMaxRetriesReachedTelemetryRecord.cs
@@ -1,6 +1,6 @@
 namespace Microsoft.ComponentDetection.Common.Telemetry.Records;
 
-public class PypiMaxRetriesReachedTelemetryRecord : BaseDetectionTelemetryRecord
+internal class PypiMaxRetriesReachedTelemetryRecord : BaseDetectionTelemetryRecord
 {
     public override string RecordName => "PypiMaxRetriesReached";
 

--- a/src/Microsoft.ComponentDetection.Common/Telemetry/Records/PypiRetryTelemetryRecord.cs
+++ b/src/Microsoft.ComponentDetection.Common/Telemetry/Records/PypiRetryTelemetryRecord.cs
@@ -2,7 +2,7 @@ namespace Microsoft.ComponentDetection.Common.Telemetry.Records;
 
 using System.Net;
 
-public class PypiRetryTelemetryRecord : BaseDetectionTelemetryRecord
+internal class PypiRetryTelemetryRecord : BaseDetectionTelemetryRecord
 {
     public override string RecordName => "PypiRetry";
 

--- a/src/Microsoft.ComponentDetection.Common/Telemetry/Records/RustCrateDetectorTelemetryRecord.cs
+++ b/src/Microsoft.ComponentDetection.Common/Telemetry/Records/RustCrateDetectorTelemetryRecord.cs
@@ -1,6 +1,6 @@
 namespace Microsoft.ComponentDetection.Common.Telemetry.Records;
 
-public class RustCrateDetectorTelemetryRecord : BaseDetectionTelemetryRecord
+internal class RustCrateDetectorTelemetryRecord : BaseDetectionTelemetryRecord
 {
     public override string RecordName => "RustCrateMalformedDependencies";
 

--- a/src/Microsoft.ComponentDetection.Common/Telemetry/Records/RustDetectionTelemetryRecord.cs
+++ b/src/Microsoft.ComponentDetection.Common/Telemetry/Records/RustDetectionTelemetryRecord.cs
@@ -1,6 +1,6 @@
 namespace Microsoft.ComponentDetection.Common.Telemetry.Records;
 
-public class RustDetectionTelemetryRecord : BaseDetectionTelemetryRecord
+internal class RustDetectionTelemetryRecord : BaseDetectionTelemetryRecord
 {
     public override string RecordName => "RustDetection";
 

--- a/src/Microsoft.ComponentDetection.Common/Telemetry/Records/RustGraphTelemetryRecord.cs
+++ b/src/Microsoft.ComponentDetection.Common/Telemetry/Records/RustGraphTelemetryRecord.cs
@@ -1,6 +1,6 @@
 namespace Microsoft.ComponentDetection.Common.Telemetry.Records;
 
-public class RustGraphTelemetryRecord : BaseDetectionTelemetryRecord
+internal class RustGraphTelemetryRecord : BaseDetectionTelemetryRecord
 {
     public override string RecordName => "RustGraph";
 

--- a/src/Microsoft.ComponentDetection.Common/Telemetry/Records/SimplePypiCacheTelemetryRecord.cs
+++ b/src/Microsoft.ComponentDetection.Common/Telemetry/Records/SimplePypiCacheTelemetryRecord.cs
@@ -1,6 +1,6 @@
 namespace Microsoft.ComponentDetection.Common.Telemetry.Records;
 
-public class SimplePypiCacheTelemetryRecord : BaseDetectionTelemetryRecord
+internal class SimplePypiCacheTelemetryRecord : BaseDetectionTelemetryRecord
 {
     public override string RecordName => "SimplePyPiCache";
 

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/PyPiClientTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/PyPiClientTests.cs
@@ -11,7 +11,6 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using AwesomeAssertions;
-using Microsoft.ComponentDetection.Common;
 using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Detectors.Pip;
 using Microsoft.Extensions.Logging;
@@ -25,7 +24,7 @@ public class PyPiClientTests
     private readonly PyPiClient pypiClient;
 
     public PyPiClientTests() => this.pypiClient = new PyPiClient(
-            new EnvironmentVariableService(),
+            new Mock<IEnvironmentVariableService>().Object,
             new Mock<ILogger<PyPiClient>>().Object);
 
     [TestMethod]

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/SimplePypiClientTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/SimplePypiClientTests.cs
@@ -9,7 +9,6 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using AwesomeAssertions;
-using Microsoft.ComponentDetection.Common;
 using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Detectors.Pip;
 using Microsoft.Extensions.Logging;
@@ -50,7 +49,7 @@ public class SimplePyPiClientTests
         var pythonProject = this.SampleValidApiJsonResponse("boto3", "0.0.1");
         var mockHandler = this.MockHttpMessageHandler(pythonProject, HttpStatusCode.OK);
 
-        var simplePypiClient = this.CreateSimplePypiClient(mockHandler.Object, new Mock<EnvironmentVariableService>().Object, new Mock<ILogger<SimplePyPiClient>>().Object);
+        var simplePypiClient = this.CreateSimplePypiClient(mockHandler.Object, new Mock<IEnvironmentVariableService>().Object, new Mock<ILogger<SimplePyPiClient>>().Object);
         var action = async () => await simplePypiClient.GetSimplePypiProjectAsync(pythonSpecs);
 
         await action.Should().NotThrowAsync();
@@ -74,7 +73,7 @@ public class SimplePyPiClientTests
         };
 
         var mockHandler = this.MockHttpMessageHandler(JsonSerializer.Serialize(pythonProject), HttpStatusCode.OK);
-        var simplePypiClient = this.CreateSimplePypiClient(mockHandler.Object, new Mock<EnvironmentVariableService>().Object, new Mock<ILogger<SimplePyPiClient>>().Object);
+        var simplePypiClient = this.CreateSimplePypiClient(mockHandler.Object, new Mock<IEnvironmentVariableService>().Object, new Mock<ILogger<SimplePyPiClient>>().Object);
 
         var action = async () =>
         {
@@ -108,7 +107,7 @@ public class SimplePyPiClientTests
         };
 
         var mockHandler = this.MockHttpMessageHandler(sampleApiResponse, HttpStatusCode.OK);
-        var simplePypiClient = this.CreateSimplePypiClient(mockHandler.Object, new Mock<EnvironmentVariableService>().Object, new Mock<ILogger<SimplePyPiClient>>().Object);
+        var simplePypiClient = this.CreateSimplePypiClient(mockHandler.Object, new Mock<IEnvironmentVariableService>().Object, new Mock<ILogger<SimplePyPiClient>>().Object);
 
         var actualResult = await simplePypiClient.GetSimplePypiProjectAsync(pythonSpecs);
         actualResult.Should().BeEquivalentTo(expectedResult);
@@ -120,7 +119,7 @@ public class SimplePyPiClientTests
         var pythonSpecs = new PipDependencySpecification { DependencySpecifiers = ["==1.0.0"], Name = "randomName" };
 
         var mockHandler = this.MockHttpMessageHandler("404 Not Found", HttpStatusCode.NotFound);
-        var simplePypiClient = this.CreateSimplePypiClient(mockHandler.Object, new Mock<EnvironmentVariableService>().Object, new Mock<ILogger<SimplePyPiClient>>().Object);
+        var simplePypiClient = this.CreateSimplePypiClient(mockHandler.Object, new Mock<IEnvironmentVariableService>().Object, new Mock<ILogger<SimplePyPiClient>>().Object);
 
         var action = async () => await simplePypiClient.GetSimplePypiProjectAsync(pythonSpecs);
 
@@ -134,7 +133,7 @@ public class SimplePyPiClientTests
 
         var content = "<!DOCTYPE html><body>\r\n\t<h1>Links for boto3</h1>\r\n\t<a\r\n\t\thref=\"some link\">boto3-0.0.1-py2.py3-none-any.whl</a><br /></html>";
         var mockHandler = this.MockHttpMessageHandler(content, HttpStatusCode.OK);
-        var simplePypiClient = this.CreateSimplePypiClient(mockHandler.Object, new Mock<EnvironmentVariableService>().Object, new Mock<ILogger<SimplePyPiClient>>().Object);
+        var simplePypiClient = this.CreateSimplePypiClient(mockHandler.Object, new Mock<IEnvironmentVariableService>().Object, new Mock<ILogger<SimplePyPiClient>>().Object);
 
         var action = async () => await simplePypiClient.GetSimplePypiProjectAsync(pythonSpecs);
 
@@ -147,7 +146,7 @@ public class SimplePyPiClientTests
         var pythonSpecs = new PipDependencySpecification { DependencySpecifiers = ["==1.0.0"] };
 
         var mockHandler = this.MockHttpMessageHandler(string.Empty, HttpStatusCode.InternalServerError);
-        var simplePypiClient = this.CreateSimplePypiClient(mockHandler.Object, new Mock<EnvironmentVariableService>().Object, new Mock<ILogger<SimplePyPiClient>>().Object);
+        var simplePypiClient = this.CreateSimplePypiClient(mockHandler.Object, new Mock<IEnvironmentVariableService>().Object, new Mock<ILogger<SimplePyPiClient>>().Object);
 
         var action = async () => await simplePypiClient.GetSimplePypiProjectAsync(pythonSpecs);
 
@@ -166,7 +165,7 @@ public class SimplePyPiClientTests
     {
         var pythonSpecs = new PipDependencySpecification { DependencySpecifiers = ["==1.0.0"] };
         var mockHandler = this.MockHttpMessageHandler("some content", HttpStatusCode.MultipleChoices);
-        var simplePypiClient = this.CreateSimplePypiClient(mockHandler.Object, new Mock<EnvironmentVariableService>().Object, new Mock<ILogger<SimplePyPiClient>>().Object);
+        var simplePypiClient = this.CreateSimplePypiClient(mockHandler.Object, new Mock<IEnvironmentVariableService>().Object, new Mock<ILogger<SimplePyPiClient>>().Object);
 
         var action = async () => await simplePypiClient.GetSimplePypiProjectAsync(pythonSpecs);
         await action.Should().NotThrowAsync();
@@ -186,7 +185,7 @@ public class SimplePyPiClientTests
         var pythonProject = this.SampleValidApiJsonResponse("boto3", "0.0.1");
 
         var mockHandler = this.MockHttpMessageHandler(pythonProject, HttpStatusCode.OK);
-        var simplePypiClient = this.CreateSimplePypiClient(mockHandler.Object, new Mock<EnvironmentVariableService>().Object, new Mock<ILogger<SimplePyPiClient>>().Object);
+        var simplePypiClient = this.CreateSimplePypiClient(mockHandler.Object, new Mock<IEnvironmentVariableService>().Object, new Mock<ILogger<SimplePyPiClient>>().Object);
 
         var action = async () => await simplePypiClient.GetSimplePypiProjectAsync(pythonSpecs);
 
@@ -265,7 +264,7 @@ public class SimplePyPiClientTests
     public async Task FetchPackageFileStream_DuplicateEntries_CallsGetAsync_OnceAsync()
     {
         var mockHandler = this.MockHttpMessageHandler(string.Empty, HttpStatusCode.OK);
-        var simplePypiClient = this.CreateSimplePypiClient(mockHandler.Object, new Mock<EnvironmentVariableService>().Object, new Mock<ILogger<SimplePyPiClient>>().Object);
+        var simplePypiClient = this.CreateSimplePypiClient(mockHandler.Object, new Mock<IEnvironmentVariableService>().Object, new Mock<ILogger<SimplePyPiClient>>().Object);
 
         var action = async () => await simplePypiClient.FetchPackageFileStreamAsync(new Uri($"https://testurl"));
 
@@ -284,7 +283,7 @@ public class SimplePyPiClientTests
     public async Task FetchPackageFileStream_DifferentEntries_CallsGetAsync_TwiceAsync()
     {
         var mockHandler = this.MockHttpMessageHandler(string.Empty, HttpStatusCode.OK);
-        var simplePypiClient = this.CreateSimplePypiClient(mockHandler.Object, new Mock<EnvironmentVariableService>().Object, new Mock<ILogger<SimplePyPiClient>>().Object);
+        var simplePypiClient = this.CreateSimplePypiClient(mockHandler.Object, new Mock<IEnvironmentVariableService>().Object, new Mock<ILogger<SimplePyPiClient>>().Object);
 
         var action = async () => await simplePypiClient.FetchPackageFileStreamAsync(new Uri($"https://{Guid.NewGuid()}"));
 
@@ -303,7 +302,7 @@ public class SimplePyPiClientTests
     public async Task FetchPackageFileStream_UnableToRetrievePackageAsync()
     {
         var mockHandler = this.MockHttpMessageHandler(string.Empty, HttpStatusCode.InternalServerError);
-        var simplePypiClient = this.CreateSimplePypiClient(mockHandler.Object, new Mock<EnvironmentVariableService>().Object, new Mock<ILogger<SimplePyPiClient>>().Object);
+        var simplePypiClient = this.CreateSimplePypiClient(mockHandler.Object, new Mock<IEnvironmentVariableService>().Object, new Mock<ILogger<SimplePyPiClient>>().Object);
 
         var action = async () => { return await simplePypiClient.FetchPackageFileStreamAsync(new Uri($"https://{Guid.NewGuid()}")); };
 


### PR DESCRIPTION
## Summary

Make ~50 classes `internal` in the Common project. These are implementation details not intended to be part of the public API surface.

### Categories of changes

**Telemetry records (~34 classes):**
- All concrete telemetry records (NuGetProjectAssetsTelemetryRecord, PyPiCacheTelemetryRecord, LinuxScannerTelemetryRecord, etc.)
- Kept `BaseDetectionTelemetryRecord` public — subclassed by component-detection-internal

**Utility classes:**
- Column, TabularStringFormat, ComponentComparer, DependencyScopeComparer, DirectoryItemFacade(Optimized)

**Docker reference exceptions (11 classes)**

**Concrete service implementations** (all registered via DI as interfaces):
- CommandLineInvocationService, EnvironmentVariableService, PathUtilityService, FileUtilityService, DirectoryUtilityService, DockerService, ConsoleWritingService, SafeFileEnumerableFactory, ComponentStreamEnumerableFactory, FastDirectoryWalkerFactory

### Kept public
- `FileWritingService` / `IFileWritingService` — used by sbom-tool
- `ComponentStream`, `LazyComponentStream` — used in detector base class signatures
- `ComponentRecorder` — used in Orchestrator public API
- `CommandLineInvocationResult` — returned by public interface
- `BaseDetectionTelemetryRecord` — subclassed externally
- All interfaces

### Stacked on #1694

Part of #455