### PR TITLE
Bump packageurl-dotnet from 2.0.0-rc.2 to 2.0.0-rc.3

### DIFF
--- a/src/Microsoft.ComponentDetection.Contracts/TypedComponent/LinuxComponent.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/TypedComponent/LinuxComponent.cs
@@ -2,6 +2,7 @@
 namespace Microsoft.ComponentDetection.Contracts.TypedComponent;
 
 using System;
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using PackageUrl;
 
@@ -60,10 +61,20 @@ public class LinuxComponent : TypedComponent
             {
                 packageType = "rpm";
             }
+            else if (this.IsAlpine())
+            {
+                packageType = "apk";
+            }
 
             if (packageType != null)
             {
-                return new PackageUrl(packageType, this.Distribution, this.Name, this.Version, null, null);
+                var distroId = this.GetDistroId();
+                var qualifiers = new SortedDictionary<string, string>
+                {
+                    { "distro", $"{distroId}-{this.Release}" },
+                };
+
+                return new PackageUrl(packageType, distroId, this.Name, this.Version, qualifiers, null);
             }
 
             return null;
@@ -95,5 +106,20 @@ public class LinuxComponent : TypedComponent
     private bool IsRHEL()
     {
         return this.Distribution.Equals("RED HAT ENTERPRISE LINUX", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private bool IsAlpine()
+    {
+        return this.Distribution.Equals("ALPINE", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private string GetDistroId()
+    {
+        if (this.IsRHEL())
+        {
+            return "redhat";
+        }
+
+        return this.Distribution.ToLowerInvariant();
     }
 }

--- a/test/Microsoft.ComponentDetection.Contracts.Tests/PurlGenerationTests.cs
+++ b/test/Microsoft.ComponentDetection.Contracts.Tests/PurlGenerationTests.cs
@@ -47,6 +47,9 @@ public class PurlGenerationTests
 
         ubuntuComponent.PackageUrl.Type.Should().Be("deb");
         debianComponent.PackageUrl.Type.Should().Be("deb");
+
+        ubuntuComponent.PackageUrl.Qualifiers["distro"].Should().Be("ubuntu-18.04");
+        debianComponent.PackageUrl.Qualifiers["distro"].Should().Be("debian-buster");
     }
 
     [TestMethod]
@@ -61,17 +64,29 @@ public class PurlGenerationTests
         centosComponent.PackageUrl.Type.Should().Be("rpm");
         fedoraComponent.PackageUrl.Type.Should().Be("rpm");
         rhelComponent.PackageUrl.Type.Should().Be("rpm");
+
+        centosComponent.PackageUrl.Qualifiers["distro"].Should().Be("centos-18.04");
+        fedoraComponent.PackageUrl.Qualifiers["distro"].Should().Be("fedora-18.04");
+        rhelComponent.PackageUrl.Qualifiers["distro"].Should().Be("redhat-18.04");
     }
 
     [TestMethod]
-    public void AlpineAndUnknownDoNotHavePurls()
+    public void AlpineIsApkType()
     {
-        // Alpine is not yet defined
-        // https://github.com/package-url/purl-spec/blame/180c46d266c45aa2bd81a2038af3f78e87bb4a25/README.rst#L711
+        // Alpine uses "apk" purl type
+        // https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst#apk
         var alpineComponent = new LinuxComponent("Alpine", "3.13", "bash", "1");
+
+        alpineComponent.PackageUrl.Type.Should().Be("apk");
+        alpineComponent.PackageUrl.Namespace.Should().Be("alpine");
+        alpineComponent.PackageUrl.Qualifiers["distro"].Should().Be("alpine-3.13");
+    }
+
+    [TestMethod]
+    public void UnknownDistroDoesNotHavePurl()
+    {
         var unknownLinuxComponent = new LinuxComponent("Linux", "0", "bash", "1'");
 
-        alpineComponent.PackageUrl.Should().BeNull();
         unknownLinuxComponent.PackageUrl.Should().BeNull();
     }
 
@@ -86,6 +101,16 @@ public class PurlGenerationTests
 
         ubuntuComponent.PackageUrl.Namespace.Should().Be("ubuntu");
         fedoraComponent.PackageUrl.Namespace.Should().Be("fedora");
+    }
+
+    [TestMethod]
+    public void RhelNamespaceIsRedhat()
+    {
+        // RHEL should use "redhat" as the namespace and distro id, matching Syft conventions
+        var rhelComponent = new LinuxComponent("Red Hat Enterprise Linux", "9.0", "bash", "1");
+
+        rhelComponent.PackageUrl.Namespace.Should().Be("redhat");
+        rhelComponent.PackageUrl.Qualifiers["distro"].Should().Be("redhat-9.0");
     }
 
     [TestMethod]


### PR DESCRIPTION
LinuxComponent purls now include a `distro` qualifier with the release version, and Alpine packages get `apk` purls instead of null.
 
## Why
 
The purl for `pkg:deb/ubuntu/bash@1` was the same whether the package came from Ubuntu 18.04 or 20.04. `ComputeBaseId()` already distinguished them, but the purl didn't, so anything downstream that relied on the purl for deduplication or resolution would over-match across distro versions.
 
The purl spec includes a `distro` qualifier for exactly this reason, and Syft already emits it (e.g., `distro=ubuntu-20.04`). We just weren't passing it through.
 
While I was in here, I also noticed Alpine was returning null even though `apk` has been a registered purl type for a while now.
 
## Changes
 
- Emit `distro=<id>-<release>` qualifier on all Linux purls
- Map "Red Hat Enterprise Linux" to `redhat` for namespace and qualifier (matches Syft)
- Add `apk` type for Alpine
- Split the old `AlpineAndUnknownDoNotHavePurls` test since Alpine does have purls now
- Added `RhelNamespaceIsRedhat` test
 
Example before: `pkg:deb/ubuntu/bash@1`
Example after: `pkg:deb/ubuntu/bash@1?distro=ubuntu-18.04`
 
Fixes #1714

