### PR TITLE
Fix SwiftComponent.PackageUrl JSON property name collision on .NET 10

### DIFF
--- a/src/Microsoft.ComponentDetection.Contracts/TypedComponent/SwiftComponent.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/TypedComponent/SwiftComponent.cs
@@ -45,7 +45,7 @@ public class SwiftComponent : TypedComponent
     // namespace: github.com/apple
     // name: swift-asn1
     [JsonPropertyName("packageUrl")]
-    public PackageURL PackageURL => new PackageURL(
+    public override PackageURL PackageUrl => new PackageURL(
         type: "swift",
         @namespace: this.GetNamespaceFromPackageUrl(),
         name: this.Name,

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/SwiftComponentTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/SwiftComponentTests.cs
@@ -30,35 +30,65 @@ public class SwiftComponentTests
     [TestMethod]
     public void Constructor_ShouldThrowException_WhenNameIsNull()
     {
-        Action action = () => new SwiftComponent(null, "5.9.1", "https://github.com/Alamofire/Alamofire", "f455c2975872ccd2d9c81594c658af65716e9b9a");
+        Action action = () =>
+            new SwiftComponent(
+                null,
+                "5.9.1",
+                "https://github.com/Alamofire/Alamofire",
+                "f455c2975872ccd2d9c81594c658af65716e9b9a"
+            );
         action.Should().Throw<ArgumentException>().WithMessage("*name*");
     }
 
     [TestMethod]
     public void Constructor_ShouldThrowException_WhenVersionIsNull()
     {
-        Action action = () => new SwiftComponent("alamofire", null, "https://github.com/Alamofire/Alamofire", "f455c2975872ccd2d9c81594c658af65716e9b9a");
+        Action action = () =>
+            new SwiftComponent(
+                "alamofire",
+                null,
+                "https://github.com/Alamofire/Alamofire",
+                "f455c2975872ccd2d9c81594c658af65716e9b9a"
+            );
         action.Should().Throw<ArgumentException>().WithMessage("*version*");
     }
 
     [TestMethod]
     public void Constructor_ShouldThrowException_WhenPackageUrlIsNull()
     {
-        Action action = () => new SwiftComponent("alamofire", "5.9.1", null, "f455c2975872ccd2d9c81594c658af65716e9b9a");
+        Action action = () =>
+            new SwiftComponent(
+                "alamofire",
+                "5.9.1",
+                null,
+                "f455c2975872ccd2d9c81594c658af65716e9b9a"
+            );
         action.Should().Throw<ArgumentException>().WithMessage("*packageUrl*");
     }
 
     [TestMethod]
     public void Constructor_ShouldThrowException_WhenHashIsNull()
     {
-        Action action = () => new SwiftComponent("alamofire", "5.9.1", "https://github.com/Alamofire/Alamofire", null);
+        Action action = () =>
+            new SwiftComponent(
+                "alamofire",
+                "5.9.1",
+                "https://github.com/Alamofire/Alamofire",
+                null
+            );
         action.Should().Throw<ArgumentException>().WithMessage("*hash*");
     }
 
     [TestMethod]
     public void Constructor_ShouldThrowException_WhenPackageUrlIsInvalid()
     {
-        Action action = () => new SwiftComponent("alamofire", "5.9.1", "invalid-url", "f455c2975872ccd2d9c81594c658af65716e9b9a");
+        Action action = () =>
+            new SwiftComponent(
+                "alamofire",
+                "5.9.1",
+                "invalid-url",
+                "f455c2975872ccd2d9c81594c658af65716e9b9a"
+            );
         action.Should().Throw<UriFormatException>();
     }
 
@@ -77,13 +107,11 @@ public class SwiftComponentTests
             @namespace: "github.com/Alamofire",
             name: name,
             version: version,
-            qualifiers: new SortedDictionary<string, string>
-            {
-                { "repository_url", packageUrl },
-            },
-            subpath: null);
+            qualifiers: new SortedDictionary<string, string> { { "repository_url", packageUrl } },
+            subpath: null
+        );
 
-        component.PackageURL.Should().BeEquivalentTo(expectedPackageURL);
+        component.PackageUrl.Should().BeEquivalentTo(expectedPackageURL);
     }
 
     [TestMethod]
@@ -105,9 +133,10 @@ public class SwiftComponentTests
             {
                 { "repository_url", "https://github.com/Alamofire/Alamofire" },
             },
-            subpath: null);
+            subpath: null
+        );
 
-        component.PackageURL.Should().BeEquivalentTo(expectedPackageURL);
+        component.PackageUrl.Should().BeEquivalentTo(expectedPackageURL);
     }
 
     [TestMethod]
@@ -125,12 +154,10 @@ public class SwiftComponentTests
             @namespace: "otherhostname.com",
             name: name,
             version: version,
-            qualifiers: new SortedDictionary<string, string>
-            {
-                { "repository_url", packageUrl },
-            },
-            subpath: null);
+            qualifiers: new SortedDictionary<string, string> { { "repository_url", packageUrl } },
+            subpath: null
+        );
 
-        component.PackageURL.Should().BeEquivalentTo(expectedPackageURL);
+        component.PackageUrl.Should().BeEquivalentTo(expectedPackageURL);
     }
 }


### PR DESCRIPTION
`SwiftComponent` declared its own `PackageUrl` property (originally cased as `PackageURL`) without the `override` keyword. Both the base `TypedComponent.PackageUrl` and the derived property carried `[JsonPropertyName("packageUrl")]`, so .NET 10's `System.Text.Json` threw `InvalidOperationException` at serialization time due to the name collision.

Added `override` so the property replaces the base instead of hiding it, matching the pattern every other component already uses.

Fixes #1619