### PR TITLE
Revert some internal changes

### DIFF
--- a/src/Microsoft.ComponentDetection.Common/Column.cs
+++ b/src/Microsoft.ComponentDetection.Common/Column.cs
@@ -1,7 +1,7 @@
 #nullable disable
 namespace Microsoft.ComponentDetection.Common;
 
-internal class Column
+public class Column
 {
     public int Width { get; set; }
 

--- a/src/Microsoft.ComponentDetection.Common/TabularStringFormat.cs
+++ b/src/Microsoft.ComponentDetection.Common/TabularStringFormat.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
-internal class TabularStringFormat
+public class TabularStringFormat
 {
     public const char DefaultVerticalLineChar = '|';
     public const char DefaultHorizontalLineChar = '_';

--- a/src/Microsoft.ComponentDetection.Detectors/pip/Contracts/PythonVersion.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pip/Contracts/PythonVersion.cs
@@ -8,7 +8,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text.RegularExpressions;
 
-internal class PythonVersion : IComparable<PythonVersion>
+public class PythonVersion : IComparable<PythonVersion>
 {
     // This is a light C# port of the python version capture regex described here:
     // https://www.python.org/dev/peps/pep-0440/#appendix-b-parsing-version-strings-with-regular-expressions

--- a/src/Microsoft.ComponentDetection.Orchestrator/Extensions/SemicolonDelimitedConverter.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Extensions/SemicolonDelimitedConverter.cs
@@ -8,7 +8,7 @@ using System.Globalization;
 /// <summary>
 /// Converts a semicolon separated string to an array of strings.
 /// </summary>
-internal class SemicolonDelimitedConverter : TypeConverter
+public class SemicolonDelimitedConverter : TypeConverter
 {
     /// <inheritdoc />
     public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)


### PR DESCRIPTION
These 4 classes were being used by downstream consumers. This reverts them back to `public`