### PR TITLE
Run snapshot publish on a schedule

### DIFF
--- a/.github/workflows/snapshot-publish.yml
+++ b/.github/workflows/snapshot-publish.yml
@@ -10,9 +10,13 @@ on:
     branches:
       - main
   schedule:
+    # GitHub cron schedules run in UTC; this runs at 06:00 UTC, Monday–Friday.
     - cron: '0 6 * * 1-5'
   workflow_dispatch:
 
+concurrency:
+  group: snapshot-publish
+  cancel-in-progress: true
 permissions:
   contents: read
 


### PR DESCRIPTION
Verification tests are oftentimes flaky, because new dependency versions are published between snapshots are generated. Running the snapshot generation on a recurring schedule should minimize the chance of this happening.