### PR TITLE
Add ability to use syft binary instead of container for Linux detector

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/linux/BinarySyftRunner.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/linux/BinarySyftRunner.cs
@@ -77,7 +77,7 @@ internal class BinarySyftRunner : ISyftRunner
         IList<string> arguments,
         CancellationToken cancellationToken = default)
     {
-        var syftSource = GetSyftSource(imageReference);
+        var (syftSourceKind, syftSource) = GetSyftSource(imageReference);
         var acquired = false;
 
         try
@@ -91,7 +91,7 @@ internal class BinarySyftRunner : ISyftRunner
                 return (string.Empty, string.Empty);
             }
 
-            var parameters = new[] { syftSource }
+            var parameters = new[] { syftSource, ISyftRunner.SyftSourceKindArgument, syftSourceKind }
                 .Concat(arguments)
                 .ToArray();
 
@@ -121,19 +121,6 @@ internal class BinarySyftRunner : ISyftRunner
         }
     }
 
-    /// <summary>
-    /// Constructs the Syft source argument from an image reference.
-    /// For local images, the host path is used directly with the appropriate scheme prefix.
-    /// </summary>
-    private static string GetSyftSource(ImageReference imageReference) =>
-        imageReference.Kind switch
-        {
-            ImageReferenceKind.DockerImage => imageReference.Reference,
-            ImageReferenceKind.OciLayout => $"oci-dir:{imageReference.Reference}",
-            ImageReferenceKind.OciArchive => $"oci-archive:{imageReference.Reference}",
-            ImageReferenceKind.DockerArchive => $"docker-archive:{imageReference.Reference}",
-            _ => throw new ArgumentOutOfRangeException(
-                nameof(imageReference),
-                $"Unsupported image reference kind '{imageReference.Kind}'."),
-        };
+    private static (string SyftSourceKind, string SyftSource) GetSyftSource(ImageReference imageReference) =>
+        (imageReference.GetSyftSourceKind(), imageReference.Reference);
 }

--- a/src/Microsoft.ComponentDetection.Detectors/linux/BinarySyftRunner.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/linux/BinarySyftRunner.cs
@@ -1,0 +1,133 @@
+namespace Microsoft.ComponentDetection.Detectors.Linux;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.ComponentDetection.Contracts;
+using Microsoft.Extensions.Logging;
+
+/// <summary>
+/// Runs Syft by invoking a local Syft binary.
+/// </summary>
+internal class BinarySyftRunner : ISyftRunner
+{
+    private static readonly SemaphoreSlim BinarySemaphore = new(2);
+
+    private static readonly int SemaphoreTimeout = Convert.ToInt32(
+        TimeSpan.FromHours(1).TotalMilliseconds);
+
+    private readonly string syftBinaryPath;
+    private readonly ICommandLineInvocationService commandLineInvocationService;
+    private readonly ILogger<BinarySyftRunner> logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BinarySyftRunner"/> class.
+    /// </summary>
+    /// <param name="syftBinaryPath">The path to the Syft binary.</param>
+    /// <param name="commandLineInvocationService">The command line invocation service.</param>
+    /// <param name="logger">The logger.</param>
+    public BinarySyftRunner(
+        string syftBinaryPath,
+        ICommandLineInvocationService commandLineInvocationService,
+        ILogger<BinarySyftRunner> logger)
+    {
+        this.syftBinaryPath = syftBinaryPath;
+        this.commandLineInvocationService = commandLineInvocationService;
+        this.logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public async Task<bool> CanRunAsync(CancellationToken cancellationToken = default)
+    {
+        var result = await this.commandLineInvocationService.ExecuteCommandAsync(
+            this.syftBinaryPath,
+            null,
+            null,
+            cancellationToken,
+            "--version");
+
+        if (result.ExitCode != 0)
+        {
+            this.logger.LogInformation(
+                "Syft binary at {SyftBinaryPath} failed version check with exit code {ExitCode}. Stderr: {StdErr}",
+                this.syftBinaryPath,
+                result.ExitCode,
+                result.StdErr);
+            return false;
+        }
+
+        this.logger.LogInformation(
+            "Using Syft binary at {SyftBinaryPath}: {SyftVersion}",
+            this.syftBinaryPath,
+            result.StdOut?.Trim());
+        return true;
+    }
+
+    /// <inheritdoc/>
+    public async Task<(string Stdout, string Stderr)> RunSyftAsync(
+        ImageReference imageReference,
+        IList<string> arguments,
+        CancellationToken cancellationToken = default)
+    {
+        var syftSource = GetSyftSource(imageReference);
+        var acquired = false;
+
+        try
+        {
+            acquired = await BinarySemaphore.WaitAsync(SemaphoreTimeout, cancellationToken);
+            if (!acquired)
+            {
+                this.logger.LogWarning(
+                    "Failed to enter the binary semaphore for image {ImageReference}",
+                    imageReference.Reference);
+                return (string.Empty, string.Empty);
+            }
+
+            var parameters = new[] { syftSource }
+                .Concat(arguments)
+                .ToArray();
+
+            var result = await this.commandLineInvocationService.ExecuteCommandAsync(
+                this.syftBinaryPath,
+                null,
+                null,
+                cancellationToken,
+                parameters);
+
+            if (result.ExitCode != 0)
+            {
+                this.logger.LogError(
+                    "Syft binary exited with code {ExitCode}. Stderr: {StdErr}",
+                    result.ExitCode,
+                    result.StdErr);
+            }
+
+            return (result.StdOut, result.StdErr);
+        }
+        finally
+        {
+            if (acquired)
+            {
+                BinarySemaphore.Release();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Constructs the Syft source argument from an image reference.
+    /// For local images, the host path is used directly with the appropriate scheme prefix.
+    /// </summary>
+    private static string GetSyftSource(ImageReference imageReference) =>
+        imageReference.Kind switch
+        {
+            ImageReferenceKind.DockerImage => imageReference.Reference,
+            ImageReferenceKind.OciLayout => $"oci-dir:{imageReference.Reference}",
+            ImageReferenceKind.OciArchive => $"oci-archive:{imageReference.Reference}",
+            ImageReferenceKind.DockerArchive => $"docker-archive:{imageReference.Reference}",
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(imageReference),
+                $"Unsupported image reference kind '{imageReference.Kind}'."),
+        };
+}

--- a/src/Microsoft.ComponentDetection.Detectors/linux/BinarySyftRunner.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/linux/BinarySyftRunner.cs
@@ -41,6 +41,12 @@ internal class BinarySyftRunner : ISyftRunner
     /// <inheritdoc/>
     public async Task<bool> CanRunAsync(CancellationToken cancellationToken = default)
     {
+        if (!await this.commandLineInvocationService.CanCommandBeLocatedAsync(this.syftBinaryPath, null, "--version"))
+        {
+            this.logger.LogInformation("Syft binary at {SyftBinaryPath} was not found in the local environment.", this.syftBinaryPath);
+            return false;
+        }
+
         var result = await this.commandLineInvocationService.ExecuteCommandAsync(
             this.syftBinaryPath,
             null,

--- a/src/Microsoft.ComponentDetection.Detectors/linux/BinarySyftRunnerFactory.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/linux/BinarySyftRunnerFactory.cs
@@ -1,0 +1,33 @@
+namespace Microsoft.ComponentDetection.Detectors.Linux;
+
+using Microsoft.ComponentDetection.Contracts;
+using Microsoft.Extensions.Logging;
+
+/// <summary>
+/// Factory for creating <see cref="BinarySyftRunner"/> instances.
+/// </summary>
+internal class BinarySyftRunnerFactory : IBinarySyftRunnerFactory
+{
+    private readonly ICommandLineInvocationService commandLineInvocationService;
+    private readonly ILoggerFactory loggerFactory;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BinarySyftRunnerFactory"/> class.
+    /// </summary>
+    /// <param name="commandLineInvocationService">The command line invocation service.</param>
+    /// <param name="loggerFactory">The logger factory.</param>
+    public BinarySyftRunnerFactory(
+        ICommandLineInvocationService commandLineInvocationService,
+        ILoggerFactory loggerFactory)
+    {
+        this.commandLineInvocationService = commandLineInvocationService;
+        this.loggerFactory = loggerFactory;
+    }
+
+    /// <inheritdoc/>
+    public ISyftRunner Create(string binaryPath) =>
+        new BinarySyftRunner(
+            binaryPath,
+            this.commandLineInvocationService,
+            this.loggerFactory.CreateLogger<BinarySyftRunner>());
+}

--- a/src/Microsoft.ComponentDetection.Detectors/linux/DockerSyftRunner.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/linux/DockerSyftRunner.cs
@@ -62,7 +62,7 @@ internal class DockerSyftRunner : IDockerSyftRunner
         IList<string> arguments,
         CancellationToken cancellationToken = default)
     {
-        var (syftSource, additionalBinds) = GetSyftSourceAndBinds(imageReference);
+        var (syftSourceKind, syftSource, additionalBinds) = GetSyftSourceAndBinds(imageReference);
         var acquired = false;
 
         try
@@ -76,7 +76,7 @@ internal class DockerSyftRunner : IDockerSyftRunner
                 return (string.Empty, string.Empty);
             }
 
-            var command = new List<string> { syftSource }
+            var command = new List<string> { syftSource, ISyftRunner.SyftSourceKindArgument, syftSourceKind }
                 .Concat(arguments)
                 .ToList();
 
@@ -100,16 +100,17 @@ internal class DockerSyftRunner : IDockerSyftRunner
     /// For Docker images, no additional binds are needed. For local images (OCI/archives),
     /// the host path is mounted into the container and the source uses the container-relative path.
     /// </summary>
-    private static (string SyftSource, IList<string> AdditionalBinds) GetSyftSourceAndBinds(ImageReference imageReference)
+    private static (string SyftSourceKind, string SyftSource, IList<string> AdditionalBinds) GetSyftSourceAndBinds(ImageReference imageReference)
     {
         switch (imageReference.Kind)
         {
             case ImageReferenceKind.DockerImage:
-                return (imageReference.Reference, []);
+                return (imageReference.GetSyftSourceKind(), imageReference.Reference, []);
 
             case ImageReferenceKind.OciLayout:
                 return (
-                    $"oci-dir:{LocalImageMountPoint}",
+                    imageReference.GetSyftSourceKind(),
+                    LocalImageMountPoint,
                     [$"{imageReference.Reference}:{LocalImageMountPoint}:ro"]);
 
             case ImageReferenceKind.OciArchive:
@@ -118,7 +119,8 @@ internal class DockerSyftRunner : IDockerSyftRunner
                     ?? throw new InvalidOperationException($"Could not determine parent directory for OCI archive path '{imageReference.Reference}'.");
                 var fileName = Path.GetFileName(imageReference.Reference);
                 return (
-                    $"oci-archive:{LocalImageMountPoint}/{fileName}",
+                    imageReference.GetSyftSourceKind(),
+                    $"{LocalImageMountPoint}/{fileName}",
                     [$"{dir}:{LocalImageMountPoint}:ro"]);
             }
 
@@ -128,14 +130,15 @@ internal class DockerSyftRunner : IDockerSyftRunner
                     ?? throw new InvalidOperationException($"Could not determine parent directory for Docker archive path '{imageReference.Reference}'.");
                 var fileName = Path.GetFileName(imageReference.Reference);
                 return (
-                    $"docker-archive:{LocalImageMountPoint}/{fileName}",
+                    imageReference.GetSyftSourceKind(),
+                    $"{LocalImageMountPoint}/{fileName}",
                     [$"{dir}:{LocalImageMountPoint}:ro"]);
             }
 
             default:
                 throw new ArgumentOutOfRangeException(
                     nameof(imageReference),
-                    $"Unsupported image reference kind '{imageReference.Kind}'.");
+                    $"Unsupported image reference kind '{imageReference.Kind}' for DockerSyft.");
         }
     }
 }

--- a/src/Microsoft.ComponentDetection.Detectors/linux/DockerSyftRunner.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/linux/DockerSyftRunner.cs
@@ -1,0 +1,141 @@
+namespace Microsoft.ComponentDetection.Detectors.Linux;
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.ComponentDetection.Common.Telemetry.Records;
+using Microsoft.ComponentDetection.Contracts;
+using Microsoft.Extensions.Logging;
+
+/// <summary>
+/// Runs Syft by executing a Docker container with the Syft image.
+/// </summary>
+internal class DockerSyftRunner : IDockerSyftRunner
+{
+    internal const string ScannerImage =
+        "governancecontainerregistry.azurecr.io/syft:v1.37.0@sha256:48d679480c6d272c1801cf30460556959c01d4826795be31d4fd8b53750b7d91";
+
+    private const string LocalImageMountPoint = "/image";
+
+    private static readonly SemaphoreSlim ContainerSemaphore = new(2);
+
+    private static readonly int SemaphoreTimeout = Convert.ToInt32(
+        TimeSpan.FromHours(1).TotalMilliseconds);
+
+    private readonly IDockerService dockerService;
+    private readonly ILogger<DockerSyftRunner> logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DockerSyftRunner"/> class.
+    /// </summary>
+    /// <param name="dockerService">The docker service.</param>
+    /// <param name="logger">The logger.</param>
+    public DockerSyftRunner(IDockerService dockerService, ILogger<DockerSyftRunner> logger)
+    {
+        this.dockerService = dockerService;
+        this.logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public async Task<bool> CanRunAsync(CancellationToken cancellationToken = default)
+    {
+        if (await this.dockerService.CanRunLinuxContainersAsync(cancellationToken))
+        {
+            return true;
+        }
+
+        using var record = new LinuxContainerDetectorUnsupportedOs
+        {
+            Os = RuntimeInformation.OSDescription,
+        };
+        this.logger.LogInformation("Linux containers are not available on this host.");
+        return false;
+    }
+
+    /// <inheritdoc/>
+    public async Task<(string Stdout, string Stderr)> RunSyftAsync(
+        ImageReference imageReference,
+        IList<string> arguments,
+        CancellationToken cancellationToken = default)
+    {
+        var (syftSource, additionalBinds) = GetSyftSourceAndBinds(imageReference);
+        var acquired = false;
+
+        try
+        {
+            acquired = await ContainerSemaphore.WaitAsync(SemaphoreTimeout, cancellationToken);
+            if (!acquired)
+            {
+                this.logger.LogWarning(
+                    "Failed to enter the container semaphore for image {ImageReference}",
+                    imageReference.Reference);
+                return (string.Empty, string.Empty);
+            }
+
+            var command = new List<string> { syftSource }
+                .Concat(arguments)
+                .ToList();
+
+            return await this.dockerService.CreateAndRunContainerAsync(
+                ScannerImage,
+                command,
+                additionalBinds,
+                cancellationToken);
+        }
+        finally
+        {
+            if (acquired)
+            {
+                ContainerSemaphore.Release();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Constructs the Syft source argument and any required Docker bind mounts from an image reference.
+    /// For Docker images, no additional binds are needed. For local images (OCI/archives),
+    /// the host path is mounted into the container and the source uses the container-relative path.
+    /// </summary>
+    private static (string SyftSource, IList<string> AdditionalBinds) GetSyftSourceAndBinds(ImageReference imageReference)
+    {
+        switch (imageReference.Kind)
+        {
+            case ImageReferenceKind.DockerImage:
+                return (imageReference.Reference, []);
+
+            case ImageReferenceKind.OciLayout:
+                return (
+                    $"oci-dir:{LocalImageMountPoint}",
+                    [$"{imageReference.Reference}:{LocalImageMountPoint}:ro"]);
+
+            case ImageReferenceKind.OciArchive:
+            {
+                var dir = Path.GetDirectoryName(imageReference.Reference)
+                    ?? throw new InvalidOperationException($"Could not determine parent directory for OCI archive path '{imageReference.Reference}'.");
+                var fileName = Path.GetFileName(imageReference.Reference);
+                return (
+                    $"oci-archive:{LocalImageMountPoint}/{fileName}",
+                    [$"{dir}:{LocalImageMountPoint}:ro"]);
+            }
+
+            case ImageReferenceKind.DockerArchive:
+            {
+                var dir = Path.GetDirectoryName(imageReference.Reference)
+                    ?? throw new InvalidOperationException($"Could not determine parent directory for Docker archive path '{imageReference.Reference}'.");
+                var fileName = Path.GetFileName(imageReference.Reference);
+                return (
+                    $"docker-archive:{LocalImageMountPoint}/{fileName}",
+                    [$"{dir}:{LocalImageMountPoint}:ro"]);
+            }
+
+            default:
+                throw new ArgumentOutOfRangeException(
+                    nameof(imageReference),
+                    $"Unsupported image reference kind '{imageReference.Kind}'.");
+        }
+    }
+}

--- a/src/Microsoft.ComponentDetection.Detectors/linux/IBinarySyftRunnerFactory.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/linux/IBinarySyftRunnerFactory.cs
@@ -1,0 +1,14 @@
+namespace Microsoft.ComponentDetection.Detectors.Linux;
+
+/// <summary>
+/// Factory for creating binary-based Syft runners.
+/// </summary>
+public interface IBinarySyftRunnerFactory
+{
+    /// <summary>
+    /// Creates a binary Syft runner configured to use the specified binary path.
+    /// </summary>
+    /// <param name="binaryPath">The path to the Syft binary.</param>
+    /// <returns>An <see cref="ISyftRunner"/> that invokes the specified Syft binary.</returns>
+    ISyftRunner Create(string binaryPath);
+}

--- a/src/Microsoft.ComponentDetection.Detectors/linux/IDockerSyftRunner.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/linux/IDockerSyftRunner.cs
@@ -1,0 +1,9 @@
+namespace Microsoft.ComponentDetection.Detectors.Linux;
+
+/// <summary>
+/// Marker interface for the Docker-based Syft runner.
+/// Runs Syft by executing a Docker container with the Syft image.
+/// </summary>
+public interface IDockerSyftRunner : ISyftRunner
+{
+}

--- a/src/Microsoft.ComponentDetection.Detectors/linux/ILinuxScanner.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/linux/ILinuxScanner.cs
@@ -16,19 +16,21 @@ public interface ILinuxScanner
     /// Scans a Linux container image for components and maps them to their respective layers.
     /// Runs Syft and processes the output in a single step.
     /// </summary>
-    /// <param name="imageHash">The hash identifier of the container image to scan.</param>
+    /// <param name="imageReference">The image reference to scan.</param>
     /// <param name="containerLayers">The collection of Docker layers that make up the container image.</param>
     /// <param name="baseImageLayerCount">The number of layers that belong to the base image, used to distinguish base image layers from application layers.</param>
     /// <param name="enabledComponentTypes">The set of component types to include in the scan results. Only components matching these types will be returned.</param>
     /// <param name="scope">The scope for scanning the image. See <see cref="LinuxScannerScope"/> for values.</param>
+    /// <param name="syftRunner">The Syft runner to use for executing the scan.</param>
     /// <param name="cancellationToken">A token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains a collection of <see cref="LayerMappedLinuxComponents"/> representing the components found in the image and their associated layers.</returns>
     public Task<IEnumerable<LayerMappedLinuxComponents>> ScanLinuxAsync(
-        string imageHash,
+        ImageReference imageReference,
         IEnumerable<DockerLayer> containerLayers,
         int baseImageLayerCount,
         ISet<ComponentType> enabledComponentTypes,
         LinuxScannerScope scope,
+        ISyftRunner syftRunner,
         CancellationToken cancellationToken = default
     );
 
@@ -36,15 +38,15 @@ public interface ILinuxScanner
     /// Runs the Syft scanner and returns the raw parsed output without processing components.
     /// Use this when the caller needs access to the full Syft output (e.g., to extract source metadata for OCI images).
     /// </summary>
-    /// <param name="syftSource">The source argument passed to Syft (e.g., an image hash or "oci-dir:/oci-image").</param>
-    /// <param name="additionalBinds">Additional volume bind mounts for the Syft container (e.g., for mounting OCI directories).</param>
+    /// <param name="imageReference">The image reference to scan.</param>
     /// <param name="scope">The scope for scanning the image.</param>
+    /// <param name="syftRunner">The Syft runner to use for executing the scan.</param>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains the parsed <see cref="SyftOutput"/>.</returns>
     public Task<SyftOutput> GetSyftOutputAsync(
-        string syftSource,
-        IList<string> additionalBinds,
+        ImageReference imageReference,
         LinuxScannerScope scope,
+        ISyftRunner syftRunner,
         CancellationToken cancellationToken = default
     );
 

--- a/src/Microsoft.ComponentDetection.Detectors/linux/ISyftRunner.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/linux/ISyftRunner.cs
@@ -10,6 +10,8 @@ using System.Threading.Tasks;
 /// </summary>
 public interface ISyftRunner
 {
+    internal const string SyftSourceKindArgument = "--from";
+
     /// <summary>
     /// Checks whether this runner is able to execute Syft scans in the current environment.
     /// </summary>

--- a/src/Microsoft.ComponentDetection.Detectors/linux/ISyftRunner.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/linux/ISyftRunner.cs
@@ -1,0 +1,31 @@
+namespace Microsoft.ComponentDetection.Detectors.Linux;
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+/// <summary>
+/// Interface for executing Syft scans against container images.
+/// Implementations may invoke Syft via Docker container or as a local binary.
+/// </summary>
+public interface ISyftRunner
+{
+    /// <summary>
+    /// Checks whether this runner is able to execute Syft scans in the current environment.
+    /// </summary>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>True if the runner is ready to execute scans, false otherwise.</returns>
+    Task<bool> CanRunAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Runs Syft against a container image and returns the raw output.
+    /// </summary>
+    /// <param name="imageReference">The image reference to scan. Each runner implementation handles this differently based on the image kind.</param>
+    /// <param name="arguments">The command-line arguments to pass to Syft (e.g., --quiet, --output json, --scope).</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>A tuple containing the standard output and standard error from the Syft execution.</returns>
+    Task<(string Stdout, string Stderr)> RunSyftAsync(
+        ImageReference imageReference,
+        IList<string> arguments,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Microsoft.ComponentDetection.Detectors/linux/ImageReference.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/linux/ImageReference.cs
@@ -117,4 +117,24 @@ public class ImageReference
         };
 #pragma warning restore CA1308
     }
+
+    /// <summary>
+    /// Gets the Syft source kind string corresponding to this image reference, which is used in Syft's --from argument.
+    /// See https://oss.anchore.com/docs/guides/sbom/scan-targets/ for details.
+    /// </summary>
+    /// <returns>The Syft source kind string.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">If an unsupported image reference kind is encountered.</exception>
+    public string GetSyftSourceKind()
+    {
+        return this.Kind switch
+        {
+            ImageReferenceKind.DockerImage => "docker",
+            ImageReferenceKind.OciLayout => "oci-dir",
+            ImageReferenceKind.OciArchive => "oci-archive",
+            ImageReferenceKind.DockerArchive => "docker-archive",
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(this.Kind),
+                $"Unsupported image reference kind '{this.Kind}'."),
+        };
+    }
 }

--- a/src/Microsoft.ComponentDetection.Detectors/linux/ImageReference.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/linux/ImageReference.cs
@@ -5,7 +5,7 @@ using System;
 /// <summary>
 /// Specifies the type of image reference.
 /// </summary>
-internal enum ImageReferenceKind
+public enum ImageReferenceKind
 {
     /// <summary>
     /// A Docker image reference (e.g., "node:latest", "sha256:abc123").
@@ -31,7 +31,7 @@ internal enum ImageReferenceKind
 /// <summary>
 /// Represents a parsed image reference from the scan input, with its type and cleaned reference string.
 /// </summary>
-internal class ImageReference
+public class ImageReference
 {
     private const string OciDirPrefix = "oci-dir:";
     private const string OciArchivePrefix = "oci-archive:";

--- a/src/Microsoft.ComponentDetection.Detectors/linux/LinuxApplicationLayerDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/linux/LinuxApplicationLayerDetector.cs
@@ -12,13 +12,17 @@ using Microsoft.Extensions.Logging;
 /// Linux detector (which only scans system packages).
 /// </summary>
 /// <param name="linuxScanner">The Linux scanner service.</param>
+/// <param name="dockerSyftRunner">The Docker-based Syft runner.</param>
+/// <param name="binarySyftRunnerFactory">The factory for creating binary Syft runners.</param>
 /// <param name="dockerService">The Docker service.</param>
 /// <param name="logger">The logger.</param>
 public class LinuxApplicationLayerDetector(
     ILinuxScanner linuxScanner,
+    IDockerSyftRunner dockerSyftRunner,
+    IBinarySyftRunnerFactory binarySyftRunnerFactory,
     IDockerService dockerService,
     ILogger<LinuxApplicationLayerDetector> logger
-) : LinuxContainerDetector(linuxScanner, dockerService, logger), IExperimentalDetector
+) : LinuxContainerDetector(linuxScanner, dockerSyftRunner, binarySyftRunnerFactory, dockerService, logger), IExperimentalDetector
 {
     /// <inheritdoc/>
     public new string Id => "LinuxApplicationLayer";

--- a/src/Microsoft.ComponentDetection.Detectors/linux/LinuxContainerDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/linux/LinuxContainerDetector.cs
@@ -5,7 +5,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.ComponentDetection.Common.Exceptions;
@@ -22,6 +21,8 @@ using Microsoft.Extensions.Logging;
 /// </summary>
 public class LinuxContainerDetector(
     ILinuxScanner linuxScanner,
+    IDockerSyftRunner dockerSyftRunner,
+    IBinarySyftRunnerFactory binarySyftRunnerFactory,
     IDockerService dockerService,
     ILogger<LinuxContainerDetector> logger
 ) : IComponentDetector
@@ -31,13 +32,15 @@ public class LinuxContainerDetector(
     private const string ScanScopeConfigKey = "Linux.ImageScanScope";
     private const LinuxScannerScope DefaultScanScope = LinuxScannerScope.AllLayers;
 
-    private const string LocalImageMountPoint = "/image";
+    private const string SyftBinaryPathConfigKey = "Linux.SyftBinaryPath";
 
     // Base image annotations from ADO dockerTask
     private const string BaseImageRefAnnotation = "image.base.ref.name";
     private const string BaseImageDigestAnnotation = "image.base.digest";
 
     private readonly ILinuxScanner linuxScanner = linuxScanner;
+    private readonly IDockerSyftRunner dockerSyftRunner = dockerSyftRunner;
+    private readonly IBinarySyftRunnerFactory binarySyftRunnerFactory = binarySyftRunnerFactory;
     private readonly IDockerService dockerService = dockerService;
     private readonly ILogger<LinuxContainerDetector> logger = logger;
 
@@ -95,17 +98,14 @@ public class LinuxContainerDetector(
         }
 
         var scannerScope = GetScanScope(request.DetectorArgs);
+        var syftRunner = this.GetSyftRunner(request.DetectorArgs);
 
         using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         timeoutCts.CancelAfter(GetTimeout(request.DetectorArgs));
 
-        if (!await this.dockerService.CanRunLinuxContainersAsync(timeoutCts.Token))
+        if (!await syftRunner.CanRunAsync(timeoutCts.Token))
         {
-            using var record = new LinuxContainerDetectorUnsupportedOs
-            {
-                Os = RuntimeInformation.OSDescription,
-            };
-            this.logger.LogInformation("Linux containers are not available on this host.");
+            this.logger.LogInformation("Syft scanner is not available. Skipping Linux container scanning.");
             return EmptySuccessfulScan();
         }
 
@@ -116,6 +116,7 @@ public class LinuxContainerDetector(
                 allImages,
                 request.ComponentRecorder,
                 scannerScope,
+                syftRunner,
                 timeoutCts.Token
             );
         }
@@ -143,7 +144,7 @@ public class LinuxContainerDetector(
     /// </summary>
     /// <param name="detectorArgs">The arguments provided by the user.</param>
     /// <returns> Time interval <see cref="TimeSpan"/> representing the timeout defined by the user, or a default value if one is not provided. </returns>
-    private static TimeSpan GetTimeout(IDictionary<string, string> detectorArgs)
+    private static TimeSpan GetTimeout(IDictionary<string, string>? detectorArgs)
     {
         var defaultTimeout = TimeSpan.FromMinutes(DefaultTimeoutMinutes);
 
@@ -219,10 +220,35 @@ public class LinuxContainerDetector(
         };
     }
 
+    /// <summary>
+    /// Gets the appropriate Syft runner based on detector arguments.
+    /// When <c>Linux.SyftBinaryPath</c> is provided, returns a binary runner via the factory;
+    /// otherwise returns the default Docker-based runner.
+    /// </summary>
+    /// <param name="detectorArgs">The arguments provided by the user.</param>
+    /// <returns>An <see cref="ISyftRunner"/> to use for scanning.</returns>
+    private ISyftRunner GetSyftRunner(IDictionary<string, string> detectorArgs)
+    {
+        if (
+            detectorArgs != null
+            && detectorArgs.TryGetValue(SyftBinaryPathConfigKey, out var syftBinaryPath)
+            && !string.IsNullOrWhiteSpace(syftBinaryPath)
+        )
+        {
+            this.logger.LogInformation(
+                "Using Syft binary at {SyftBinaryPath} for Linux container scanning",
+                syftBinaryPath);
+            return this.binarySyftRunnerFactory.Create(syftBinaryPath);
+        }
+
+        return this.dockerSyftRunner;
+    }
+
     private async Task<IEnumerable<ImageScanningResult>> ProcessImagesAsync(
         IEnumerable<ImageReference> imageReferences,
         IComponentRecorder componentRecorder,
         LinuxScannerScope scannerScope,
+        ISyftRunner syftRunner,
         CancellationToken cancellationToken = default
     )
     {
@@ -232,7 +258,7 @@ public class LinuxContainerDetector(
         var processedDockerImages = new ConcurrentDictionary<string, ContainerDetails>();
 
         // Local images will be validated for existence and tracked by their file path.
-        var localImages = new ConcurrentDictionary<string, ImageReferenceKind>();
+        var localImages = new ConcurrentDictionary<string, ImageReference>();
 
         var resolveTasks = imageReferences.Select(imageRef =>
             this.ResolveImageAsync(imageRef, processedDockerImages, localImages, componentRecorder, cancellationToken));
@@ -243,11 +269,11 @@ public class LinuxContainerDetector(
         var scanTasks = new List<Task<ImageScanningResult>>();
 
         scanTasks.AddRange(processedDockerImages.Select(kvp =>
-            this.ScanDockerImageAsync(kvp.Key, kvp.Value, scannerScope, componentRecorder, cancellationToken)));
+            this.ScanDockerImageAsync(kvp.Key, kvp.Value, scannerScope, syftRunner, componentRecorder, cancellationToken)));
 
         scanTasks.AddRange(localImages
             .Select(kvp =>
-                this.ScanLocalImageAsync(kvp.Key, kvp.Value, scannerScope, componentRecorder, cancellationToken)));
+                this.ScanLocalImageAsync(kvp.Value, scannerScope, syftRunner, componentRecorder, cancellationToken)));
 
         return await Task.WhenAll(scanTasks);
     }
@@ -262,7 +288,7 @@ public class LinuxContainerDetector(
     private async Task ResolveImageAsync(
         ImageReference imageRef,
         ConcurrentDictionary<string, ContainerDetails> resolvedDockerImages,
-        ConcurrentDictionary<string, ImageReferenceKind> localImages,
+        ConcurrentDictionary<string, ImageReference> localImages,
         IComponentRecorder componentRecorder,
         CancellationToken cancellationToken)
     {
@@ -277,7 +303,13 @@ public class LinuxContainerDetector(
                 case ImageReferenceKind.OciArchive:
                 case ImageReferenceKind.DockerArchive:
                     var fullPath = this.ValidateLocalImagePath(imageRef);
-                    localImages.TryAdd(fullPath, imageRef.Kind);
+                    var resolvedRef = new ImageReference
+                    {
+                        OriginalInput = imageRef.OriginalInput,
+                        Reference = fullPath,
+                        Kind = imageRef.Kind,
+                    };
+                    localImages.TryAdd(fullPath, resolvedRef);
                     break;
                 default:
                     throw new InvalidUserInputException(
@@ -355,6 +387,7 @@ public class LinuxContainerDetector(
         string imageId,
         ContainerDetails containerDetails,
         LinuxScannerScope scannerScope,
+        ISyftRunner syftRunner,
         IComponentRecorder componentRecorder,
         CancellationToken cancellationToken)
     {
@@ -377,14 +410,21 @@ public class LinuxContainerDetector(
             ).ToList();
 
             var enabledComponentTypes = this.GetEnabledComponentTypes();
+            var dockerImageRef = new ImageReference
+            {
+                OriginalInput = containerDetails.ImageId,
+                Reference = containerDetails.ImageId,
+                Kind = ImageReferenceKind.DockerImage,
+            };
             var layers = await this.linuxScanner.ScanLinuxAsync(
-                containerDetails.ImageId,
+                dockerImageRef,
                 containerDetails.Layers,
                 baseImageLayerCount,
                 enabledComponentTypes,
                 scannerScope,
-                cancellationToken
-            ) ?? throw new InvalidOperationException($"Failed to scan image layers for image {containerDetails.ImageId}");
+                syftRunner,
+                cancellationToken)
+                ?? throw new InvalidOperationException($"Failed to scan image layers for image {containerDetails.ImageId}");
 
             return this.RecordComponents(containerDetails, layers, componentRecorder);
         }
@@ -402,54 +442,25 @@ public class LinuxContainerDetector(
     }
 
     /// <summary>
-    /// Scans a local image (OCI layout directory or archive file) by invoking Syft with a volume
-    /// mount, extracting metadata from the Syft output to build ContainerDetails, and processing
+    /// Scans a local image (OCI layout directory or archive file) by invoking Syft,
+    /// extracting metadata from the Syft output to build ContainerDetails, and processing
     /// detected components.
     /// </summary>
     private async Task<ImageScanningResult> ScanLocalImageAsync(
-        string localImagePath,
-        ImageReferenceKind imageRefKind,
+        ImageReference imageReference,
         LinuxScannerScope scannerScope,
+        ISyftRunner syftRunner,
         IComponentRecorder componentRecorder,
         CancellationToken cancellationToken)
     {
-        string hostPathToBind;
-        string syftContainerPath;
-        switch (imageRefKind)
-        {
-            case ImageReferenceKind.OciLayout:
-                hostPathToBind = localImagePath;
-                syftContainerPath = $"oci-dir:{LocalImageMountPoint}";
-                break;
-            case ImageReferenceKind.OciArchive:
-                hostPathToBind = Path.GetDirectoryName(localImagePath)
-                    ?? throw new InvalidOperationException($"Could not determine parent directory for OCI archive path '{localImagePath}'.");
-                syftContainerPath = $"oci-archive:{LocalImageMountPoint}/{Path.GetFileName(localImagePath)}";
-                break;
-            case ImageReferenceKind.DockerArchive:
-                hostPathToBind = Path.GetDirectoryName(localImagePath)
-                    ?? throw new InvalidOperationException($"Could not determine parent directory for Docker archive path '{localImagePath}'.");
-                syftContainerPath = $"docker-archive:{LocalImageMountPoint}/{Path.GetFileName(localImagePath)}";
-                break;
-            case ImageReferenceKind.DockerImage:
-            default:
-                throw new InvalidUserInputException(
-                    $"Unsupported image reference kind '{imageRefKind}' for local image at path '{localImagePath}'."
-                );
-        }
+        var localImagePath = imageReference.Reference;
 
         try
         {
-            var additionalBinds = new List<string>
-            {
-                // Bind the local image path into the Syft container as read-only
-                $"{hostPathToBind}:{LocalImageMountPoint}:ro",
-            };
-
             var syftOutput = await this.linuxScanner.GetSyftOutputAsync(
-                syftContainerPath,
-                additionalBinds,
+                imageReference,
                 scannerScope,
+                syftRunner,
                 cancellationToken
             );
 

--- a/src/Microsoft.ComponentDetection.Detectors/linux/LinuxScanner.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/linux/LinuxScanner.cs
@@ -7,7 +7,6 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.ComponentDetection.Common.Telemetry.Records;
-using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Contracts.BcdeModels;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.ComponentDetection.Detectors.Linux.Contracts;
@@ -20,22 +19,12 @@ using Microsoft.Extensions.Logging;
 /// </summary>
 internal class LinuxScanner : ILinuxScanner
 {
-    private const string ScannerImage =
-        "governancecontainerregistry.azurecr.io/syft:v1.37.0@sha256:48d679480c6d272c1801cf30460556959c01d4826795be31d4fd8b53750b7d91";
-
     private static readonly IList<string> CmdParameters = ["--quiet", "--output", "json"];
 
     private static readonly IList<string> ScopeAllLayersParameter = ["--scope", "all-layers"];
 
     private static readonly IList<string> ScopeSquashedParameter = ["--scope", "squashed"];
 
-    private static readonly SemaphoreSlim ContainerSemaphore = new SemaphoreSlim(2);
-
-    private static readonly int SemaphoreTimeout = Convert.ToInt32(
-        TimeSpan.FromHours(1).TotalMilliseconds
-    );
-
-    private readonly IDockerService dockerService;
     private readonly ILogger<LinuxScanner> logger;
     private readonly IEnumerable<IArtifactComponentFactory> componentFactories;
     private readonly IEnumerable<IArtifactFilter> artifactFilters;
@@ -48,18 +37,15 @@ internal class LinuxScanner : ILinuxScanner
     /// <summary>
     /// Initializes a new instance of the <see cref="LinuxScanner"/> class.
     /// </summary>
-    /// <param name="dockerService">The docker service.</param>
     /// <param name="logger">The logger.</param>
     /// <param name="componentFactories">The component factories.</param>
     /// <param name="artifactFilters">The artifact filters.</param>
     public LinuxScanner(
-        IDockerService dockerService,
         ILogger<LinuxScanner> logger,
         IEnumerable<IArtifactComponentFactory> componentFactories,
         IEnumerable<IArtifactFilter> artifactFilters
     )
     {
-        this.dockerService = dockerService;
         this.logger = logger;
         this.componentFactories = componentFactories;
         this.artifactFilters = artifactFilters;
@@ -79,21 +65,22 @@ internal class LinuxScanner : ILinuxScanner
 
     /// <inheritdoc/>
     public async Task<IEnumerable<LayerMappedLinuxComponents>> ScanLinuxAsync(
-        string imageHash,
+        ImageReference imageReference,
         IEnumerable<DockerLayer> containerLayers,
         int baseImageLayerCount,
         ISet<ComponentType> enabledComponentTypes,
         LinuxScannerScope scope,
+        ISyftRunner syftRunner,
         CancellationToken cancellationToken = default
     )
     {
         using var record = new LinuxScannerTelemetryRecord
         {
-            ImageToScan = imageHash,
-            ScannerVersion = ScannerImage,
+            ImageToScan = imageReference.Reference,
+            ScannerVersion = DockerSyftRunner.ScannerImage,
         };
         using var syftTelemetryRecord = new LinuxScannerSyftTelemetryRecord();
-        var stdout = await this.RunSyftAsync(imageHash, scope, additionalBinds: [], record, syftTelemetryRecord, cancellationToken);
+        var stdout = await this.RunSyftAsync(imageReference, scope, syftRunner, record, syftTelemetryRecord, cancellationToken);
 
         try
         {
@@ -103,26 +90,26 @@ internal class LinuxScanner : ILinuxScanner
         catch (Exception e)
         {
             record.FailedDeserializingScannerOutput = e.ToString();
-            this.logger.LogError(e, "Failed to deserialize Syft output for image {ImageHash}", imageHash);
+            this.logger.LogError(e, "Failed to deserialize Syft output for image {ImageReference}", imageReference.Reference);
             return [];
         }
     }
 
     /// <inheritdoc/>
     public async Task<SyftOutput> GetSyftOutputAsync(
-        string syftSource,
-        IList<string> additionalBinds,
+        ImageReference imageReference,
         LinuxScannerScope scope,
+        ISyftRunner syftRunner,
         CancellationToken cancellationToken = default
     )
     {
         using var record = new LinuxScannerTelemetryRecord
         {
-            ImageToScan = syftSource,
-            ScannerVersion = ScannerImage,
+            ImageToScan = imageReference.Reference,
+            ScannerVersion = DockerSyftRunner.ScannerImage,
         };
         using var syftTelemetryRecord = new LinuxScannerSyftTelemetryRecord();
-        var stdout = await this.RunSyftAsync(syftSource, scope, additionalBinds, record, syftTelemetryRecord, cancellationToken);
+        var stdout = await this.RunSyftAsync(imageReference, scope, syftRunner, record, syftTelemetryRecord, cancellationToken);
         try
         {
             return SyftOutput.FromJson(stdout);
@@ -130,7 +117,7 @@ internal class LinuxScanner : ILinuxScanner
         catch (Exception e)
         {
             record.FailedDeserializingScannerOutput = e.ToString();
-            this.logger.LogError(e, "Failed to deserialize Syft output for source {SyftSource}", syftSource);
+            this.logger.LogError(e, "Failed to deserialize Syft output for source {ImageReference}", imageReference.Reference);
             throw;
         }
     }
@@ -252,17 +239,16 @@ internal class LinuxScanner : ILinuxScanner
     }
 
     /// <summary>
-    /// Runs the Syft scanner container and returns the stdout output.
+    /// Runs the Syft scanner and returns the stdout output.
     /// </summary>
     private async Task<string> RunSyftAsync(
-        string syftSource,
+        ImageReference imageReference,
         LinuxScannerScope scope,
-        IList<string> additionalBinds,
+        ISyftRunner syftRunner,
         LinuxScannerTelemetryRecord record,
         LinuxScannerSyftTelemetryRecord syftTelemetryRecord,
         CancellationToken cancellationToken)
     {
-        var acquired = false;
         var stdout = string.Empty;
         var stderr = string.Empty;
 
@@ -278,44 +264,20 @@ internal class LinuxScanner : ILinuxScanner
 
         try
         {
-            acquired = await ContainerSemaphore.WaitAsync(SemaphoreTimeout, cancellationToken);
-            if (acquired)
-            {
-                try
-                {
-                    var command = new List<string> { syftSource }
-                        .Concat(CmdParameters)
-                        .Concat(scopeParameters)
-                        .ToList();
-                    (stdout, stderr) = await this.dockerService.CreateAndRunContainerAsync(
-                        ScannerImage,
-                        command,
-                        additionalBinds,
-                        cancellationToken
-                    );
-                }
-                catch (Exception e)
-                {
-                    syftTelemetryRecord.Exception = JsonSerializer.Serialize(e);
-                    this.logger.LogError(e, "Failed to run syft");
-                    throw;
-                }
-            }
-            else
-            {
-                record.SemaphoreFailure = true;
-                this.logger.LogWarning(
-                    "Failed to enter the container semaphore for image {SyftSource}",
-                    syftSource
-                );
-            }
+            var arguments = CmdParameters
+                .Concat(scopeParameters)
+                .ToList();
+            (stdout, stderr) = await syftRunner.RunSyftAsync(
+                imageReference,
+                arguments,
+                cancellationToken
+            );
         }
-        finally
+        catch (Exception e)
         {
-            if (acquired)
-            {
-                ContainerSemaphore.Release();
-            }
+            syftTelemetryRecord.Exception = JsonSerializer.Serialize(e);
+            this.logger.LogError(e, "Failed to run syft");
+            throw;
         }
 
         record.ScanStdErr = stderr;

--- a/src/Microsoft.ComponentDetection.Orchestrator/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Extensions/ServiceCollectionExtensions.cs
@@ -43,6 +43,7 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddComponentDetection(this IServiceCollection services)
     {
         // Shared services
+        services.AddLogging();
         services.AddSingleton<ITelemetryService, CommandLineTelemetryService>();
         services.AddSingleton<ICommandLineInvocationService, CommandLineInvocationService>();
         services.AddSingleton<IComponentStreamEnumerableFactory, ComponentStreamEnumerableFactory>();
@@ -102,6 +103,8 @@ public static class ServiceCollectionExtensions
 
         // Linux
         services.AddSingleton<ILinuxScanner, LinuxScanner>();
+        services.AddSingleton<IDockerSyftRunner, DockerSyftRunner>();
+        services.AddSingleton<IBinarySyftRunnerFactory, BinarySyftRunnerFactory>();
         services.AddSingleton<IArtifactComponentFactory, LinuxComponentFactory>();
         services.AddSingleton<IArtifactComponentFactory, NpmComponentFactory>();
         services.AddSingleton<IArtifactComponentFactory, PipComponentFactory>();

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/BinarySyftRunnerTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/BinarySyftRunnerTests.cs
@@ -25,13 +25,20 @@ public class BinarySyftRunnerTests
     }
 
     [TestMethod]
-    public async Task CanRunAsync_ReturnsTrueWhenVersionCheckSucceeds()
+    public async Task CanRunAsync_ReturnsTrueWhenBinaryExistsAndVersionCheckSucceeds()
     {
+        this.mockCommandLineService.Setup(service =>
+                service.CanCommandBeLocatedAsync(
+                    "/usr/local/bin/syft",
+                    null,
+                    "--version"))
+            .ReturnsAsync(true);
+
         this.mockCommandLineService.Setup(service =>
                 service.ExecuteCommandAsync(
                     "/usr/local/bin/syft",
-                    It.IsAny<IEnumerable<string>>(),
-                    It.IsAny<System.IO.DirectoryInfo>(),
+                    null,
+                    null,
                     It.IsAny<CancellationToken>(),
                     "--version"))
             .ReturnsAsync(new CommandLineExecutionResult
@@ -52,13 +59,40 @@ public class BinarySyftRunnerTests
     }
 
     [TestMethod]
+    public async Task CanRunAsync_ReturnsFalseWhenBinaryNotFound()
+    {
+        this.mockCommandLineService.Setup(service =>
+                service.CanCommandBeLocatedAsync(
+                    "/nonexistent/syft",
+                    null,
+                    "--version"))
+            .ReturnsAsync(false);
+
+        var runner = new BinarySyftRunner(
+            "/nonexistent/syft",
+            this.mockCommandLineService.Object,
+            this.mockLogger.Object);
+
+        var result = await runner.CanRunAsync();
+
+        result.Should().BeFalse();
+    }
+
+    [TestMethod]
     public async Task CanRunAsync_ReturnsFalseWhenVersionCheckFails()
     {
         this.mockCommandLineService.Setup(service =>
+                service.CanCommandBeLocatedAsync(
+                    "/usr/local/bin/syft",
+                    null,
+                    "--version"))
+            .ReturnsAsync(true);
+
+        this.mockCommandLineService.Setup(service =>
                 service.ExecuteCommandAsync(
                     "/usr/local/bin/syft",
-                    It.IsAny<IEnumerable<string>>(),
-                    It.IsAny<System.IO.DirectoryInfo>(),
+                    null,
+                    null,
                     It.IsAny<CancellationToken>(),
                     "--version"))
             .ReturnsAsync(new CommandLineExecutionResult

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/BinarySyftRunnerTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/BinarySyftRunnerTests.cs
@@ -149,13 +149,15 @@ public class BinarySyftRunnerTests
                 null,
                 It.IsAny<CancellationToken>(),
                 It.Is<string[]>(args =>
-                    args.Length == 6
+                    args.Length == 8
                     && args[0] == "fake_hash"
-                    && args[1] == "--quiet"
-                    && args[2] == "--output"
-                    && args[3] == "json"
-                    && args[4] == "--scope"
-                    && args[5] == "all-layers")),
+                    && args[1] == "--from"
+                    && args[2] == "docker"
+                    && args[3] == "--quiet"
+                    && args[4] == "--output"
+                    && args[5] == "json"
+                    && args[6] == "--scope"
+                    && args[7] == "all-layers")),
             Times.Once);
     }
 
@@ -227,14 +229,15 @@ public class BinarySyftRunnerTests
     }
 
     [TestMethod]
-    [DataRow(ImageReferenceKind.OciLayout, "/path/to/oci", "oci-dir:/path/to/oci")]
-    [DataRow(ImageReferenceKind.OciArchive, "/path/to/image.tar", "oci-archive:/path/to/image.tar")]
-    [DataRow(ImageReferenceKind.DockerArchive, "/path/to/save.tar", "docker-archive:/path/to/save.tar")]
-    [DataRow(ImageReferenceKind.DockerImage, "ubuntu:22.04", "ubuntu:22.04")]
+    [DataRow(ImageReferenceKind.OciLayout, "/path/to/oci", "/path/to/oci", "oci-dir")]
+    [DataRow(ImageReferenceKind.OciArchive, "/path/to/image.tar", "/path/to/image.tar", "oci-archive")]
+    [DataRow(ImageReferenceKind.DockerArchive, "/path/to/save.tar", "/path/to/save.tar", "docker-archive")]
+    [DataRow(ImageReferenceKind.DockerImage, "ubuntu:22.04", "ubuntu:22.04", "docker")]
     public async Task RunSyftAsync_ConstructsCorrectSourceForImageKind(
         ImageReferenceKind kind,
         string reference,
-        string expectedSource)
+        string expectedSource,
+        string expectedSourceKind)
     {
         this.mockCommandLineService.Setup(service =>
                 service.ExecuteCommandAsync(
@@ -270,7 +273,7 @@ public class BinarySyftRunnerTests
                 null,
                 null,
                 It.IsAny<CancellationToken>(),
-                It.Is<string[]>(args => args[0] == expectedSource)),
+                It.Is<string[]>(args => args[0] == expectedSource && args[1] == "--from" && args[2] == expectedSourceKind)),
             Times.Once);
     }
 }

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/BinarySyftRunnerTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/BinarySyftRunnerTests.cs
@@ -1,0 +1,242 @@
+namespace Microsoft.ComponentDetection.Detectors.Tests;
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using AwesomeAssertions;
+using Microsoft.ComponentDetection.Contracts;
+using Microsoft.ComponentDetection.Detectors.Linux;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+[TestClass]
+[TestCategory("Governance/All")]
+[TestCategory("Governance/ComponentDetection")]
+public class BinarySyftRunnerTests
+{
+    private readonly Mock<ICommandLineInvocationService> mockCommandLineService;
+    private readonly Mock<ILogger<BinarySyftRunner>> mockLogger;
+
+    public BinarySyftRunnerTests()
+    {
+        this.mockCommandLineService = new Mock<ICommandLineInvocationService>();
+        this.mockLogger = new Mock<ILogger<BinarySyftRunner>>();
+    }
+
+    [TestMethod]
+    public async Task CanRunAsync_ReturnsTrueWhenVersionCheckSucceeds()
+    {
+        this.mockCommandLineService.Setup(service =>
+                service.ExecuteCommandAsync(
+                    "/usr/local/bin/syft",
+                    It.IsAny<IEnumerable<string>>(),
+                    It.IsAny<System.IO.DirectoryInfo>(),
+                    It.IsAny<CancellationToken>(),
+                    "--version"))
+            .ReturnsAsync(new CommandLineExecutionResult
+            {
+                StdOut = "syft 1.37.0",
+                StdErr = string.Empty,
+                ExitCode = 0,
+            });
+
+        var runner = new BinarySyftRunner(
+            "/usr/local/bin/syft",
+            this.mockCommandLineService.Object,
+            this.mockLogger.Object);
+
+        var result = await runner.CanRunAsync();
+
+        result.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public async Task CanRunAsync_ReturnsFalseWhenVersionCheckFails()
+    {
+        this.mockCommandLineService.Setup(service =>
+                service.ExecuteCommandAsync(
+                    "/usr/local/bin/syft",
+                    It.IsAny<IEnumerable<string>>(),
+                    It.IsAny<System.IO.DirectoryInfo>(),
+                    It.IsAny<CancellationToken>(),
+                    "--version"))
+            .ReturnsAsync(new CommandLineExecutionResult
+            {
+                StdOut = string.Empty,
+                StdErr = "not a valid syft binary",
+                ExitCode = 1,
+            });
+
+        var runner = new BinarySyftRunner(
+            "/usr/local/bin/syft",
+            this.mockCommandLineService.Object,
+            this.mockLogger.Object);
+
+        var result = await runner.CanRunAsync();
+
+        result.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public async Task RunSyftAsync_ConstructsCorrectCommandLine()
+    {
+        var expectedOutput = """{"artifacts":[],"distro":{"id":"ubuntu","versionID":"22.04"}}""";
+        this.mockCommandLineService.Setup(service =>
+                service.ExecuteCommandAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<IEnumerable<string>>(),
+                    It.IsAny<System.IO.DirectoryInfo>(),
+                    It.IsAny<CancellationToken>(),
+                    It.IsAny<string[]>()))
+            .ReturnsAsync(new CommandLineExecutionResult
+            {
+                StdOut = expectedOutput,
+                StdErr = string.Empty,
+                ExitCode = 0,
+            });
+
+        var runner = new BinarySyftRunner(
+            "/usr/local/bin/syft",
+            this.mockCommandLineService.Object,
+            this.mockLogger.Object);
+
+        var (stdout, stderr) = await runner.RunSyftAsync(
+            new ImageReference { OriginalInput = "fake_hash", Reference = "fake_hash", Kind = ImageReferenceKind.DockerImage },
+            ["--quiet", "--output", "json", "--scope", "all-layers"]);
+
+        stdout.Should().Be(expectedOutput);
+        stderr.Should().BeEmpty();
+
+        this.mockCommandLineService.Verify(
+            service => service.ExecuteCommandAsync(
+                "/usr/local/bin/syft",
+                null,
+                null,
+                It.IsAny<CancellationToken>(),
+                It.Is<string[]>(args =>
+                    args.Length == 6
+                    && args[0] == "fake_hash"
+                    && args[1] == "--quiet"
+                    && args[2] == "--output"
+                    && args[3] == "json"
+                    && args[4] == "--scope"
+                    && args[5] == "all-layers")),
+            Times.Once);
+    }
+
+    [TestMethod]
+    public async Task RunSyftAsync_NonZeroExitCode_LogsErrorAndReturnsOutput()
+    {
+        this.mockCommandLineService.Setup(service =>
+                service.ExecuteCommandAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<IEnumerable<string>>(),
+                    It.IsAny<System.IO.DirectoryInfo>(),
+                    It.IsAny<CancellationToken>(),
+                    It.IsAny<string[]>()))
+            .ReturnsAsync(new CommandLineExecutionResult
+            {
+                StdOut = string.Empty,
+                StdErr = "error: image not found",
+                ExitCode = 1,
+            });
+
+        var runner = new BinarySyftRunner(
+            "/usr/local/bin/syft",
+            this.mockCommandLineService.Object,
+            this.mockLogger.Object);
+
+        var (stdout, stderr) = await runner.RunSyftAsync(
+            new ImageReference { OriginalInput = "fake_hash", Reference = "fake_hash", Kind = ImageReferenceKind.DockerImage },
+            ["--quiet", "--output", "json"]);
+
+        stdout.Should().BeEmpty();
+        stderr.Should().Be("error: image not found");
+
+        this.mockLogger.Verify(
+            logger => logger.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<System.Exception>(),
+                (System.Func<It.IsAnyType, System.Exception?, string>)It.IsAny<object>()),
+            Times.Once);
+    }
+
+    [TestMethod]
+    public async Task RunSyftAsync_CancellationToken_PropagatedToCommand()
+    {
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        this.mockCommandLineService.Setup(service =>
+                service.ExecuteCommandAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<IEnumerable<string>>(),
+                    It.IsAny<System.IO.DirectoryInfo>(),
+                    cts.Token,
+                    It.IsAny<string[]>()))
+            .ThrowsAsync(new System.OperationCanceledException());
+
+        var runner = new BinarySyftRunner(
+            "/usr/local/bin/syft",
+            this.mockCommandLineService.Object,
+            this.mockLogger.Object);
+
+        System.Func<Task> action = async () => await runner.RunSyftAsync(
+            new ImageReference { OriginalInput = "fake_hash", Reference = "fake_hash", Kind = ImageReferenceKind.DockerImage },
+            ["--quiet", "--output", "json"],
+            cts.Token);
+
+        await action.Should().ThrowAsync<System.OperationCanceledException>();
+    }
+
+    [TestMethod]
+    [DataRow(ImageReferenceKind.OciLayout, "/path/to/oci", "oci-dir:/path/to/oci")]
+    [DataRow(ImageReferenceKind.OciArchive, "/path/to/image.tar", "oci-archive:/path/to/image.tar")]
+    [DataRow(ImageReferenceKind.DockerArchive, "/path/to/save.tar", "docker-archive:/path/to/save.tar")]
+    [DataRow(ImageReferenceKind.DockerImage, "ubuntu:22.04", "ubuntu:22.04")]
+    public async Task RunSyftAsync_ConstructsCorrectSourceForImageKind(
+        ImageReferenceKind kind,
+        string reference,
+        string expectedSource)
+    {
+        this.mockCommandLineService.Setup(service =>
+                service.ExecuteCommandAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<IEnumerable<string>>(),
+                    It.IsAny<System.IO.DirectoryInfo>(),
+                    It.IsAny<CancellationToken>(),
+                    It.IsAny<string[]>()))
+            .ReturnsAsync(new CommandLineExecutionResult
+            {
+                StdOut = "{}",
+                StdErr = string.Empty,
+                ExitCode = 0,
+            });
+
+        var runner = new BinarySyftRunner(
+            "/usr/local/bin/syft",
+            this.mockCommandLineService.Object,
+            this.mockLogger.Object);
+
+        var imageRef = new ImageReference
+        {
+            OriginalInput = reference,
+            Reference = reference,
+            Kind = kind,
+        };
+
+        await runner.RunSyftAsync(imageRef, ["--quiet", "--output", "json"]);
+
+        this.mockCommandLineService.Verify(
+            service => service.ExecuteCommandAsync(
+                "/usr/local/bin/syft",
+                null,
+                null,
+                It.IsAny<CancellationToken>(),
+                It.Is<string[]>(args => args[0] == expectedSource)),
+            Times.Once);
+    }
+}

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/DockerSyftRunnerTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/DockerSyftRunnerTests.cs
@@ -1,0 +1,211 @@
+namespace Microsoft.ComponentDetection.Detectors.Tests;
+
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using AwesomeAssertions;
+using Microsoft.ComponentDetection.Contracts;
+using Microsoft.ComponentDetection.Detectors.Linux;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+[TestClass]
+[TestCategory("Governance/All")]
+[TestCategory("Governance/ComponentDetection")]
+public class DockerSyftRunnerTests
+{
+    private readonly Mock<IDockerService> mockDockerService;
+    private readonly Mock<ILogger<DockerSyftRunner>> mockLogger;
+
+    public DockerSyftRunnerTests()
+    {
+        this.mockDockerService = new Mock<IDockerService>();
+        this.mockLogger = new Mock<ILogger<DockerSyftRunner>>();
+    }
+
+    [TestMethod]
+    public async Task CanRunAsync_ReturnsTrueWhenDockerCanRunLinuxContainers()
+    {
+        this.mockDockerService.Setup(s =>
+                s.CanRunLinuxContainersAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var runner = new DockerSyftRunner(this.mockDockerService.Object, this.mockLogger.Object);
+
+        var result = await runner.CanRunAsync();
+
+        result.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public async Task CanRunAsync_ReturnsFalseWhenDockerCannotRunLinuxContainers()
+    {
+        this.mockDockerService.Setup(s =>
+                s.CanRunLinuxContainersAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var runner = new DockerSyftRunner(this.mockDockerService.Object, this.mockLogger.Object);
+
+        var result = await runner.CanRunAsync();
+
+        result.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public async Task RunSyftAsync_DockerImage_PassesReferenceDirectly()
+    {
+        this.mockDockerService.Setup(s =>
+                s.CreateAndRunContainerAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<IList<string>>(),
+                    It.IsAny<IList<string>>(),
+                    It.IsAny<CancellationToken>()))
+            .ReturnsAsync(("{}", string.Empty));
+
+        var runner = new DockerSyftRunner(this.mockDockerService.Object, this.mockLogger.Object);
+        var imageRef = new ImageReference
+        {
+            OriginalInput = "ubuntu:22.04",
+            Reference = "ubuntu:22.04",
+            Kind = ImageReferenceKind.DockerImage,
+        };
+
+        await runner.RunSyftAsync(imageRef, ["--quiet", "--output", "json"]);
+
+        this.mockDockerService.Verify(
+            s => s.CreateAndRunContainerAsync(
+                It.IsAny<string>(),
+                It.Is<IList<string>>(cmd => cmd[0] == "ubuntu:22.04"),
+                It.Is<IList<string>>(binds => binds.Count == 0),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [TestMethod]
+    public async Task RunSyftAsync_OciLayout_MountsDirectoryAndUsesMountPoint()
+    {
+        this.mockDockerService.Setup(s =>
+                s.CreateAndRunContainerAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<IList<string>>(),
+                    It.IsAny<IList<string>>(),
+                    It.IsAny<CancellationToken>()))
+            .ReturnsAsync(("{}", string.Empty));
+
+        var runner = new DockerSyftRunner(this.mockDockerService.Object, this.mockLogger.Object);
+        var imageRef = new ImageReference
+        {
+            OriginalInput = "oci-dir:/path/to/oci",
+            Reference = "/path/to/oci",
+            Kind = ImageReferenceKind.OciLayout,
+        };
+
+        await runner.RunSyftAsync(imageRef, ["--quiet", "--output", "json"]);
+
+        this.mockDockerService.Verify(
+            s => s.CreateAndRunContainerAsync(
+                It.IsAny<string>(),
+                It.Is<IList<string>>(cmd => cmd[0] == "oci-dir:/image"),
+                It.Is<IList<string>>(binds =>
+                    binds.Count == 1 && binds[0] == "/path/to/oci:/image:ro"),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [TestMethod]
+    public async Task RunSyftAsync_OciArchive_MountsParentDirAndUsesFileName()
+    {
+        this.mockDockerService.Setup(s =>
+                s.CreateAndRunContainerAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<IList<string>>(),
+                    It.IsAny<IList<string>>(),
+                    It.IsAny<CancellationToken>()))
+            .ReturnsAsync(("{}", string.Empty));
+
+        var runner = new DockerSyftRunner(this.mockDockerService.Object, this.mockLogger.Object);
+        var imageRef = new ImageReference
+        {
+            OriginalInput = "oci-archive:/archives/image.tar",
+            Reference = "/archives/image.tar",
+            Kind = ImageReferenceKind.OciArchive,
+        };
+
+        await runner.RunSyftAsync(imageRef, ["--quiet", "--output", "json"]);
+
+        var expectedDir = Path.GetDirectoryName("/archives/image.tar");
+        this.mockDockerService.Verify(
+            s => s.CreateAndRunContainerAsync(
+                It.IsAny<string>(),
+                It.Is<IList<string>>(cmd => cmd[0] == "oci-archive:/image/image.tar"),
+                It.Is<IList<string>>(binds =>
+                    binds.Count == 1 && binds[0] == $"{expectedDir}:/image:ro"),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [TestMethod]
+    public async Task RunSyftAsync_DockerArchive_MountsParentDirAndUsesFileName()
+    {
+        this.mockDockerService.Setup(s =>
+                s.CreateAndRunContainerAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<IList<string>>(),
+                    It.IsAny<IList<string>>(),
+                    It.IsAny<CancellationToken>()))
+            .ReturnsAsync(("{}", string.Empty));
+
+        var runner = new DockerSyftRunner(this.mockDockerService.Object, this.mockLogger.Object);
+        var imageRef = new ImageReference
+        {
+            OriginalInput = "docker-archive:/saves/myimage.tar",
+            Reference = "/saves/myimage.tar",
+            Kind = ImageReferenceKind.DockerArchive,
+        };
+
+        await runner.RunSyftAsync(imageRef, ["--quiet", "--output", "json"]);
+
+        var expectedDir = Path.GetDirectoryName("/saves/myimage.tar");
+        this.mockDockerService.Verify(
+            s => s.CreateAndRunContainerAsync(
+                It.IsAny<string>(),
+                It.Is<IList<string>>(cmd => cmd[0] == "docker-archive:/image/myimage.tar"),
+                It.Is<IList<string>>(binds =>
+                    binds.Count == 1 && binds[0] == $"{expectedDir}:/image:ro"),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [TestMethod]
+    public async Task RunSyftAsync_OciLayout_PreservesCaseSensitivePath()
+    {
+        this.mockDockerService.Setup(s =>
+                s.CreateAndRunContainerAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<IList<string>>(),
+                    It.IsAny<IList<string>>(),
+                    It.IsAny<CancellationToken>()))
+            .ReturnsAsync(("{}", string.Empty));
+
+        var runner = new DockerSyftRunner(this.mockDockerService.Object, this.mockLogger.Object);
+        var imageRef = new ImageReference
+        {
+            OriginalInput = "oci-dir:/Path/To/MyImage",
+            Reference = "/Path/To/MyImage",
+            Kind = ImageReferenceKind.OciLayout,
+        };
+
+        await runner.RunSyftAsync(imageRef, ["--quiet", "--output", "json"]);
+
+        this.mockDockerService.Verify(
+            s => s.CreateAndRunContainerAsync(
+                It.IsAny<string>(),
+                It.IsAny<IList<string>>(),
+                It.Is<IList<string>>(binds =>
+                    binds.Count == 1 && binds[0] == "/Path/To/MyImage:/image:ro"),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+}

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/DockerSyftRunnerTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/DockerSyftRunnerTests.cs
@@ -77,7 +77,7 @@ public class DockerSyftRunnerTests
         this.mockDockerService.Verify(
             s => s.CreateAndRunContainerAsync(
                 It.IsAny<string>(),
-                It.Is<IList<string>>(cmd => cmd[0] == "ubuntu:22.04"),
+                It.Is<IList<string>>(cmd => cmd[0] == "ubuntu:22.04" && cmd[1] == "--from" && cmd[2] == "docker"),
                 It.Is<IList<string>>(binds => binds.Count == 0),
                 It.IsAny<CancellationToken>()),
             Times.Once);
@@ -107,7 +107,7 @@ public class DockerSyftRunnerTests
         this.mockDockerService.Verify(
             s => s.CreateAndRunContainerAsync(
                 It.IsAny<string>(),
-                It.Is<IList<string>>(cmd => cmd[0] == "oci-dir:/image"),
+                It.Is<IList<string>>(cmd => cmd[0] == "/image" && cmd[1] == "--from" && cmd[2] == "oci-dir"),
                 It.Is<IList<string>>(binds =>
                     binds.Count == 1 && binds[0] == "/path/to/oci:/image:ro"),
                 It.IsAny<CancellationToken>()),
@@ -139,7 +139,7 @@ public class DockerSyftRunnerTests
         this.mockDockerService.Verify(
             s => s.CreateAndRunContainerAsync(
                 It.IsAny<string>(),
-                It.Is<IList<string>>(cmd => cmd[0] == "oci-archive:/image/image.tar"),
+                It.Is<IList<string>>(cmd => cmd[0] == "/image/image.tar" && cmd[1] == "--from" && cmd[2] == "oci-archive"),
                 It.Is<IList<string>>(binds =>
                     binds.Count == 1 && binds[0] == $"{expectedDir}:/image:ro"),
                 It.IsAny<CancellationToken>()),
@@ -171,7 +171,7 @@ public class DockerSyftRunnerTests
         this.mockDockerService.Verify(
             s => s.CreateAndRunContainerAsync(
                 It.IsAny<string>(),
-                It.Is<IList<string>>(cmd => cmd[0] == "docker-archive:/image/myimage.tar"),
+                It.Is<IList<string>>(cmd => cmd[0] == "/image/myimage.tar" && cmd[1] == "--from" && cmd[2] == "docker-archive"),
                 It.Is<IList<string>>(binds =>
                     binds.Count == 1 && binds[0] == $"{expectedDir}:/image:ro"),
                 It.IsAny<CancellationToken>()),

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/LinuxContainerDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/LinuxContainerDetectorTests.cs
@@ -38,15 +38,13 @@ public class LinuxContainerDetectorTests
     private readonly Mock<IDockerService> mockDockerService;
     private readonly Mock<ILogger> mockLogger;
     private readonly Mock<ILogger<LinuxContainerDetector>> mockLinuxContainerDetectorLogger;
+    private readonly Mock<IDockerSyftRunner> mockDockerSyftRunner;
+    private readonly Mock<IBinarySyftRunnerFactory> mockBinarySyftRunnerFactory;
     private readonly Mock<ILinuxScanner> mockSyftLinuxScanner;
 
     public LinuxContainerDetectorTests()
     {
         this.mockDockerService = new Mock<IDockerService>();
-        this.mockDockerService.Setup(service =>
-                service.CanRunLinuxContainersAsync(It.IsAny<CancellationToken>())
-            )
-            .ReturnsAsync(true);
         this.mockDockerService.Setup(service =>
                 service.TryPullImageAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())
             )
@@ -67,15 +65,22 @@ public class LinuxContainerDetectorTests
 
         this.mockLogger = new Mock<ILogger>();
         this.mockLinuxContainerDetectorLogger = new Mock<ILogger<LinuxContainerDetector>>();
+        this.mockDockerSyftRunner = new Mock<IDockerSyftRunner>();
+        this.mockDockerSyftRunner.Setup(runner =>
+                runner.CanRunAsync(It.IsAny<CancellationToken>())
+            )
+            .ReturnsAsync(true);
+        this.mockBinarySyftRunnerFactory = new Mock<IBinarySyftRunnerFactory>();
 
         this.mockSyftLinuxScanner = new Mock<ILinuxScanner>();
         this.mockSyftLinuxScanner.Setup(scanner =>
                 scanner.ScanLinuxAsync(
-                    It.IsAny<string>(),
+                    It.IsAny<ImageReference>(),
                     It.IsAny<IEnumerable<DockerLayer>>(),
                     It.IsAny<int>(),
                     It.IsAny<ISet<ComponentType>>(),
                     It.IsAny<LinuxScannerScope>(),
+                    It.IsAny<ISyftRunner>(),
                     It.IsAny<CancellationToken>()
                 )
             )
@@ -98,6 +103,8 @@ public class LinuxContainerDetectorTests
 
         var linuxContainerDetector = new LinuxContainerDetector(
             this.mockSyftLinuxScanner.Object,
+            this.mockDockerSyftRunner.Object,
+            this.mockBinarySyftRunnerFactory.Object,
             this.mockDockerService.Object,
             this.mockLinuxContainerDetectorLogger.Object
         );
@@ -138,13 +145,15 @@ public class LinuxContainerDetectorTests
             componentRecorder
         );
 
-        this.mockDockerService.Setup(service =>
-                service.CanRunLinuxContainersAsync(It.IsAny<CancellationToken>())
+        this.mockDockerSyftRunner.Setup(runner =>
+                runner.CanRunAsync(It.IsAny<CancellationToken>())
             )
             .ReturnsAsync(false);
 
         var linuxContainerDetector = new LinuxContainerDetector(
             this.mockSyftLinuxScanner.Object,
+            this.mockDockerSyftRunner.Object,
+            this.mockBinarySyftRunnerFactory.Object,
             this.mockDockerService.Object,
             this.mockLinuxContainerDetectorLogger.Object
         );
@@ -183,6 +192,8 @@ public class LinuxContainerDetectorTests
 
         var linuxContainerDetector = new LinuxContainerDetector(
             this.mockSyftLinuxScanner.Object,
+            this.mockDockerSyftRunner.Object,
+            this.mockBinarySyftRunnerFactory.Object,
             this.mockDockerService.Object,
             this.mockLinuxContainerDetectorLogger.Object
         );
@@ -221,6 +232,8 @@ public class LinuxContainerDetectorTests
 
         var linuxContainerDetector = new LinuxContainerDetector(
             this.mockSyftLinuxScanner.Object,
+            this.mockDockerSyftRunner.Object,
+            this.mockBinarySyftRunnerFactory.Object,
             this.mockDockerService.Object,
             this.mockLinuxContainerDetectorLogger.Object
         );
@@ -256,6 +269,8 @@ public class LinuxContainerDetectorTests
 
         var linuxContainerDetector = new LinuxContainerDetector(
             this.mockSyftLinuxScanner.Object,
+            this.mockDockerSyftRunner.Object,
+            this.mockBinarySyftRunnerFactory.Object,
             this.mockDockerService.Object,
             this.mockLinuxContainerDetectorLogger.Object
         );
@@ -276,11 +291,12 @@ public class LinuxContainerDetectorTests
         this.mockSyftLinuxScanner.Verify(
             scanner =>
                 scanner.ScanLinuxAsync(
-                    It.IsAny<string>(),
+                    It.IsAny<ImageReference>(),
                     It.IsAny<IEnumerable<DockerLayer>>(),
                     It.IsAny<int>(),
                     It.IsAny<ISet<ComponentType>>(),
                     It.IsAny<LinuxScannerScope>(),
+                    It.IsAny<ISyftRunner>(),
                     It.IsAny<CancellationToken>()
                 ),
             Times.Once
@@ -302,6 +318,8 @@ public class LinuxContainerDetectorTests
 
         var linuxContainerDetector = new LinuxContainerDetector(
             this.mockSyftLinuxScanner.Object,
+            this.mockDockerSyftRunner.Object,
+            this.mockBinarySyftRunnerFactory.Object,
             this.mockDockerService.Object,
             this.mockLinuxContainerDetectorLogger.Object
         );
@@ -333,6 +351,8 @@ public class LinuxContainerDetectorTests
 
         var linuxContainerDetector = new LinuxContainerDetector(
             this.mockSyftLinuxScanner.Object,
+            this.mockDockerSyftRunner.Object,
+            this.mockBinarySyftRunnerFactory.Object,
             this.mockDockerService.Object,
             this.mockLinuxContainerDetectorLogger.Object
         );
@@ -342,11 +362,12 @@ public class LinuxContainerDetectorTests
         this.mockSyftLinuxScanner.Verify(
             scanner =>
                 scanner.ScanLinuxAsync(
-                    It.IsAny<string>(),
+                    It.IsAny<ImageReference>(),
                     It.IsAny<IEnumerable<DockerLayer>>(),
                     It.IsAny<int>(),
                     It.IsAny<ISet<ComponentType>>(),
                     expectedScope,
+                    It.IsAny<ISyftRunner>(),
                     It.IsAny<CancellationToken>()
                 ),
             Times.Once
@@ -429,9 +450,9 @@ public class LinuxContainerDetectorTests
 
             this.mockSyftLinuxScanner.Setup(scanner =>
                     scanner.GetSyftOutputAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<IList<string>>(),
+                        It.IsAny<ImageReference>(),
                         It.IsAny<LinuxScannerScope>(),
+                        It.IsAny<ISyftRunner>(),
                         It.IsAny<CancellationToken>()
                     )
                 )
@@ -456,10 +477,12 @@ public class LinuxContainerDetectorTests
                 .Returns(layerMappedComponents);
 
             var linuxContainerDetector = new LinuxContainerDetector(
-                this.mockSyftLinuxScanner.Object,
-                this.mockDockerService.Object,
-                this.mockLinuxContainerDetectorLogger.Object
-            );
+            this.mockSyftLinuxScanner.Object,
+            this.mockDockerSyftRunner.Object,
+            this.mockBinarySyftRunnerFactory.Object,
+            this.mockDockerService.Object,
+            this.mockLinuxContainerDetectorLogger.Object
+        );
 
             var scanResult = await linuxContainerDetector.ExecuteDetectorAsync(scanRequest);
 
@@ -484,10 +507,9 @@ public class LinuxContainerDetectorTests
             this.mockSyftLinuxScanner.Verify(
                 scanner =>
                     scanner.GetSyftOutputAsync(
-                        It.Is<string>(s => s.StartsWith("oci-dir:")),
-                        It.Is<IList<string>>(binds =>
-                            binds.Count == 1 && binds[0].Contains(ociDir)),
+                        It.Is<ImageReference>(r => r.Kind == ImageReferenceKind.OciLayout),
                         It.IsAny<LinuxScannerScope>(),
+                        It.IsAny<ISyftRunner>(),
                         It.IsAny<CancellationToken>()
                     ),
                 Times.Once
@@ -563,9 +585,9 @@ public class LinuxContainerDetectorTests
 
             this.mockSyftLinuxScanner.Setup(scanner =>
                     scanner.GetSyftOutputAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<IList<string>>(),
+                        It.IsAny<ImageReference>(),
                         It.IsAny<LinuxScannerScope>(),
+                        It.IsAny<ISyftRunner>(),
                         It.IsAny<CancellationToken>()
                     )
                 )
@@ -581,10 +603,12 @@ public class LinuxContainerDetectorTests
                 .Returns([]);
 
             var linuxContainerDetector = new LinuxContainerDetector(
-                this.mockSyftLinuxScanner.Object,
-                this.mockDockerService.Object,
-                this.mockLinuxContainerDetectorLogger.Object
-            );
+            this.mockSyftLinuxScanner.Object,
+            this.mockDockerSyftRunner.Object,
+            this.mockBinarySyftRunnerFactory.Object,
+            this.mockDockerService.Object,
+            this.mockLinuxContainerDetectorLogger.Object
+        );
 
             await linuxContainerDetector.ExecuteDetectorAsync(scanRequest);
 
@@ -592,10 +616,9 @@ public class LinuxContainerDetectorTests
             this.mockSyftLinuxScanner.Verify(
                 scanner =>
                     scanner.GetSyftOutputAsync(
-                        It.Is<string>(s => s.StartsWith("oci-dir:")),
-                        It.Is<IList<string>>(binds =>
-                            binds.Count == 1 && binds[0].Contains(ociDir)),
+                        It.Is<ImageReference>(r => r.Kind == ImageReferenceKind.OciLayout && r.Reference == ociDir),
                         It.IsAny<LinuxScannerScope>(),
+                        It.IsAny<ISyftRunner>(),
                         It.IsAny<CancellationToken>()
                     ),
                 Times.Once
@@ -651,9 +674,9 @@ public class LinuxContainerDetectorTests
 
             this.mockSyftLinuxScanner.Setup(scanner =>
                     scanner.GetSyftOutputAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<IList<string>>(),
+                        It.IsAny<ImageReference>(),
                         It.IsAny<LinuxScannerScope>(),
+                        It.IsAny<ISyftRunner>(),
                         It.IsAny<CancellationToken>()
                     )
                 )
@@ -669,20 +692,21 @@ public class LinuxContainerDetectorTests
                 .Returns([]);
 
             var linuxContainerDetector = new LinuxContainerDetector(
-                this.mockSyftLinuxScanner.Object,
-                this.mockDockerService.Object,
-                this.mockLinuxContainerDetectorLogger.Object
-            );
+            this.mockSyftLinuxScanner.Object,
+            this.mockDockerSyftRunner.Object,
+            this.mockBinarySyftRunnerFactory.Object,
+            this.mockDockerService.Object,
+            this.mockLinuxContainerDetectorLogger.Object
+        );
 
             await linuxContainerDetector.ExecuteDetectorAsync(scanRequest);
 
             this.mockSyftLinuxScanner.Verify(
                 scanner =>
                     scanner.GetSyftOutputAsync(
-                        It.Is<string>(s => s.StartsWith("oci-dir:")),
-                        It.Is<IList<string>>(binds =>
-                            binds.Count == 1 && binds[0].Contains(ociDir) && !binds[0].Contains(ociDirWithExtraComponents)),
+                        It.Is<ImageReference>(r => r.Kind == ImageReferenceKind.OciLayout && r.Reference.Contains(ociDir) && !r.Reference.Contains(ociDirWithExtraComponents)),
                         It.IsAny<LinuxScannerScope>(),
+                        It.IsAny<ISyftRunner>(),
                         It.IsAny<CancellationToken>()
                     ),
                 Times.Once
@@ -739,9 +763,9 @@ public class LinuxContainerDetectorTests
 
             this.mockSyftLinuxScanner.Setup(scanner =>
                     scanner.GetSyftOutputAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<IList<string>>(),
+                        It.IsAny<ImageReference>(),
                         It.IsAny<LinuxScannerScope>(),
+                        It.IsAny<ISyftRunner>(),
                         It.IsAny<CancellationToken>()
                     )
                 )
@@ -766,10 +790,12 @@ public class LinuxContainerDetectorTests
                 .Returns(ociLayerMappedComponents);
 
             var linuxContainerDetector = new LinuxContainerDetector(
-                this.mockSyftLinuxScanner.Object,
-                this.mockDockerService.Object,
-                this.mockLinuxContainerDetectorLogger.Object
-            );
+            this.mockSyftLinuxScanner.Object,
+            this.mockDockerSyftRunner.Object,
+            this.mockBinarySyftRunnerFactory.Object,
+            this.mockDockerService.Object,
+            this.mockLinuxContainerDetectorLogger.Object
+        );
 
             var scanResult = await linuxContainerDetector.ExecuteDetectorAsync(scanRequest);
 
@@ -824,9 +850,9 @@ public class LinuxContainerDetectorTests
 
             this.mockSyftLinuxScanner.Setup(scanner =>
                     scanner.GetSyftOutputAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<IList<string>>(),
+                        It.IsAny<ImageReference>(),
                         It.IsAny<LinuxScannerScope>(),
+                        It.IsAny<ISyftRunner>(),
                         It.IsAny<CancellationToken>()
                     )
                 )
@@ -851,10 +877,12 @@ public class LinuxContainerDetectorTests
                 .Returns(layerMappedComponents);
 
             var linuxContainerDetector = new LinuxContainerDetector(
-                this.mockSyftLinuxScanner.Object,
-                this.mockDockerService.Object,
-                this.mockLinuxContainerDetectorLogger.Object
-            );
+            this.mockSyftLinuxScanner.Object,
+            this.mockDockerSyftRunner.Object,
+            this.mockBinarySyftRunnerFactory.Object,
+            this.mockDockerService.Object,
+            this.mockLinuxContainerDetectorLogger.Object
+        );
 
             var scanResult = await linuxContainerDetector.ExecuteDetectorAsync(scanRequest);
 
@@ -937,9 +965,9 @@ public class LinuxContainerDetectorTests
 
             this.mockSyftLinuxScanner.Setup(scanner =>
                     scanner.GetSyftOutputAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<IList<string>>(),
+                        It.IsAny<ImageReference>(),
                         It.IsAny<LinuxScannerScope>(),
+                        It.IsAny<ISyftRunner>(),
                         It.IsAny<CancellationToken>()
                     )
                 )
@@ -964,10 +992,12 @@ public class LinuxContainerDetectorTests
                 .Returns(layerMappedComponents);
 
             var linuxContainerDetector = new LinuxContainerDetector(
-                this.mockSyftLinuxScanner.Object,
-                this.mockDockerService.Object,
-                this.mockLinuxContainerDetectorLogger.Object
-            );
+            this.mockSyftLinuxScanner.Object,
+            this.mockDockerSyftRunner.Object,
+            this.mockBinarySyftRunnerFactory.Object,
+            this.mockDockerService.Object,
+            this.mockLinuxContainerDetectorLogger.Object
+        );
 
             var scanResult = await linuxContainerDetector.ExecuteDetectorAsync(scanRequest);
 
@@ -1045,9 +1075,9 @@ public class LinuxContainerDetectorTests
 
             this.mockSyftLinuxScanner.Setup(scanner =>
                     scanner.GetSyftOutputAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<IList<string>>(),
+                        It.IsAny<ImageReference>(),
                         It.IsAny<LinuxScannerScope>(),
+                        It.IsAny<ISyftRunner>(),
                         It.IsAny<CancellationToken>()
                     )
                 )
@@ -1072,10 +1102,12 @@ public class LinuxContainerDetectorTests
                 .Returns(layerMappedComponents);
 
             var linuxContainerDetector = new LinuxContainerDetector(
-                this.mockSyftLinuxScanner.Object,
-                this.mockDockerService.Object,
-                this.mockLinuxContainerDetectorLogger.Object
-            );
+            this.mockSyftLinuxScanner.Object,
+            this.mockDockerSyftRunner.Object,
+            this.mockBinarySyftRunnerFactory.Object,
+            this.mockDockerService.Object,
+            this.mockLinuxContainerDetectorLogger.Object
+        );
 
             var scanResult = await linuxContainerDetector.ExecuteDetectorAsync(scanRequest);
 
@@ -1098,10 +1130,9 @@ public class LinuxContainerDetectorTests
             this.mockSyftLinuxScanner.Verify(
                 scanner =>
                     scanner.GetSyftOutputAsync(
-                        It.Is<string>(s => s.StartsWith("oci-archive:") && s.Contains(ociArchiveName)),
-                        It.Is<IList<string>>(binds =>
-                            binds.Count == 1 && binds[0].Contains(ociArchiveDir)),
+                        It.Is<ImageReference>(r => r.Kind == ImageReferenceKind.OciArchive && r.Reference == ociArchive),
                         It.IsAny<LinuxScannerScope>(),
+                        It.IsAny<ISyftRunner>(),
                         It.IsAny<CancellationToken>()
                     ),
                 Times.Once
@@ -1177,9 +1208,9 @@ public class LinuxContainerDetectorTests
 
             this.mockSyftLinuxScanner.Setup(scanner =>
                     scanner.GetSyftOutputAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<IList<string>>(),
+                        It.IsAny<ImageReference>(),
                         It.IsAny<LinuxScannerScope>(),
+                        It.IsAny<ISyftRunner>(),
                         It.IsAny<CancellationToken>()
                     )
                 )
@@ -1204,10 +1235,12 @@ public class LinuxContainerDetectorTests
                 .Returns(layerMappedComponents);
 
             var linuxContainerDetector = new LinuxContainerDetector(
-                this.mockSyftLinuxScanner.Object,
-                this.mockDockerService.Object,
-                this.mockLinuxContainerDetectorLogger.Object
-            );
+            this.mockSyftLinuxScanner.Object,
+            this.mockDockerSyftRunner.Object,
+            this.mockBinarySyftRunnerFactory.Object,
+            this.mockDockerService.Object,
+            this.mockLinuxContainerDetectorLogger.Object
+        );
 
             var scanResult = await linuxContainerDetector.ExecuteDetectorAsync(scanRequest);
 
@@ -1230,10 +1263,9 @@ public class LinuxContainerDetectorTests
             this.mockSyftLinuxScanner.Verify(
                 scanner =>
                     scanner.GetSyftOutputAsync(
-                        It.Is<string>(s => s.StartsWith("docker-archive:") && s.Contains(dockerArchiveName)),
-                        It.Is<IList<string>>(binds =>
-                            binds.Count == 1 && binds[0].Contains(dockerArchiveDir)),
+                        It.Is<ImageReference>(r => r.Kind == ImageReferenceKind.DockerArchive && r.Reference == dockerArchive),
                         It.IsAny<LinuxScannerScope>(),
+                        It.IsAny<ISyftRunner>(),
                         It.IsAny<CancellationToken>()
                     ),
                 Times.Once
@@ -1262,6 +1294,8 @@ public class LinuxContainerDetectorTests
 
         var linuxContainerDetector = new LinuxContainerDetector(
             this.mockSyftLinuxScanner.Object,
+            this.mockDockerSyftRunner.Object,
+            this.mockBinarySyftRunnerFactory.Object,
             this.mockDockerService.Object,
             this.mockLinuxContainerDetectorLogger.Object
         );

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/LinuxScannerTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/LinuxScannerTests.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using AwesomeAssertions;
-using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Contracts.BcdeModels;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.ComponentDetection.Detectors.Linux;
@@ -221,21 +220,14 @@ public class LinuxScannerTests
         """;
 
     private readonly LinuxScanner linuxScanner;
-    private readonly Mock<IDockerService> mockDockerService;
+    private readonly Mock<ISyftRunner> mockSyftRunner;
     private readonly Mock<ILogger<LinuxScanner>> mockLogger;
     private readonly List<IArtifactComponentFactory> componentFactories;
     private readonly List<IArtifactFilter> artifactFilters;
 
     public LinuxScannerTests()
     {
-        this.mockDockerService = new Mock<IDockerService>();
-        this.mockDockerService.Setup(service =>
-                service.CanPingDockerAsync(It.IsAny<CancellationToken>())
-            )
-            .ReturnsAsync(true);
-        this.mockDockerService.Setup(service =>
-            service.TryPullImageAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())
-        );
+        this.mockSyftRunner = new Mock<ISyftRunner>();
 
         this.mockLogger = new Mock<ILogger<LinuxScanner>>();
 
@@ -250,7 +242,6 @@ public class LinuxScannerTests
         this.artifactFilters = [new Mariner2ArtifactFilter()];
 
         this.linuxScanner = new LinuxScanner(
-            this.mockDockerService.Object,
             this.mockLogger.Object,
             this.componentFactories,
             this.artifactFilters
@@ -262,10 +253,9 @@ public class LinuxScannerTests
     [DataRow(SyftOutputLicenseFieldAndMaintainer)]
     public async Task TestLinuxScannerAsync(string syftOutput)
     {
-        this.mockDockerService.Setup(service =>
-                service.CreateAndRunContainerAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<List<string>>(),
+        this.mockSyftRunner.Setup(runner =>
+                runner.RunSyftAsync(
+                    It.IsAny<ImageReference>(),
                     It.IsAny<IList<string>>(),
                     It.IsAny<CancellationToken>()
                 )
@@ -280,7 +270,7 @@ public class LinuxScannerTests
         };
         var result = (
             await this.linuxScanner.ScanLinuxAsync(
-                "fake_hash",
+                new ImageReference { OriginalInput = "fake_hash", Reference = "fake_hash", Kind = ImageReferenceKind.DockerImage },
                 [
                     new DockerLayer
                     {
@@ -291,7 +281,8 @@ public class LinuxScannerTests
                 ],
                 0,
                 enabledTypes,
-                LinuxScannerScope.AllLayers
+                LinuxScannerScope.AllLayers,
+                this.mockSyftRunner.Object
             )
         )
             .First()
@@ -313,10 +304,9 @@ public class LinuxScannerTests
     [DataRow(SyftOutputNoAuthorOrLicense)]
     public async Task TestLinuxScanner_ReturnsNullAuthorAndLicense_Async(string syftOutput)
     {
-        this.mockDockerService.Setup(service =>
-                service.CreateAndRunContainerAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<List<string>>(),
+        this.mockSyftRunner.Setup(runner =>
+                runner.RunSyftAsync(
+                    It.IsAny<ImageReference>(),
                     It.IsAny<IList<string>>(),
                     It.IsAny<CancellationToken>()
                 )
@@ -331,7 +321,7 @@ public class LinuxScannerTests
         };
         var result = (
             await this.linuxScanner.ScanLinuxAsync(
-                "fake_hash",
+                new ImageReference { OriginalInput = "fake_hash", Reference = "fake_hash", Kind = ImageReferenceKind.DockerImage },
                 [
                     new DockerLayer
                     {
@@ -342,7 +332,8 @@ public class LinuxScannerTests
                 ],
                 0,
                 enabledTypes,
-                LinuxScannerScope.AllLayers
+                LinuxScannerScope.AllLayers,
+                this.mockSyftRunner.Object
             )
         )
             .First()
@@ -366,10 +357,9 @@ public class LinuxScannerTests
         string syftOutput
     )
     {
-        this.mockDockerService.Setup(service =>
-                service.CreateAndRunContainerAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<List<string>>(),
+        this.mockSyftRunner.Setup(runner =>
+                runner.RunSyftAsync(
+                    It.IsAny<ImageReference>(),
                     It.IsAny<IList<string>>(),
                     It.IsAny<CancellationToken>()
                 )
@@ -384,7 +374,7 @@ public class LinuxScannerTests
         };
         var result = (
             await this.linuxScanner.ScanLinuxAsync(
-                "fake_hash",
+                new ImageReference { OriginalInput = "fake_hash", Reference = "fake_hash", Kind = ImageReferenceKind.DockerImage },
                 [
                     new DockerLayer
                     {
@@ -395,7 +385,8 @@ public class LinuxScannerTests
                 ],
                 0,
                 enabledTypes,
-                LinuxScannerScope.AllLayers
+                LinuxScannerScope.AllLayers,
+                this.mockSyftRunner.Object
             )
         )
             .First()
@@ -419,10 +410,9 @@ public class LinuxScannerTests
         string syftOutput
     )
     {
-        this.mockDockerService.Setup(service =>
-                service.CreateAndRunContainerAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<List<string>>(),
+        this.mockSyftRunner.Setup(runner =>
+                runner.RunSyftAsync(
+                    It.IsAny<ImageReference>(),
                     It.IsAny<IList<string>>(),
                     It.IsAny<CancellationToken>()
                 )
@@ -437,7 +427,7 @@ public class LinuxScannerTests
         };
         var result = (
             await this.linuxScanner.ScanLinuxAsync(
-                "fake_hash",
+                new ImageReference { OriginalInput = "fake_hash", Reference = "fake_hash", Kind = ImageReferenceKind.DockerImage },
                 [
                     new DockerLayer
                     {
@@ -448,7 +438,8 @@ public class LinuxScannerTests
                 ],
                 0,
                 enabledTypes,
-                LinuxScannerScope.AllLayers
+                LinuxScannerScope.AllLayers,
+                this.mockSyftRunner.Object
             )
         )
             .First()
@@ -515,10 +506,9 @@ public class LinuxScannerTests
             }
             """;
 
-        this.mockDockerService.Setup(service =>
-                service.CreateAndRunContainerAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<List<string>>(),
+        this.mockSyftRunner.Setup(runner =>
+                runner.RunSyftAsync(
+                    It.IsAny<ImageReference>(),
                     It.IsAny<IList<string>>(),
                     It.IsAny<CancellationToken>()
                 )
@@ -532,14 +522,15 @@ public class LinuxScannerTests
             ComponentType.Pip,
         };
         var layers = await this.linuxScanner.ScanLinuxAsync(
-            "fake_hash",
+            new ImageReference { OriginalInput = "fake_hash", Reference = "fake_hash", Kind = ImageReferenceKind.DockerImage },
             [
                 new DockerLayer { LayerIndex = 0, DiffId = "sha256:layer1" },
                 new DockerLayer { LayerIndex = 1, DiffId = "sha256:layer2" },
             ],
             0,
             enabledTypes,
-            LinuxScannerScope.AllLayers
+            LinuxScannerScope.AllLayers,
+            this.mockSyftRunner.Object
         );
 
         var allComponents = layers.SelectMany(l => l.Components).ToList();
@@ -621,10 +612,9 @@ public class LinuxScannerTests
             }
             """;
 
-        this.mockDockerService.Setup(service =>
-                service.CreateAndRunContainerAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<List<string>>(),
+        this.mockSyftRunner.Setup(runner =>
+                runner.RunSyftAsync(
+                    It.IsAny<ImageReference>(),
                     It.IsAny<IList<string>>(),
                     It.IsAny<CancellationToken>()
                 )
@@ -634,14 +624,15 @@ public class LinuxScannerTests
         // Only enable Linux component type
         var enabledTypes = new HashSet<ComponentType> { ComponentType.Linux };
         var layers = await this.linuxScanner.ScanLinuxAsync(
-            "fake_hash",
+            new ImageReference { OriginalInput = "fake_hash", Reference = "fake_hash", Kind = ImageReferenceKind.DockerImage },
             [
                 new DockerLayer { LayerIndex = 0, DiffId = "sha256:layer1" },
                 new DockerLayer { LayerIndex = 1, DiffId = "sha256:layer2" },
             ],
             0,
             enabledTypes,
-            LinuxScannerScope.AllLayers
+            LinuxScannerScope.AllLayers,
+            this.mockSyftRunner.Object
         );
 
         var allComponents = layers.SelectMany(l => l.Components).ToList();
@@ -708,10 +699,9 @@ public class LinuxScannerTests
             }
             """;
 
-        this.mockDockerService.Setup(service =>
-                service.CreateAndRunContainerAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<List<string>>(),
+        this.mockSyftRunner.Setup(runner =>
+                runner.RunSyftAsync(
+                    It.IsAny<ImageReference>(),
                     It.IsAny<IList<string>>(),
                     It.IsAny<CancellationToken>()
                 )
@@ -721,14 +711,15 @@ public class LinuxScannerTests
         // Only enable Npm and Pip component types (exclude Linux)
         var enabledTypes = new HashSet<ComponentType> { ComponentType.Npm, ComponentType.Pip };
         var layers = await this.linuxScanner.ScanLinuxAsync(
-            "fake_hash",
+            new ImageReference { OriginalInput = "fake_hash", Reference = "fake_hash", Kind = ImageReferenceKind.DockerImage },
             [
                 new DockerLayer { LayerIndex = 0, DiffId = "sha256:layer1" },
                 new DockerLayer { LayerIndex = 1, DiffId = "sha256:layer2" },
             ],
             0,
             enabledTypes,
-            LinuxScannerScope.AllLayers
+            LinuxScannerScope.AllLayers,
+            this.mockSyftRunner.Object
         );
 
         var allComponents = layers.SelectMany(l => l.Components).ToList();
@@ -752,10 +743,9 @@ public class LinuxScannerTests
         string expectedFlag
     )
     {
-        this.mockDockerService.Setup(service =>
-                service.CreateAndRunContainerAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<List<string>>(),
+        this.mockSyftRunner.Setup(runner =>
+                runner.RunSyftAsync(
+                    It.IsAny<ImageReference>(),
                     It.IsAny<IList<string>>(),
                     It.IsAny<CancellationToken>()
                 )
@@ -764,21 +754,21 @@ public class LinuxScannerTests
 
         var enabledTypes = new HashSet<ComponentType> { ComponentType.Linux };
         await this.linuxScanner.ScanLinuxAsync(
-            "fake_hash",
+            new ImageReference { OriginalInput = "fake_hash", Reference = "fake_hash", Kind = ImageReferenceKind.DockerImage },
             [new DockerLayer { LayerIndex = 0, DiffId = "sha256:layer1" }],
             0,
             enabledTypes,
-            scope
+            scope,
+            this.mockSyftRunner.Object
         );
 
-        this.mockDockerService.Verify(
-            service =>
-                service.CreateAndRunContainerAsync(
-                    It.IsAny<string>(),
-                    It.Is<List<string>>(cmd =>
-                        cmd.Contains("--scope") && cmd.Contains(expectedFlag)
+        this.mockSyftRunner.Verify(
+            runner =>
+                runner.RunSyftAsync(
+                    It.IsAny<ImageReference>(),
+                    It.Is<IList<string>>(args =>
+                        args.Contains("--scope") && args.Contains(expectedFlag)
                     ),
-                    It.IsAny<IList<string>>(),
                     It.IsAny<CancellationToken>()
                 ),
             Times.Once
@@ -793,11 +783,12 @@ public class LinuxScannerTests
 
         Func<Task> action = async () =>
             await this.linuxScanner.ScanLinuxAsync(
-                "fake_hash",
+                new ImageReference { OriginalInput = "fake_hash", Reference = "fake_hash", Kind = ImageReferenceKind.DockerImage },
                 [new DockerLayer { LayerIndex = 0, DiffId = "sha256:layer1" }],
                 0,
                 enabledTypes,
-                invalidScope
+                invalidScope,
+                this.mockSyftRunner.Object
             );
 
         await action.Should().ThrowAsync<ArgumentOutOfRangeException>();
@@ -865,21 +856,20 @@ public class LinuxScannerTests
             }
             """;
 
-        this.mockDockerService.Setup(service =>
-                service.CreateAndRunContainerAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<List<string>>(),
+        this.mockSyftRunner.Setup(runner =>
+                runner.RunSyftAsync(
+                    It.IsAny<ImageReference>(),
                     It.IsAny<IList<string>>(),
                     It.IsAny<CancellationToken>()
                 )
             )
             .ReturnsAsync((syftOutputWithSource, string.Empty));
 
-        var additionalBinds = new List<string> { "/some/oci/path:/oci-image:ro" };
+        var ociRef = new ImageReference { OriginalInput = "oci-dir:/oci-image", Reference = "/host/path/to/oci", Kind = ImageReferenceKind.OciLayout };
         var syftOutput = await this.linuxScanner.GetSyftOutputAsync(
-            "oci-dir:/oci-image",
-            additionalBinds,
-            LinuxScannerScope.AllLayers
+            ociRef,
+            LinuxScannerScope.AllLayers,
+            this.mockSyftRunner.Object
         );
 
         syftOutput.Should().NotBeNull();
@@ -936,10 +926,9 @@ public class LinuxScannerTests
             }
             """;
 
-        this.mockDockerService.Setup(service =>
-                service.CreateAndRunContainerAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<List<string>>(),
+        this.mockSyftRunner.Setup(runner =>
+                runner.RunSyftAsync(
+                    It.IsAny<ImageReference>(),
                     It.IsAny<IList<string>>(),
                     It.IsAny<CancellationToken>()
                 )
@@ -947,21 +936,19 @@ public class LinuxScannerTests
             .ReturnsAsync((syftOutput, string.Empty));
 
         var additionalBinds = new List<string> { "/host/path/to/oci:/oci-image:ro" };
+        var ociRef = new ImageReference { OriginalInput = "oci-dir:/oci-image", Reference = "/host/path/to/oci", Kind = ImageReferenceKind.OciLayout };
         await this.linuxScanner.GetSyftOutputAsync(
-            "oci-dir:/oci-image",
-            additionalBinds,
-            LinuxScannerScope.AllLayers
+            ociRef,
+            LinuxScannerScope.AllLayers,
+            this.mockSyftRunner.Object
         );
 
         // Verify the Syft command uses oci-dir: scheme and passes binds
-        this.mockDockerService.Verify(
-            service =>
-                service.CreateAndRunContainerAsync(
-                    It.IsAny<string>(),
-                    It.Is<List<string>>(cmd => cmd[0] == "oci-dir:/oci-image"),
-                    It.Is<IList<string>>(binds =>
-                        binds.Count == 1 && binds[0] == "/host/path/to/oci:/oci-image:ro"
-                    ),
+        this.mockSyftRunner.Verify(
+            runner =>
+                runner.RunSyftAsync(
+                    It.Is<ImageReference>(r => r.Kind == ImageReferenceKind.OciLayout && r.Reference == "/host/path/to/oci"),
+                    It.IsAny<IList<string>>(),
                     It.IsAny<CancellationToken>()
                 ),
             Times.Once

--- a/test/Microsoft.ComponentDetection.Orchestrator.Tests/Experiments/LinuxApplicationLayerExperimentTests.cs
+++ b/test/Microsoft.ComponentDetection.Orchestrator.Tests/Experiments/LinuxApplicationLayerExperimentTests.cs
@@ -16,7 +16,7 @@ public class LinuxApplicationLayerExperimentTests
     [TestMethod]
     public void IsInControlGroup_LinuxContainerDetector_ReturnsTrue()
     {
-        var linuxDetector = new LinuxContainerDetector(null!, null!, null!);
+        var linuxDetector = new LinuxContainerDetector(null!, null!, null!, null!, null!);
         this.experiment.IsInControlGroup(linuxDetector).Should().BeTrue();
     }
 
@@ -63,21 +63,21 @@ public class LinuxApplicationLayerExperimentTests
     [TestMethod]
     public void IsInControlGroup_LinuxApplicationLayerDetector_ReturnsFalse()
     {
-        var experimentalDetector = new LinuxApplicationLayerDetector(null!, null!, null!);
+        var experimentalDetector = new LinuxApplicationLayerDetector(null!, null!, null!, null!, null!);
         this.experiment.IsInControlGroup(experimentalDetector).Should().BeFalse();
     }
 
     [TestMethod]
     public void IsInExperimentGroup_LinuxApplicationLayerDetector_ReturnsTrue()
     {
-        var experimentalDetector = new LinuxApplicationLayerDetector(null!, null!, null!);
+        var experimentalDetector = new LinuxApplicationLayerDetector(null!, null!, null!, null!, null!);
         this.experiment.IsInExperimentGroup(experimentalDetector).Should().BeTrue();
     }
 
     [TestMethod]
     public void IsInExperimentGroup_LinuxContainerDetector_ReturnsFalse()
     {
-        var linuxDetector = new LinuxContainerDetector(null!, null!, null!);
+        var linuxDetector = new LinuxContainerDetector(null!, null!, null!, null!, null!);
         this.experiment.IsInExperimentGroup(linuxDetector).Should().BeFalse();
     }
 
@@ -124,28 +124,28 @@ public class LinuxApplicationLayerExperimentTests
     [TestMethod]
     public void ShouldRecord_ExperimentGroup_ReturnsTrue_WhenNumComponentsGreaterThanZero()
     {
-        var experimentalDetector = new LinuxApplicationLayerDetector(null!, null!, null!);
+        var experimentalDetector = new LinuxApplicationLayerDetector(null!, null!, null!, null!, null!);
         this.experiment.ShouldRecord(experimentalDetector, 1).Should().BeTrue();
     }
 
     [TestMethod]
     public void ShouldRecord_ExperimentGroup_ReturnsFalse_WhenNumComponentsIsZero()
     {
-        var experimentalDetector = new LinuxApplicationLayerDetector(null!, null!, null!);
+        var experimentalDetector = new LinuxApplicationLayerDetector(null!, null!, null!, null!, null!);
         this.experiment.ShouldRecord(experimentalDetector, 0).Should().BeFalse();
     }
 
     [TestMethod]
     public void ShouldRecord_ControlGroup_ReturnsTrue_WhenNumComponentsGreaterThanZero()
     {
-        var linuxDetector = new LinuxContainerDetector(null!, null!, null!);
+        var linuxDetector = new LinuxContainerDetector(null!, null!, null!, null!, null!);
         this.experiment.ShouldRecord(linuxDetector, 1).Should().BeTrue();
     }
 
     [TestMethod]
     public void ShouldRecord_ControlGroup_ReturnsFalse_WhenNumComponentsIsZero()
     {
-        var linuxDetector = new LinuxContainerDetector(null!, null!, null!);
+        var linuxDetector = new LinuxContainerDetector(null!, null!, null!, null!, null!);
         this.experiment.ShouldRecord(linuxDetector, 0).Should().BeFalse();
     }
 


### PR DESCRIPTION
By passing the detector argument `Linux.SyftBinaryPath`, the Linux detector will invoke the given syft binary instead of using the syft docker image to scan images.