### PR TITLE
refactor: make Orchestrator implementation details internal

### DIFF
--- a/src/Microsoft.ComponentDetection.Orchestrator/ArgumentHelper.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/ArgumentHelper.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using CommandLine;
 using Microsoft.ComponentDetection.Orchestrator.Commands;
 
-public class ArgumentHelper : IArgumentHelper
+internal class ArgumentHelper : IArgumentHelper
 {
     private readonly IEnumerable<ScanSettings> argumentSets;
 

--- a/src/Microsoft.ComponentDetection.Orchestrator/Extensions/CommaDelimitedConverter.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Extensions/CommaDelimitedConverter.cs
@@ -8,7 +8,7 @@ using System.Globalization;
 /// <summary>
 /// Converts a comma separated string to an array of strings.
 /// </summary>
-public class CommaDelimitedConverter : TypeConverter
+internal class CommaDelimitedConverter : TypeConverter
 {
     /// <inheritdoc />
     public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)

--- a/src/Microsoft.ComponentDetection.Orchestrator/Extensions/KeyValueDelimitedConverter.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Extensions/KeyValueDelimitedConverter.cs
@@ -9,7 +9,7 @@ using System.Globalization;
 /// <summary>
 /// Converts a comma separated string of key value pairs to a dictionary.
 /// </summary>
-public class KeyValueDelimitedConverter : TypeConverter
+internal class KeyValueDelimitedConverter : TypeConverter
 {
     /// <inheritdoc />
     public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)

--- a/src/Microsoft.ComponentDetection.Orchestrator/Extensions/SemicolonDelimitedConverter.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Extensions/SemicolonDelimitedConverter.cs
@@ -8,7 +8,7 @@ using System.Globalization;
 /// <summary>
 /// Converts a semicolon separated string to an array of strings.
 /// </summary>
-public class SemicolonDelimitedConverter : TypeConverter
+internal class SemicolonDelimitedConverter : TypeConverter
 {
     /// <inheritdoc />
     public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)

--- a/src/Microsoft.ComponentDetection.Orchestrator/IArgumentHelper.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/IArgumentHelper.cs
@@ -2,7 +2,7 @@ namespace Microsoft.ComponentDetection.Orchestrator;
 
 using CommandLine;
 
-public interface IArgumentHelper
+internal interface IArgumentHelper
 {
     ParserResult<object> ParseArguments(string[] args);
 

--- a/src/Microsoft.ComponentDetection.Orchestrator/Microsoft.ComponentDetection.Orchestrator.csproj
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Microsoft.ComponentDetection.Orchestrator.csproj
@@ -4,6 +4,7 @@
         <InternalsVisibleTo Include="Microsoft.ComponentDetection.Orchestrator.Tests" />
         <InternalsVisibleTo Include="Microsoft.ComponentDetection" />
         <InternalsVisibleTo Include="Microsoft.ComponentDetection.TestsUtilities" />
+        <InternalsVisibleTo Include="DynamicProxyGenAssembly2" PublicKey="0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/DetectorProcessingService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/DetectorProcessingService.cs
@@ -22,7 +22,7 @@ using Microsoft.Extensions.Logging;
 using Spectre.Console;
 using static System.Environment;
 
-public class DetectorProcessingService : IDetectorProcessingService
+internal class DetectorProcessingService : IDetectorProcessingService
 {
     private const int DefaultMaxDetectionThreads = 5;
     private const int ExperimentalTimeoutSeconds = 240; // 4 minutes

--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/DetectorRestrictionService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/DetectorRestrictionService.cs
@@ -7,7 +7,7 @@ using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Orchestrator.Exceptions;
 using Microsoft.Extensions.Logging;
 
-public class DetectorRestrictionService : IDetectorRestrictionService
+internal class DetectorRestrictionService : IDetectorRestrictionService
 {
     private readonly IList<string> oldDetectorIds = ["MSLicenseDevNpm", "MSLicenseDevNpmList", "MSLicenseNpm", "MSLicenseNpmList"];
     private readonly string newDetectorId = "NpmWithRoots";

--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/GraphTranslation/DefaultGraphTranslationService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/GraphTranslation/DefaultGraphTranslationService.cs
@@ -15,7 +15,7 @@ using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.ComponentDetection.Orchestrator.Commands;
 using Microsoft.Extensions.Logging;
 
-public class DefaultGraphTranslationService : IGraphTranslationService
+internal class DefaultGraphTranslationService : IGraphTranslationService
 {
     private readonly ILogger<DefaultGraphTranslationService> logger;
 


### PR DESCRIPTION
## Summary

Make 8 classes `internal` in the Orchestrator project.

### Changes

**Converters:**
- CommaDelimitedConverter, KeyValueDelimitedConverter, SemicolonDelimitedConverter

**CLI helpers:**
- ArgumentHelper, IArgumentHelper

**Concrete service implementations** (interfaces remain public):
- DetectorProcessingService → `IDetectorProcessingService`
- DetectorRestrictionService → `IDetectorRestrictionService`
- DefaultGraphTranslationService → `IGraphTranslationService`

### Kept public
- `ServiceCollectionExtensions.AddComponentDetection()` — primary DI entry point
- `ScanExecutionService` / `IScanExecutionService` — sbom-tool instantiates directly
- `ScanCommand` — sbom-tool instantiates directly
- `ScanSettings`, `BaseSettings`, `LoggingEnricher`, `DetectorRestrictions`
- All experiment types (used by component-detection-internal)
- All service interfaces
- `DetectorRunResult`, `DetectorProcessingResult` — exposed in public interface signatures

### Stacked on #1695

Part of #455