### PR TITLE
Address follow-up review feedback for matcher reuse and null-pattern validation

### DIFF
--- a/src/Microsoft.ComponentDetection.Common/FastDirectoryWalkerFactory.cs
+++ b/src/Microsoft.ComponentDetection.Common/FastDirectoryWalkerFactory.cs
@@ -39,15 +39,11 @@ internal class FastDirectoryWalkerFactory : IObservableDirectoryWalkerFactory
                 return Task.CompletedTask;
             }
 
-            PatternMatchingUtility.FilePatternMatcher fileIsMatch = null;
+            PatternMatchingUtility.CompiledMatcher fileIsMatch = null;
 
-            if (filePatterns == null || !filePatterns.Any())
+            if (filePatterns != null && filePatterns.Any())
             {
-                fileIsMatch = span => true;
-            }
-            else
-            {
-                fileIsMatch = PatternMatchingUtility.GetFilePatternMatcher(filePatterns);
+                fileIsMatch = PatternMatchingUtility.Compile(filePatterns);
             }
 
             var sw = Stopwatch.StartNew();
@@ -100,7 +96,7 @@ internal class FastDirectoryWalkerFactory : IObservableDirectoryWalkerFactory
             {
                 ShouldIncludePredicate = (ref FileSystemEntry entry) =>
                 {
-                    if (!entry.IsDirectory && fileIsMatch(entry.FileName))
+                    if (!entry.IsDirectory && (fileIsMatch == null || fileIsMatch.IsMatch(entry.FileName)))
                     {
                         return true;
                     }
@@ -210,22 +206,20 @@ internal class FastDirectoryWalkerFactory : IObservableDirectoryWalkerFactory
 
     public IObservable<FileSystemInfo> Subscribe(DirectoryInfo root, IEnumerable<string> patterns)
     {
-        var patternArray = patterns.ToArray();
-
         if (this.pendingScans.TryGetValue(root, out var scannerObservable))
         {
             this.logger.LogDebug("Logging patterns {Patterns} for {Root}", string.Join(":", patterns), root.FullName);
+
+            var compiled = PatternMatchingUtility.Compile(patterns);
 
             var inner = scannerObservable.Value.Where(fsi =>
             {
                 if (fsi is FileInfo fi)
                 {
-                    return this.MatchesAnyPattern(fi, patternArray);
+                    return compiled.IsMatch(fi.Name.AsSpan());
                 }
-                else
-                {
-                    return true;
-                }
+
+                return true;
             });
 
             return inner;
@@ -236,20 +230,18 @@ internal class FastDirectoryWalkerFactory : IObservableDirectoryWalkerFactory
 
     public IObservable<ProcessRequest> GetFilteredComponentStreamObservable(DirectoryInfo root, IEnumerable<string> patterns, IComponentRecorder componentRecorder)
     {
-        var observable = this.Subscribe(root, patterns).OfType<FileInfo>().SelectMany(f => patterns.Select(sp => new
-        {
-            SearchPattern = sp,
-            File = f,
-        })).Where(x =>
-            {
-                var searchPattern = x.SearchPattern;
-                var fileName = x.File.Name;
+        var compiled = PatternMatchingUtility.Compile(patterns);
 
-                return this.pathUtilityService.MatchesPattern(searchPattern, fileName);
-            }).Where(x => x.File.Exists)
+        var observable = this.Subscribe(root, patterns).OfType<FileInfo>()
+            .Select(f => new
+            {
+                File = f,
+                MatchedPattern = compiled.GetMatchingPattern(f.Name),
+            })
+            .Where(x => x.MatchedPattern != null && x.File.Exists)
             .Select(x =>
             {
-                var lazyComponentStream = new LazyComponentStream(x.File, x.SearchPattern, this.logger);
+                var lazyComponentStream = new LazyComponentStream(x.File, x.MatchedPattern, this.logger);
                 return new ProcessRequest
                 {
                     ComponentStream = lazyComponentStream,
@@ -284,10 +276,5 @@ internal class FastDirectoryWalkerFactory : IObservableDirectoryWalkerFactory
     {
         return this.GetDirectoryScanner(di, new ConcurrentDictionary<string, bool>(), directoryExclusionPredicate, filePatterns, true).Replay() // Returns a replay subject which will republish anything found to new subscribers.
             .AutoConnect(minimumConnectionCount); // Specifies that this connectable observable should start when minimumConnectionCount subscribe.
-    }
-
-    private bool MatchesAnyPattern(FileInfo fi, params string[] searchPatterns)
-    {
-        return searchPatterns != null && searchPatterns.Any(sp => this.pathUtilityService.MatchesPattern(sp, fi.Name));
     }
 }

--- a/src/Microsoft.ComponentDetection.Common/FastDirectoryWalkerFactory.cs
+++ b/src/Microsoft.ComponentDetection.Common/FastDirectoryWalkerFactory.cs
@@ -207,28 +207,9 @@ internal class FastDirectoryWalkerFactory : IObservableDirectoryWalkerFactory
 
     public IObservable<FileSystemInfo> Subscribe(DirectoryInfo root, IEnumerable<string> patterns)
     {
-        if (this.pendingScans.TryGetValue(root, out var scannerObservable))
-        {
-            var patternsArray = patterns as string[] ?? patterns.ToArray();
-
-            this.logger.LogDebug("Logging patterns {Patterns} for {Root}", string.Join(":", patternsArray), root.FullName);
-
-            var compiled = PatternMatchingUtility.Compile(patternsArray);
-
-            var inner = scannerObservable.Value.Where(fsi =>
-            {
-                if (fsi is FileInfo fi)
-                {
-                    return compiled.IsMatch(fi.Name.AsSpan());
-                }
-
-                return true;
-            });
-
-            return inner;
-        }
-
-        throw new InvalidOperationException("Subscribe called without initializing scanner");
+        var patternsArray = patterns as string[] ?? patterns.ToArray();
+        var compiled = PatternMatchingUtility.Compile(patternsArray);
+        return this.Subscribe(root, patternsArray, compiled);
     }
 
     public IObservable<ProcessRequest> GetFilteredComponentStreamObservable(DirectoryInfo root, IEnumerable<string> patterns, IComponentRecorder componentRecorder)
@@ -236,7 +217,7 @@ internal class FastDirectoryWalkerFactory : IObservableDirectoryWalkerFactory
         var patternsArray = patterns as string[] ?? patterns.ToArray();
         var compiled = PatternMatchingUtility.Compile(patternsArray);
 
-        var observable = this.Subscribe(root, patternsArray).OfType<FileInfo>()
+        var observable = this.Subscribe(root, patternsArray, compiled).OfType<FileInfo>()
             .Select(f => new
             {
                 File = f,
@@ -274,6 +255,28 @@ internal class FastDirectoryWalkerFactory : IObservableDirectoryWalkerFactory
     private FileSystemInfo Transform(ref FileSystemEntry entry)
     {
         return entry.ToFileSystemInfo();
+    }
+
+    private IObservable<FileSystemInfo> Subscribe(DirectoryInfo root, string[] patterns, PatternMatchingUtility.CompiledMatcher compiled)
+    {
+        if (this.pendingScans.TryGetValue(root, out var scannerObservable))
+        {
+            this.logger.LogDebug("Logging patterns {Patterns} for {Root}", string.Join(":", patterns), root.FullName);
+
+            var inner = scannerObservable.Value.Where(fsi =>
+            {
+                if (fsi is FileInfo fi)
+                {
+                    return compiled.IsMatch(fi.Name.AsSpan());
+                }
+
+                return true;
+            });
+
+            return inner;
+        }
+
+        throw new InvalidOperationException("Subscribe called without initializing scanner");
     }
 
     private IObservable<FileSystemInfo> CreateDirectoryWalker(DirectoryInfo di, ExcludeDirectoryPredicate directoryExclusionPredicate, int minimumConnectionCount, IEnumerable<string> filePatterns)

--- a/src/Microsoft.ComponentDetection.Common/FastDirectoryWalkerFactory.cs
+++ b/src/Microsoft.ComponentDetection.Common/FastDirectoryWalkerFactory.cs
@@ -40,10 +40,11 @@ internal class FastDirectoryWalkerFactory : IObservableDirectoryWalkerFactory
             }
 
             PatternMatchingUtility.CompiledMatcher fileIsMatch = null;
+            var patternsArray = filePatterns?.ToArray();
 
-            if (filePatterns != null && filePatterns.Any())
+            if (patternsArray is { Length: > 0 })
             {
-                fileIsMatch = PatternMatchingUtility.Compile(filePatterns);
+                fileIsMatch = PatternMatchingUtility.Compile(patternsArray);
             }
 
             var sw = Stopwatch.StartNew();
@@ -208,9 +209,11 @@ internal class FastDirectoryWalkerFactory : IObservableDirectoryWalkerFactory
     {
         if (this.pendingScans.TryGetValue(root, out var scannerObservable))
         {
-            this.logger.LogDebug("Logging patterns {Patterns} for {Root}", string.Join(":", patterns), root.FullName);
+            var patternsArray = patterns as string[] ?? patterns.ToArray();
 
-            var compiled = PatternMatchingUtility.Compile(patterns);
+            this.logger.LogDebug("Logging patterns {Patterns} for {Root}", string.Join(":", patternsArray), root.FullName);
+
+            var compiled = PatternMatchingUtility.Compile(patternsArray);
 
             var inner = scannerObservable.Value.Where(fsi =>
             {
@@ -230,9 +233,10 @@ internal class FastDirectoryWalkerFactory : IObservableDirectoryWalkerFactory
 
     public IObservable<ProcessRequest> GetFilteredComponentStreamObservable(DirectoryInfo root, IEnumerable<string> patterns, IComponentRecorder componentRecorder)
     {
-        var compiled = PatternMatchingUtility.Compile(patterns);
+        var patternsArray = patterns as string[] ?? patterns.ToArray();
+        var compiled = PatternMatchingUtility.Compile(patternsArray);
 
-        var observable = this.Subscribe(root, patterns).OfType<FileInfo>()
+        var observable = this.Subscribe(root, patternsArray).OfType<FileInfo>()
             .Select(f => new
             {
                 File = f,

--- a/src/Microsoft.ComponentDetection.Common/PathUtilityService.cs
+++ b/src/Microsoft.ComponentDetection.Common/PathUtilityService.cs
@@ -1,9 +1,7 @@
 #nullable disable
 namespace Microsoft.ComponentDetection.Common;
 
-using System;
 using System.IO;
-using System.IO.Enumeration;
 using Microsoft.ComponentDetection.Contracts;
 using Microsoft.Extensions.Logging;
 
@@ -22,21 +20,6 @@ internal class PathUtilityService : IPathUtilityService
 
     public PathUtilityService(ILogger<PathUtilityService> logger) => this.logger = logger;
 
-    public static bool MatchesPattern(string searchPattern, ref FileSystemEntry fse)
-    {
-        if (searchPattern.StartsWith('*') && fse.FileName.EndsWith(searchPattern.AsSpan()[1..], StringComparison.OrdinalIgnoreCase))
-        {
-            return true;
-        }
-
-        if (searchPattern.EndsWith('*') && fse.FileName.StartsWith(searchPattern.AsSpan()[..^1], StringComparison.OrdinalIgnoreCase))
-        {
-            return true;
-        }
-
-        return fse.FileName.Equals(searchPattern.AsSpan(), StringComparison.OrdinalIgnoreCase);
-    }
-
     public string GetParentDirectory(string path) => Path.GetDirectoryName(path);
 
     public bool IsFileBelowAnother(string aboveFilePath, string belowFilePath)
@@ -46,21 +29,6 @@ internal class PathUtilityService : IPathUtilityService
 
         // Return true if they are not the same path but the second has the first as its base
         return (aboveDirectoryPath.Length != belowDirectoryPath.Length) && belowDirectoryPath.StartsWith(aboveDirectoryPath);
-    }
-
-    public bool MatchesPattern(string searchPattern, string fileName)
-    {
-        if (searchPattern.StartsWith('*') && fileName.EndsWith(searchPattern[1..], StringComparison.OrdinalIgnoreCase))
-        {
-            return true;
-        }
-
-        if (searchPattern.EndsWith('*') && fileName.StartsWith(searchPattern[..^1], StringComparison.OrdinalIgnoreCase))
-        {
-            return true;
-        }
-
-        return searchPattern.Equals(fileName, StringComparison.OrdinalIgnoreCase);
     }
 
     public string ResolvePhysicalPath(string path)

--- a/src/Microsoft.ComponentDetection.Common/PathUtilityService.cs
+++ b/src/Microsoft.ComponentDetection.Common/PathUtilityService.cs
@@ -1,6 +1,7 @@
 #nullable disable
 namespace Microsoft.ComponentDetection.Common;
 
+using System;
 using System.IO;
 using Microsoft.ComponentDetection.Contracts;
 using Microsoft.Extensions.Logging;
@@ -42,6 +43,9 @@ internal class PathUtilityService : IPathUtilityService
         var fileInfo = new FileInfo(path);
         return fileInfo.Exists ? this.ResolvePathFromInfo(fileInfo) : null;
     }
+
+    [Obsolete("Use PatternMatchingUtility.MatchesPattern instead.")]
+    public bool MatchesPattern(string pattern, string fileName) => PatternMatchingUtility.MatchesPattern(pattern, fileName);
 
     private string ResolvePathFromInfo(FileSystemInfo info) => info.LinkTarget ?? info.FullName;
 

--- a/src/Microsoft.ComponentDetection.Common/PatternMatchingUtility.cs
+++ b/src/Microsoft.ComponentDetection.Common/PatternMatchingUtility.cs
@@ -79,7 +79,7 @@ public static class PatternMatchingUtility
         private readonly string[] patterns;
 
         public CompiledMatcher(IEnumerable<string> patterns)
-            : this(patterns?.ToArray()!)
+            : this(patterns is string[] arr ? arr : (patterns ?? throw new ArgumentNullException(nameof(patterns))).ToArray())
         {
         }
 

--- a/src/Microsoft.ComponentDetection.Common/PatternMatchingUtility.cs
+++ b/src/Microsoft.ComponentDetection.Common/PatternMatchingUtility.cs
@@ -2,38 +2,61 @@ namespace Microsoft.ComponentDetection.Common;
 
 using System;
 using System.Collections.Generic;
+using System.IO.Enumeration;
 using System.Linq;
 
 public static class PatternMatchingUtility
 {
-    public delegate bool FilePatternMatcher(ReadOnlySpan<char> span);
+    public static bool MatchesPattern(string pattern, string fileName) =>
+        FileSystemName.MatchesSimpleExpression(pattern, fileName, ignoreCase: true);
 
-    public static FilePatternMatcher GetFilePatternMatcher(IEnumerable<string> patterns)
+    public static string? GetMatchingPattern(string fileName, IEnumerable<string> patterns)
     {
-        var matchers = patterns.Select<string, FilePatternMatcher>(pattern => pattern switch
+        var span = fileName.AsSpan();
+        foreach (var pattern in patterns)
         {
-            _ when pattern.StartsWith('*') && pattern.EndsWith('*') =>
-                pattern.Length <= 2
-                    ? _ => true
-                    : span => span.Contains(pattern.AsSpan(1, pattern.Length - 2), StringComparison.Ordinal),
-            _ when pattern.StartsWith('*') =>
-                span => span.EndsWith(pattern.AsSpan(1), StringComparison.Ordinal),
-            _ when pattern.EndsWith('*') =>
-                span => span.StartsWith(pattern.AsSpan(0, pattern.Length - 1), StringComparison.Ordinal),
-            _ => span => span.Equals(pattern.AsSpan(), StringComparison.Ordinal),
-        }).ToList();
-
-        return span =>
-        {
-            foreach (var matcher in matchers)
+            if (FileSystemName.MatchesSimpleExpression(pattern, span, ignoreCase: true))
             {
-                if (matcher(span))
+                return pattern;
+            }
+        }
+
+        return null;
+    }
+
+    internal static CompiledMatcher Compile(IEnumerable<string> patterns) => new(patterns);
+
+    internal sealed class CompiledMatcher
+    {
+        private readonly string[] patterns;
+
+        public CompiledMatcher(IEnumerable<string> patterns) =>
+            this.patterns = patterns.ToArray();
+
+        public bool IsMatch(ReadOnlySpan<char> fileName)
+        {
+            foreach (var pattern in this.patterns)
+            {
+                if (FileSystemName.MatchesSimpleExpression(pattern, fileName, ignoreCase: true))
                 {
                     return true;
                 }
             }
 
             return false;
-        };
+        }
+
+        public string? GetMatchingPattern(ReadOnlySpan<char> fileName)
+        {
+            foreach (var pattern in this.patterns)
+            {
+                if (FileSystemName.MatchesSimpleExpression(pattern, fileName, ignoreCase: true))
+                {
+                    return pattern;
+                }
+            }
+
+            return null;
+        }
     }
 }

--- a/src/Microsoft.ComponentDetection.Common/PatternMatchingUtility.cs
+++ b/src/Microsoft.ComponentDetection.Common/PatternMatchingUtility.cs
@@ -31,6 +31,12 @@ public static class PatternMatchingUtility
     public static CompiledMatcher Compile(IEnumerable<string> patterns)
     {
         ArgumentNullException.ThrowIfNull(patterns);
+        return patterns is string[] array ? Compile(array) : new(patterns.ToArray());
+    }
+
+    public static CompiledMatcher Compile(string[] patterns)
+    {
+        ArgumentNullException.ThrowIfNull(patterns);
         return new(patterns);
     }
 
@@ -49,6 +55,22 @@ public static class PatternMatchingUtility
         return null;
     }
 
+    /// <summary>
+    /// Fast path for pre-validated pattern arrays. Skips per-element null checks.
+    /// </summary>
+    private static string? GetFirstMatchingPattern(ReadOnlySpan<char> fileName, string[] patterns)
+    {
+        foreach (var pattern in patterns)
+        {
+            if (IsPatternMatch(pattern, fileName))
+            {
+                return pattern;
+            }
+        }
+
+        return null;
+    }
+
     private static bool IsPatternMatch(string pattern, ReadOnlySpan<char> fileName) =>
         FileSystemName.MatchesSimpleExpression(pattern, fileName, ignoreCase: true);
 
@@ -57,10 +79,15 @@ public static class PatternMatchingUtility
         private readonly string[] patterns;
 
         public CompiledMatcher(IEnumerable<string> patterns)
+            : this(patterns?.ToArray()!)
+        {
+        }
+
+        internal CompiledMatcher(string[] patterns)
         {
             ArgumentNullException.ThrowIfNull(patterns);
-            this.patterns = patterns.ToArray();
-            ValidatePatternElements(this.patterns);
+            ValidatePatternElements(patterns);
+            this.patterns = patterns;
         }
 
         public bool IsMatch(ReadOnlySpan<char> fileName) => GetFirstMatchingPattern(fileName, this.patterns) is not null;

--- a/src/Microsoft.ComponentDetection.Common/PatternMatchingUtility.cs
+++ b/src/Microsoft.ComponentDetection.Common/PatternMatchingUtility.cs
@@ -38,6 +38,8 @@ public static class PatternMatchingUtility
     {
         foreach (var pattern in patterns)
         {
+            ArgumentNullException.ThrowIfNull(pattern);
+
             if (IsPatternMatch(pattern, fileName))
             {
                 return pattern;
@@ -58,6 +60,7 @@ public static class PatternMatchingUtility
         {
             ArgumentNullException.ThrowIfNull(patterns);
             this.patterns = patterns.ToArray();
+            ValidatePatternElements(this.patterns);
         }
 
         public bool IsMatch(ReadOnlySpan<char> fileName) => GetFirstMatchingPattern(fileName, this.patterns) is not null;
@@ -68,5 +71,13 @@ public static class PatternMatchingUtility
         /// </summary>
         /// <returns>The first matching pattern, or <see langword="null"/> if no patterns match.</returns>
         public string? GetMatchingPattern(ReadOnlySpan<char> fileName) => GetFirstMatchingPattern(fileName, this.patterns);
+
+        private static void ValidatePatternElements(IEnumerable<string> patterns)
+        {
+            foreach (var pattern in patterns)
+            {
+                ArgumentNullException.ThrowIfNull(pattern);
+            }
+        }
     }
 }

--- a/src/Microsoft.ComponentDetection.Common/PatternMatchingUtility.cs
+++ b/src/Microsoft.ComponentDetection.Common/PatternMatchingUtility.cs
@@ -7,15 +7,23 @@ using System.Linq;
 
 public static class PatternMatchingUtility
 {
-    public static bool MatchesPattern(string pattern, string fileName) =>
-        FileSystemName.MatchesSimpleExpression(pattern, fileName, ignoreCase: true);
+    public static bool MatchesPattern(string pattern, string fileName) => IsPatternMatch(pattern, fileName.AsSpan());
 
+    /// <summary>
+    /// Returns the first matching pattern for <paramref name="fileName"/>.
+    /// Earlier patterns in <paramref name="patterns"/> have higher priority when multiple match.
+    /// </summary>
+    /// <returns>The first matching pattern, or <see langword="null"/> if no patterns match.</returns>
     public static string? GetMatchingPattern(string fileName, IEnumerable<string> patterns)
+        => GetFirstMatchingPattern(fileName.AsSpan(), patterns);
+
+    public static CompiledMatcher Compile(IEnumerable<string> patterns) => new(patterns);
+
+    private static string? GetFirstMatchingPattern(ReadOnlySpan<char> fileName, IEnumerable<string> patterns)
     {
-        var span = fileName.AsSpan();
         foreach (var pattern in patterns)
         {
-            if (FileSystemName.MatchesSimpleExpression(pattern, span, ignoreCase: true))
+            if (IsPatternMatch(pattern, fileName))
             {
                 return pattern;
             }
@@ -24,39 +32,23 @@ public static class PatternMatchingUtility
         return null;
     }
 
-    internal static CompiledMatcher Compile(IEnumerable<string> patterns) => new(patterns);
+    private static bool IsPatternMatch(string pattern, ReadOnlySpan<char> fileName) =>
+        FileSystemName.MatchesSimpleExpression(pattern, fileName, ignoreCase: true);
 
-    internal sealed class CompiledMatcher
+    public sealed class CompiledMatcher
     {
         private readonly string[] patterns;
 
         public CompiledMatcher(IEnumerable<string> patterns) =>
             this.patterns = patterns.ToArray();
 
-        public bool IsMatch(ReadOnlySpan<char> fileName)
-        {
-            foreach (var pattern in this.patterns)
-            {
-                if (FileSystemName.MatchesSimpleExpression(pattern, fileName, ignoreCase: true))
-                {
-                    return true;
-                }
-            }
+        public bool IsMatch(ReadOnlySpan<char> fileName) => GetFirstMatchingPattern(fileName, this.patterns) is not null;
 
-            return false;
-        }
-
-        public string? GetMatchingPattern(ReadOnlySpan<char> fileName)
-        {
-            foreach (var pattern in this.patterns)
-            {
-                if (FileSystemName.MatchesSimpleExpression(pattern, fileName, ignoreCase: true))
-                {
-                    return pattern;
-                }
-            }
-
-            return null;
-        }
+        /// <summary>
+        /// Returns the first matching pattern for <paramref name="fileName"/>.
+        /// Earlier patterns in the compiled set have higher priority when multiple match.
+        /// </summary>
+        /// <returns>The first matching pattern, or <see langword="null"/> if no patterns match.</returns>
+        public string? GetMatchingPattern(ReadOnlySpan<char> fileName) => GetFirstMatchingPattern(fileName, this.patterns);
     }
 }

--- a/src/Microsoft.ComponentDetection.Common/PatternMatchingUtility.cs
+++ b/src/Microsoft.ComponentDetection.Common/PatternMatchingUtility.cs
@@ -86,8 +86,8 @@ public static class PatternMatchingUtility
         internal CompiledMatcher(string[] patterns)
         {
             ArgumentNullException.ThrowIfNull(patterns);
-            ValidatePatternElements(patterns);
-            this.patterns = patterns;
+            this.patterns = (string[])patterns.Clone();
+            ValidatePatternElements(this.patterns);
         }
 
         public bool IsMatch(ReadOnlySpan<char> fileName) => GetFirstMatchingPattern(fileName, this.patterns) is not null;

--- a/src/Microsoft.ComponentDetection.Common/PatternMatchingUtility.cs
+++ b/src/Microsoft.ComponentDetection.Common/PatternMatchingUtility.cs
@@ -7,7 +7,13 @@ using System.Linq;
 
 public static class PatternMatchingUtility
 {
-    public static bool MatchesPattern(string pattern, string fileName) => IsPatternMatch(pattern, fileName.AsSpan());
+    public static bool MatchesPattern(string pattern, string fileName)
+    {
+        ArgumentNullException.ThrowIfNull(pattern);
+        ArgumentNullException.ThrowIfNull(fileName);
+
+        return IsPatternMatch(pattern, fileName.AsSpan());
+    }
 
     /// <summary>
     /// Returns the first matching pattern for <paramref name="fileName"/>.
@@ -15,9 +21,18 @@ public static class PatternMatchingUtility
     /// </summary>
     /// <returns>The first matching pattern, or <see langword="null"/> if no patterns match.</returns>
     public static string? GetMatchingPattern(string fileName, IEnumerable<string> patterns)
-        => GetFirstMatchingPattern(fileName.AsSpan(), patterns);
+    {
+        ArgumentNullException.ThrowIfNull(fileName);
+        ArgumentNullException.ThrowIfNull(patterns);
 
-    public static CompiledMatcher Compile(IEnumerable<string> patterns) => new(patterns);
+        return GetFirstMatchingPattern(fileName.AsSpan(), patterns);
+    }
+
+    public static CompiledMatcher Compile(IEnumerable<string> patterns)
+    {
+        ArgumentNullException.ThrowIfNull(patterns);
+        return new(patterns);
+    }
 
     private static string? GetFirstMatchingPattern(ReadOnlySpan<char> fileName, IEnumerable<string> patterns)
     {
@@ -39,8 +54,11 @@ public static class PatternMatchingUtility
     {
         private readonly string[] patterns;
 
-        public CompiledMatcher(IEnumerable<string> patterns) =>
+        public CompiledMatcher(IEnumerable<string> patterns)
+        {
+            ArgumentNullException.ThrowIfNull(patterns);
             this.patterns = patterns.ToArray();
+        }
 
         public bool IsMatch(ReadOnlySpan<char> fileName) => GetFirstMatchingPattern(fileName, this.patterns) is not null;
 

--- a/src/Microsoft.ComponentDetection.Common/PatternMatchingUtility.cs
+++ b/src/Microsoft.ComponentDetection.Common/PatternMatchingUtility.cs
@@ -25,7 +25,7 @@ public static class PatternMatchingUtility
         ArgumentNullException.ThrowIfNull(fileName);
         ArgumentNullException.ThrowIfNull(patterns);
 
-        return GetFirstMatchingPattern(fileName.AsSpan(), patterns);
+        return Compile(patterns).GetMatchingPattern(fileName.AsSpan());
     }
 
     public static CompiledMatcher Compile(IEnumerable<string> patterns)
@@ -40,24 +40,6 @@ public static class PatternMatchingUtility
         return new(patterns);
     }
 
-    private static string? GetFirstMatchingPattern(ReadOnlySpan<char> fileName, IEnumerable<string> patterns)
-    {
-        foreach (var pattern in patterns)
-        {
-            ArgumentNullException.ThrowIfNull(pattern);
-
-            if (IsPatternMatch(pattern, fileName))
-            {
-                return pattern;
-            }
-        }
-
-        return null;
-    }
-
-    /// <summary>
-    /// Fast path for pre-validated pattern arrays. Skips per-element null checks.
-    /// </summary>
     private static string? GetFirstMatchingPattern(ReadOnlySpan<char> fileName, string[] patterns)
     {
         foreach (var pattern in patterns)
@@ -99,7 +81,7 @@ public static class PatternMatchingUtility
         /// <returns>The first matching pattern, or <see langword="null"/> if no patterns match.</returns>
         public string? GetMatchingPattern(ReadOnlySpan<char> fileName) => GetFirstMatchingPattern(fileName, this.patterns);
 
-        private static void ValidatePatternElements(IEnumerable<string> patterns)
+        private static void ValidatePatternElements(string[] patterns)
         {
             foreach (var pattern in patterns)
             {

--- a/src/Microsoft.ComponentDetection.Common/SafeFileEnumerable.cs
+++ b/src/Microsoft.ComponentDetection.Common/SafeFileEnumerable.cs
@@ -11,7 +11,6 @@ using Microsoft.Extensions.Logging;
 
 public class SafeFileEnumerable : IEnumerable<MatchedFile>
 {
-    private readonly IEnumerable<string> searchPatterns;
     private readonly ExcludeDirectoryPredicate directoryExclusionPredicate;
     private readonly DirectoryInfo directory;
     private readonly IPathUtilityService pathUtilityService;
@@ -28,7 +27,6 @@ public class SafeFileEnumerable : IEnumerable<MatchedFile>
     {
         this.directory = directory;
         this.logger = logger;
-        this.searchPatterns = searchPatterns;
         this.directoryExclusionPredicate = directoryExclusionPredicate;
         this.recursivelyScanDirectories = recursivelyScanDirectories;
         this.pathUtilityService = pathUtilityService;

--- a/src/Microsoft.ComponentDetection.Common/SafeFileEnumerable.cs
+++ b/src/Microsoft.ComponentDetection.Common/SafeFileEnumerable.cs
@@ -60,6 +60,8 @@ public class SafeFileEnumerable : IEnumerable<MatchedFile>
                     throw new InvalidOperationException("Encountered directory when expecting a file");
                 }
 
+                // Pattern priority is first-match-wins: earlier entries in searchPatterns
+                // are treated as higher priority when multiple patterns match.
                 var foundPattern = this.compiledMatcher.GetMatchingPattern(entry.FileName)
                     ?? entry.FileName.ToString();
 

--- a/src/Microsoft.ComponentDetection.Common/SafeFileEnumerable.cs
+++ b/src/Microsoft.ComponentDetection.Common/SafeFileEnumerable.cs
@@ -17,6 +17,7 @@ public class SafeFileEnumerable : IEnumerable<MatchedFile>
     private readonly IPathUtilityService pathUtilityService;
     private readonly bool recursivelyScanDirectories;
     private readonly Func<FileInfo, bool> fileMatchingPredicate;
+    private readonly PatternMatchingUtility.CompiledMatcher compiledMatcher;
 
     private readonly EnumerationOptions enumerationOptions;
 
@@ -32,6 +33,7 @@ public class SafeFileEnumerable : IEnumerable<MatchedFile>
         this.recursivelyScanDirectories = recursivelyScanDirectories;
         this.pathUtilityService = pathUtilityService;
         this.enumeratedDirectories = previouslyEnumeratedDirectories;
+        this.compiledMatcher = PatternMatchingUtility.Compile(searchPatterns);
 
         this.enumerationOptions = new EnumerationOptions()
         {
@@ -58,14 +60,8 @@ public class SafeFileEnumerable : IEnumerable<MatchedFile>
                     throw new InvalidOperationException("Encountered directory when expecting a file");
                 }
 
-                var foundPattern = entry.FileName.ToString();
-                foreach (var searchPattern in this.searchPatterns)
-                {
-                    if (PathUtilityService.MatchesPattern(searchPattern, ref entry))
-                    {
-                        foundPattern = searchPattern;
-                    }
-                }
+                var foundPattern = this.compiledMatcher.GetMatchingPattern(entry.FileName)
+                    ?? entry.FileName.ToString();
 
                 return new MatchedFile() { File = fi, Pattern = foundPattern };
             },
@@ -78,15 +74,7 @@ public class SafeFileEnumerable : IEnumerable<MatchedFile>
                     return false;
                 }
 
-                foreach (var searchPattern in this.searchPatterns)
-                {
-                    if (PathUtilityService.MatchesPattern(searchPattern, ref entry))
-                    {
-                        return true;
-                    }
-                }
-
-                return false;
+                return this.compiledMatcher.IsMatch(entry.FileName);
             },
             ShouldRecursePredicate = (ref FileSystemEntry entry) =>
             {

--- a/src/Microsoft.ComponentDetection.Contracts/FileComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/FileComponentDetector.cs
@@ -34,7 +34,10 @@ public abstract class FileComponentDetector : IComponentDetector
     /// <inheritdoc />
     public abstract string Id { get; }
 
-    /// <summary> Gets the search patterns used to produce the list of valid folders to scan. These patterns are evaluated with .Net's Directory.EnumerateFiles function. </summary>
+    /// <summary>
+    /// Gets the search patterns used to produce the list of valid folders to scan.
+    /// The first pattern that matches a given file will be used to determine how that file is processed, so more specific patterns should be listed before more general ones. Wildcards are accepted.
+    /// </summary>
     public abstract IList<string> SearchPatterns { get; }
 
     /// <summary>Gets the categories this detector is considered a member of. Used by the DetectorCategories arg to include detectors.</summary>

--- a/src/Microsoft.ComponentDetection.Contracts/FileComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/FileComponentDetector.cs
@@ -35,7 +35,7 @@ public abstract class FileComponentDetector : IComponentDetector
     public abstract string Id { get; }
 
     /// <summary>
-    /// Gets the search patterns used to produce the list of valid folders to scan.
+    /// Gets the search patterns used to produce the list of valid files to scan.
     /// The first pattern that matches a given file will be used to determine how that file is processed, so more specific patterns should be listed before more general ones. Wildcards are accepted.
     /// </summary>
     public abstract IList<string> SearchPatterns { get; }

--- a/src/Microsoft.ComponentDetection.Contracts/IPathUtilityService.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/IPathUtilityService.cs
@@ -1,6 +1,8 @@
 #nullable disable
 namespace Microsoft.ComponentDetection.Contracts;
 
+using System;
+
 /// <summary>
 /// Wraps some common folder operations, shared across command line app and service.
 /// </summary>
@@ -27,6 +29,15 @@ public interface IPathUtilityService
     /// <param name="belowFilePath">The file path to find within the top file path.</param>
     /// <returns>Returns true if the below file path exists under the above file path, otherwise false.</returns>
     bool IsFileBelowAnother(string aboveFilePath, string belowFilePath);
+
+    /// <summary>
+    /// Matches file names to simple wildcard patterns.
+    /// </summary>
+    /// <param name="pattern">Pattern to match against.</param>
+    /// <param name="fileName">File name to evaluate.</param>
+    /// <returns>Returns true when the file name matches the pattern, otherwise false.</returns>
+    [Obsolete("Use PatternMatchingUtility.MatchesPattern instead.")]
+    bool MatchesPattern(string pattern, string fileName);
 
     /// <summary>
     /// Normalize the path directory seperator to / on Unix systems and on Windows.

--- a/src/Microsoft.ComponentDetection.Contracts/IPathUtilityService.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/IPathUtilityService.cs
@@ -29,14 +29,6 @@ public interface IPathUtilityService
     bool IsFileBelowAnother(string aboveFilePath, string belowFilePath);
 
     /// <summary>
-    /// Returns true if file name matches pattern.
-    /// </summary>
-    /// <param name="searchPattern">Search pattern.</param>
-    /// <param name="fileName">File name without directory.</param>
-    /// <returns>Returns true if file name matches a pattern, otherwise false.</returns>
-    bool MatchesPattern(string searchPattern, string fileName);
-
-    /// <summary>
     /// Normalize the path directory seperator to / on Unix systems and on Windows.
     /// This is the behavior we want as Windows accepts / as a separator.
     /// </summary>

--- a/test/Microsoft.ComponentDetection.Common.Tests/PathUtilityServiceTests.cs
+++ b/test/Microsoft.ComponentDetection.Common.Tests/PathUtilityServiceTests.cs
@@ -32,4 +32,15 @@ public class PathUtilityServiceTests
 
         normalizedPath.Should().Be(expectedPath);
     }
+
+    [TestMethod]
+    public void MatchesPattern_IsForwardedToPatternMatchingUtility()
+    {
+        var service = new PathUtilityService(new NullLogger<PathUtilityService>());
+
+#pragma warning disable CS0618 // Type or member is obsolete
+        service.MatchesPattern("*.json", "package.json").Should().BeTrue();
+        service.MatchesPattern("*.json", "package.yaml").Should().BeFalse();
+#pragma warning restore CS0618 // Type or member is obsolete
+    }
 }

--- a/test/Microsoft.ComponentDetection.Common.Tests/PatternMatchingUtilityTests.cs
+++ b/test/Microsoft.ComponentDetection.Common.Tests/PatternMatchingUtilityTests.cs
@@ -1,6 +1,7 @@
 #nullable disable
 namespace Microsoft.ComponentDetection.Common.Tests;
 
+using System;
 using AwesomeAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -15,6 +16,7 @@ public class PatternMatchingUtilityTests
     [DataRow("*test", "123test", true)]
     [DataRow("*test", "test123", false)]
     [DataRow("test", "test", true)]
+    [DataRow("test", "TEST", true)]
     [DataRow("test", "123test", false)]
     [DataRow("*test*", "123test456", true)]
     [DataRow("*test*", "test456", true)]
@@ -22,31 +24,89 @@ public class PatternMatchingUtilityTests
     [DataRow("*test*", "test", true)]
     [DataRow("*test*", "tes", false)]
     [DataRow("*", "anything", true)]
-    [DataRow("*", "", true)]
+    [DataRow("*", "", false)]
     [DataRow("**", "anything", true)]
-    [DataRow("**", "", true)]
+    [DataRow("**", "", false)]
+    [DataRow("*.csproj", "MyProject.csproj", true)]
+    [DataRow("*.csproj", "MyProject.json", false)]
+    [DataRow("package.json", "package.json", true)]
+    [DataRow("package.json", "PACKAGE.JSON", true)]
+    [DataRow("dockerfile.*", "dockerfile.prod", true)]
+    [DataRow("dockerfile.*", "dockerfile", false)]
+    [DataRow("*.cargo-sbom.json", "test.cargo-sbom.json", true)]
+    [DataRow("*values*.yaml", "myvalues.yaml", true)]
+    [DataRow("*values*.yaml", "values.yaml", true)]
+    [DataRow("*values*.yaml", "values.json", false)]
     public void PatternMatcher_MatchesExpected(string pattern, string input, bool expected)
     {
-        var matcher = PatternMatchingUtility.GetFilePatternMatcher([pattern]);
+        var matcher = PatternMatchingUtility.Compile([pattern]);
 
-        matcher(input).Should().Be(expected);
+        matcher.IsMatch(input.AsSpan()).Should().Be(expected);
     }
 
     [TestMethod]
     public void PatternMatcher_MultiplePatterns_MatchesAny()
     {
-        var matcher = PatternMatchingUtility.GetFilePatternMatcher(["a*", "*b"]);
+        var matcher = PatternMatchingUtility.Compile(["a*", "*b"]);
 
-        matcher("apple").Should().BeTrue();
-        matcher("crab").Should().BeTrue();
-        matcher("middle").Should().BeFalse();
+        matcher.IsMatch("apple".AsSpan()).Should().BeTrue();
+        matcher.IsMatch("crab".AsSpan()).Should().BeTrue();
+        matcher.IsMatch("middle".AsSpan()).Should().BeFalse();
     }
 
     [TestMethod]
     public void PatternMatcher_EmptyPatterns_DoesNotThrow()
     {
-        var matcher = PatternMatchingUtility.GetFilePatternMatcher([]);
+        var matcher = PatternMatchingUtility.Compile([]);
 
-        matcher("anything").Should().BeFalse();
+        matcher.IsMatch("anything".AsSpan()).Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void MatchesPattern_SinglePattern()
+    {
+        PatternMatchingUtility.MatchesPattern("*.json", "package.json").Should().BeTrue();
+        PatternMatchingUtility.MatchesPattern("*.json", "package.yaml").Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void MatchesPattern_CaseInsensitive()
+    {
+        PatternMatchingUtility.MatchesPattern("package.json", "PACKAGE.JSON").Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void GetMatchingPattern_ReturnsFirstMatch()
+    {
+        var result = PatternMatchingUtility.GetMatchingPattern("package.json", ["*.json", "package.json"]);
+        result.Should().Be("*.json");
+    }
+
+    [TestMethod]
+    public void GetMatchingPattern_ReturnsNullWhenNoMatch()
+    {
+        var result = PatternMatchingUtility.GetMatchingPattern("package.yaml", ["*.json", "*.xml"]);
+        result.Should().BeNull();
+    }
+
+    [TestMethod]
+    public void CompiledMatcher_GetMatchingPattern_Works()
+    {
+        var compiled = PatternMatchingUtility.Compile(["*.json", "*.xml", "Cargo.toml"]);
+
+        compiled.GetMatchingPattern("package.json").Should().Be("*.json");
+        compiled.GetMatchingPattern("pom.xml").Should().Be("*.xml");
+        compiled.GetMatchingPattern("Cargo.toml").Should().Be("Cargo.toml");
+        compiled.GetMatchingPattern("README.md").Should().BeNull();
+    }
+
+    [TestMethod]
+    public void CompiledMatcher_IsMatch_SpanBased()
+    {
+        var compiled = PatternMatchingUtility.Compile(["package.json", "*.lock"]);
+
+        compiled.IsMatch("package.json".AsSpan()).Should().BeTrue();
+        compiled.IsMatch("yarn.lock".AsSpan()).Should().BeTrue();
+        compiled.IsMatch("README.md".AsSpan()).Should().BeFalse();
     }
 }

--- a/test/Microsoft.ComponentDetection.Common.Tests/PatternMatchingUtilityTests.cs
+++ b/test/Microsoft.ComponentDetection.Common.Tests/PatternMatchingUtilityTests.cs
@@ -136,4 +136,18 @@ public class PatternMatchingUtilityTests
         Action action = () => PatternMatchingUtility.Compile(null);
         action.Should().ThrowExactly<ArgumentNullException>();
     }
+
+    [TestMethod]
+    public void Compile_ThrowsForNullPatternElement()
+    {
+        Action action = () => PatternMatchingUtility.Compile(["*.json", null, "*.xml"]);
+        action.Should().ThrowExactly<ArgumentNullException>();
+    }
+
+    [TestMethod]
+    public void GetMatchingPattern_ThrowsForNullPatternElement()
+    {
+        Action action = () => PatternMatchingUtility.GetMatchingPattern("package.json", ["*.xml", null, "*.yaml"]);
+        action.Should().ThrowExactly<ArgumentNullException>();
+    }
 }

--- a/test/Microsoft.ComponentDetection.Common.Tests/PatternMatchingUtilityTests.cs
+++ b/test/Microsoft.ComponentDetection.Common.Tests/PatternMatchingUtilityTests.cs
@@ -109,4 +109,31 @@ public class PatternMatchingUtilityTests
         compiled.IsMatch("yarn.lock".AsSpan()).Should().BeTrue();
         compiled.IsMatch("README.md".AsSpan()).Should().BeFalse();
     }
+
+    [TestMethod]
+    public void MatchesPattern_ThrowsForNullInputs()
+    {
+        Action nullPattern = () => PatternMatchingUtility.MatchesPattern(null, "package.json");
+        Action nullFileName = () => PatternMatchingUtility.MatchesPattern("*.json", null);
+
+        nullPattern.Should().ThrowExactly<ArgumentNullException>();
+        nullFileName.Should().ThrowExactly<ArgumentNullException>();
+    }
+
+    [TestMethod]
+    public void GetMatchingPattern_ThrowsForNullInputs()
+    {
+        Action nullFileName = () => PatternMatchingUtility.GetMatchingPattern(null, ["*.json"]);
+        Action nullPatterns = () => PatternMatchingUtility.GetMatchingPattern("package.json", null);
+
+        nullFileName.Should().ThrowExactly<ArgumentNullException>();
+        nullPatterns.Should().ThrowExactly<ArgumentNullException>();
+    }
+
+    [TestMethod]
+    public void Compile_ThrowsForNullPatterns()
+    {
+        Action action = () => PatternMatchingUtility.Compile(null);
+        action.Should().ThrowExactly<ArgumentNullException>();
+    }
 }

--- a/test/Microsoft.ComponentDetection.Common.Tests/SafeFileEnumerableTests.cs
+++ b/test/Microsoft.ComponentDetection.Common.Tests/SafeFileEnumerableTests.cs
@@ -50,7 +50,6 @@ public class SafeFileEnumerableTests
         IEnumerable<string> searchPatterns = [name];
 
         this.pathUtilityServiceMock.Setup(x => x.ResolvePhysicalPath(It.IsAny<string>())).Returns<string>((s) => s);
-        this.pathUtilityServiceMock.Setup(x => x.MatchesPattern(name, name)).Returns(true);
 
         var enumerable = new SafeFileEnumerable(new DirectoryInfo(this.temporaryDirectory), searchPatterns, this.loggerMock.Object, this.pathUtilityServiceMock.Object, (directoryName, span) => false, true);
 
@@ -76,8 +75,6 @@ public class SafeFileEnumerableTests
         File.Create(Path.Combine(this.temporaryDirectory, "SubDir", name)).Close();
 
         IEnumerable<string> searchPatterns = [name];
-
-        this.pathUtilityServiceMock.Setup(x => x.MatchesPattern(name, name)).Returns(true);
 
         var enumerable = new SafeFileEnumerable(new DirectoryInfo(this.temporaryDirectory), searchPatterns, this.loggerMock.Object, this.pathUtilityServiceMock.Object, (directoryName, span) => false, false);
 

--- a/test/Microsoft.ComponentDetection.TestsUtilities/DetectorTestUtilityBuilder.cs
+++ b/test/Microsoft.ComponentDetection.TestsUtilities/DetectorTestUtilityBuilder.cs
@@ -125,9 +125,7 @@ public class DetectorTestUtilityBuilder<T>
 
     private static string FindMatchingPattern(string fileName, IEnumerable<string> searchPatterns)
     {
-        var foundPattern = searchPatterns.FirstOrDefault(searchPattern => new PathUtilityService(null).MatchesPattern(searchPattern, fileName));
-
-        return foundPattern ?? fileName;
+        return PatternMatchingUtility.GetMatchingPattern(fileName, searchPatterns) ?? fileName;
     }
 
     private ProcessRequest CreateProcessRequest(string pattern, string filePath, Stream content) =>


### PR DESCRIPTION
This pull request refactors and modernizes the file pattern matching logic throughout the codebase. The main improvements are the introduction of a new `PatternMatchingUtility.CompiledMatcher` class for efficient, reusable pattern matching, the removal of legacy pattern matching code, and the simplification of APIs that deal with file pattern matching. These changes improve maintainability, performance, and code clarity.

Worth noting is that as a part of this change, the ordering of the `SearchPatterns` in each detector is now ordered so that earlier patterns have a higher priority when multiple patterns match a file.

Additionally, only **one** `ProcessRequest` is returned per matching **file**, previously we returned one per matching **pattern**.

Old behavior (one per matching pattern): If a file like `package.json` matched both `*.json` and `package.json`, the detector's `OnFileFoundAsync` would be called twice for the same file. Both calls would parse the same content and register the same components into the same `SingleFileComponentRecorder` (since it's keyed by file path via `CreateSingleFileComponentRecorder(lazyComponentStream.Location)`). The second call is pure waste.

New behavior (one per file): Each file is processed exactly once. No duplicate parsing, no redundant `RegisterUsage` calls.