### PR TITLE
Simplify PatternMatchingUtility by removing expression trees

### DIFF
--- a/src/Microsoft.ComponentDetection.Common/PatternMatchingUtility.cs
+++ b/src/Microsoft.ComponentDetection.Common/PatternMatchingUtility.cs
@@ -1,11 +1,8 @@
-#nullable disable
 namespace Microsoft.ComponentDetection.Common;
 
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
-using System.Reflection;
 
 public static class PatternMatchingUtility
 {
@@ -13,44 +10,30 @@ public static class PatternMatchingUtility
 
     public static FilePatternMatcher GetFilePatternMatcher(IEnumerable<string> patterns)
     {
-        var ordinalComparison = Expression.Constant(StringComparison.Ordinal, typeof(StringComparison));
-        var asSpan = typeof(MemoryExtensions).GetMethod("AsSpan", BindingFlags.Public | BindingFlags.Static, null, CallingConventions.Standard, [typeof(string)], []);
-        var equals = typeof(MemoryExtensions).GetMethod("Equals", BindingFlags.Public | BindingFlags.Static, null, CallingConventions.Standard, [typeof(ReadOnlySpan<char>), typeof(ReadOnlySpan<char>), typeof(StringComparison)], []);
-        var startsWith = typeof(MemoryExtensions).GetMethod("StartsWith", BindingFlags.Public | BindingFlags.Static, null, CallingConventions.Standard, [typeof(ReadOnlySpan<char>), typeof(ReadOnlySpan<char>), typeof(StringComparison)], []);
-        var endsWith = typeof(MemoryExtensions).GetMethod("EndsWith", BindingFlags.Public | BindingFlags.Static, null, CallingConventions.Standard, [typeof(ReadOnlySpan<char>), typeof(ReadOnlySpan<char>), typeof(StringComparison)], []);
-
-        var predicates = new List<Expression>();
-        var left = Expression.Parameter(typeof(ReadOnlySpan<char>), "fileName");
-
-        foreach (var pattern in patterns)
+        var matchers = patterns.Select<string, FilePatternMatcher>(pattern => pattern switch
         {
-            if (pattern.StartsWith('*'))
-            {
-                var match = Expression.Constant(pattern[1..], typeof(string));
-                var right = Expression.Call(null, asSpan, match);
-                var combine = Expression.Call(null, endsWith, left, right, ordinalComparison);
-                predicates.Add(combine);
-            }
-            else if (pattern.EndsWith('*'))
-            {
-                var match = Expression.Constant(pattern[..^1], typeof(string));
-                var right = Expression.Call(null, asSpan, match);
-                var combine = Expression.Call(null, startsWith, left, right, ordinalComparison);
-                predicates.Add(combine);
-            }
-            else
-            {
-                var match = Expression.Constant(pattern, typeof(string));
-                var right = Expression.Call(null, asSpan, match);
-                var combine = Expression.Call(null, equals, left, right, ordinalComparison);
-                predicates.Add(combine);
-            }
-        }
+            _ when pattern.StartsWith('*') && pattern.EndsWith('*') =>
+                pattern.Length <= 2
+                    ? _ => true
+                    : span => span.Contains(pattern.AsSpan(1, pattern.Length - 2), StringComparison.Ordinal),
+            _ when pattern.StartsWith('*') =>
+                span => span.EndsWith(pattern.AsSpan(1), StringComparison.Ordinal),
+            _ when pattern.EndsWith('*') =>
+                span => span.StartsWith(pattern.AsSpan(0, pattern.Length - 1), StringComparison.Ordinal),
+            _ => span => span.Equals(pattern.AsSpan(), StringComparison.Ordinal),
+        }).ToList();
 
-        var aggregateExpression = predicates.Aggregate(Expression.OrElse);
+        return span =>
+        {
+            foreach (var matcher in matchers)
+            {
+                if (matcher(span))
+                {
+                    return true;
+                }
+            }
 
-        var func = Expression.Lambda<FilePatternMatcher>(aggregateExpression, left).Compile();
-
-        return func;
+            return false;
+        };
     }
 }

--- a/test/Microsoft.ComponentDetection.Common.Tests/PatternMatchingUtilityTests.cs
+++ b/test/Microsoft.ComponentDetection.Common.Tests/PatternMatchingUtilityTests.cs
@@ -10,38 +10,25 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 public class PatternMatchingUtilityTests
 {
     [TestMethod]
-    public void PatternMatcher_Matches_StartsWith()
+    [DataRow("test*", "test123", true)]
+    [DataRow("test*", "123test", false)]
+    [DataRow("*test", "123test", true)]
+    [DataRow("*test", "test123", false)]
+    [DataRow("test", "test", true)]
+    [DataRow("test", "123test", false)]
+    [DataRow("*test*", "123test456", true)]
+    [DataRow("*test*", "test456", true)]
+    [DataRow("*test*", "123test", true)]
+    [DataRow("*test*", "test", true)]
+    [DataRow("*test*", "tes", false)]
+    [DataRow("*", "anything", true)]
+    [DataRow("*", "", true)]
+    [DataRow("**", "anything", true)]
+    [DataRow("**", "", true)]
+    public void PatternMatcher_MatchesExpected(string pattern, string input, bool expected)
     {
-        var pattern = "test*";
-        var input = "test123";
-
         var matcher = PatternMatchingUtility.GetFilePatternMatcher([pattern]);
 
-        matcher(input).Should().BeTrue();
-        matcher("123test").Should().BeFalse();
-    }
-
-    [TestMethod]
-    public void PatternMatcher_Matches_EndsWith()
-    {
-        var pattern = "*test";
-        var input = "123test";
-
-        var matcher = PatternMatchingUtility.GetFilePatternMatcher([pattern]);
-
-        matcher(input).Should().BeTrue();
-        matcher("test123").Should().BeFalse();
-    }
-
-    [TestMethod]
-    public void PatternMatcher_Matches_Exact()
-    {
-        var pattern = "test";
-        var input = "test";
-
-        var matcher = PatternMatchingUtility.GetFilePatternMatcher([pattern]);
-
-        matcher(input).Should().BeTrue();
-        matcher("123test").Should().BeFalse();
+        matcher(input).Should().Be(expected);
     }
 }

--- a/test/Microsoft.ComponentDetection.Common.Tests/PatternMatchingUtilityTests.cs
+++ b/test/Microsoft.ComponentDetection.Common.Tests/PatternMatchingUtilityTests.cs
@@ -41,4 +41,12 @@ public class PatternMatchingUtilityTests
         matcher("crab").Should().BeTrue();
         matcher("middle").Should().BeFalse();
     }
+
+    [TestMethod]
+    public void PatternMatcher_EmptyPatterns_DoesNotThrow()
+    {
+        var matcher = PatternMatchingUtility.GetFilePatternMatcher([]);
+
+        matcher("anything").Should().BeFalse();
+    }
 }

--- a/test/Microsoft.ComponentDetection.Common.Tests/PatternMatchingUtilityTests.cs
+++ b/test/Microsoft.ComponentDetection.Common.Tests/PatternMatchingUtilityTests.cs
@@ -31,4 +31,14 @@ public class PatternMatchingUtilityTests
 
         matcher(input).Should().Be(expected);
     }
+
+    [TestMethod]
+    public void PatternMatcher_MultiplePatterns_MatchesAny()
+    {
+        var matcher = PatternMatchingUtility.GetFilePatternMatcher(["a*", "*b"]);
+
+        matcher("apple").Should().BeTrue();
+        matcher("crab").Should().BeTrue();
+        matcher("middle").Should().BeFalse();
+    }
 }


### PR DESCRIPTION
Replaces the expression tree and reflection-based implementation in `PatternMatchingUtility` with plain closures.

The old code used `Expression.Lambda`, `Expression.Call`, and four reflection `GetMethod` lookups to build a compiled delegate at runtime. This was unnecessary given the small, static pattern lists from detector `SearchPatterns` (typically 1-3 entries). The reflection calls had no null checks and would throw cryptic errors if the API surface changed. Calling `Aggregate` on an empty pattern list would throw `InvalidOperationException`.

The new version calls the same `ReadOnlySpan<char>` extension methods directly from closures. It also handles `*foo*` (contains) patterns, which the old code silently treated as exact matches.