### PR TITLE
Fix Docker scan hang: bound container removal, surface timeout telemetry

### DIFF
--- a/src/Microsoft.ComponentDetection.Common/DockerService.cs
+++ b/src/Microsoft.ComponentDetection.Common/DockerService.cs
@@ -216,8 +216,21 @@ internal class DockerService : IDockerService
         }
         finally
         {
-            // Best-effort container cleanup; RemoveContainerAsync already handles not-found.
-            await RemoveContainerAsync(container.ID, CancellationToken.None);
+            // Best-effort container cleanup with a bounded timeout.
+            // RemoveContainerAsync already handles not-found, but we must guard against
+            // the Docker daemon hanging on container removal (e.g. when the container
+            // process is stuck), which would block the detector indefinitely.
+            using var removeCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            try
+            {
+                await RemoveContainerAsync(container.ID, removeCts.Token);
+            }
+            catch (Exception ex) when (ex is OperationCanceledException or TimeoutException)
+            {
+                this.logger.LogWarning(
+                    "Timed out removing container {ContainerId} after 30s; abandoning cleanup",
+                    container.ID);
+            }
         }
     }
 

--- a/src/Microsoft.ComponentDetection.Common/DockerService.cs
+++ b/src/Microsoft.ComponentDetection.Common/DockerService.cs
@@ -228,6 +228,7 @@ internal class DockerService : IDockerService
             catch (Exception ex) when (ex is OperationCanceledException or TimeoutException)
             {
                 this.logger.LogWarning(
+                    ex,
                     "Timed out removing container {ContainerId} after 30s; abandoning cleanup",
                     container.ID);
             }

--- a/src/Microsoft.ComponentDetection.Common/DockerService.cs
+++ b/src/Microsoft.ComponentDetection.Common/DockerService.cs
@@ -225,11 +225,11 @@ internal class DockerService : IDockerService
             {
                 await RemoveContainerAsync(container.ID, removeCts.Token);
             }
-            catch (Exception ex) when (ex is OperationCanceledException or TimeoutException)
+            catch (Exception ex)
             {
                 this.logger.LogWarning(
                     ex,
-                    "Timed out removing container {ContainerId} after 30s; abandoning cleanup",
+                    "Failed to remove container {ContainerId}; abandoning cleanup",
                     container.ID);
             }
         }

--- a/src/Microsoft.ComponentDetection.Detectors/linux/LinuxContainerDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/linux/LinuxContainerDetector.cs
@@ -127,6 +127,10 @@ public class LinuxContainerDetector(
                 GetTimeout(request.DetectorArgs)
             );
         }
+        catch (Exception e)
+        {
+            this.logger.LogError(e, "Unexpected error during Linux container image scanning");
+        }
 
         return new IndividualDetectorScanResult
         {
@@ -285,6 +289,10 @@ public class LinuxContainerDetector(
                     );
             }
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception e)
         {
             this.logger.LogWarning(e, "Processing of image {ContainerImage} (kind {ImageType}) failed", imageRef.OriginalInput, imageRef.Kind);
@@ -387,6 +395,10 @@ public class LinuxContainerDetector(
             ) ?? throw new InvalidOperationException($"Failed to scan image layers for image {containerDetails.ImageId}");
 
             return this.RecordComponents(containerDetails, layers, componentRecorder);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception e)
         {
@@ -524,6 +536,10 @@ public class LinuxContainerDetector(
             );
 
             return this.RecordComponents(containerDetails, layers, componentRecorder);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception e)
         {

--- a/src/Microsoft.ComponentDetection.Detectors/linux/LinuxScanner.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/linux/LinuxScanner.cs
@@ -296,7 +296,7 @@ internal class LinuxScanner : ILinuxScanner
                 }
                 catch (Exception e)
                 {
-                    syftTelemetryRecord.Exception = JsonSerializer.Serialize(e);
+                    syftTelemetryRecord.Exception = e.ToString();
                     this.logger.LogError(e, "Failed to run syft");
                     throw;
                 }

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/LinuxContainerDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/LinuxContainerDetectorTests.cs
@@ -1290,4 +1290,181 @@ public class LinuxContainerDetectorTests
             Times.Once
         );
     }
+
+    [TestMethod]
+    public async Task ExecuteDetectorAsync_ScannerThrowsOce_ReturnsSuccessWithEmptyResults()
+    {
+        // Verifies Fix 2 + OCE catch: when the scanning timeout fires,
+        // the OCE propagates out of the scan methods and is caught by
+        // ExecuteDetectorAsync, which returns Success with no components.
+        var componentRecorder = new ComponentRecorder();
+        var detectorArgs = new Dictionary<string, string> { { "Linux.ScanningTimeoutSec", "600" } };
+
+        var scanRequest = new ScanRequest(
+            new DirectoryInfo(Path.GetTempPath()),
+            (_, __) => false,
+            this.mockLogger.Object,
+            detectorArgs,
+            [NodeLatestImage],
+            componentRecorder
+        );
+
+        this.mockSyftLinuxScanner.Setup(scanner =>
+                scanner.ScanLinuxAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<IEnumerable<DockerLayer>>(),
+                    It.IsAny<int>(),
+                    It.IsAny<ISet<ComponentType>>(),
+                    It.IsAny<LinuxScannerScope>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ThrowsAsync(new OperationCanceledException());
+
+        var detector = new LinuxContainerDetector(
+            this.mockSyftLinuxScanner.Object,
+            this.mockDockerService.Object,
+            this.mockLinuxContainerDetectorLogger.Object
+        );
+
+        var result = await detector.ExecuteDetectorAsync(scanRequest);
+
+        result.ResultCode.Should().Be(ProcessingResultCode.Success);
+        result.ContainerDetails.Should().BeEmpty();
+        componentRecorder.GetDetectedComponents().Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task ExecuteDetectorAsync_ScannerThrowsUnexpectedException_ReturnsSuccessDoesNotCrash()
+    {
+        // Verifies Fix 4 safety net: an unexpected exception from the
+        // scanner must never escape the detector. It should be caught,
+        // and the detector should return Success with empty results.
+        var componentRecorder = new ComponentRecorder();
+
+        var scanRequest = new ScanRequest(
+            new DirectoryInfo(Path.GetTempPath()),
+            (_, __) => false,
+            this.mockLogger.Object,
+            null,
+            [NodeLatestImage],
+            componentRecorder
+        );
+
+        this.mockSyftLinuxScanner.Setup(scanner =>
+                scanner.ScanLinuxAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<IEnumerable<DockerLayer>>(),
+                    It.IsAny<int>(),
+                    It.IsAny<ISet<ComponentType>>(),
+                    It.IsAny<LinuxScannerScope>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ThrowsAsync(new InvalidOperationException("Unexpected Docker failure"));
+
+        var detector = new LinuxContainerDetector(
+            this.mockSyftLinuxScanner.Object,
+            this.mockDockerService.Object,
+            this.mockLinuxContainerDetectorLogger.Object
+        );
+
+        // The critical assertion: the detector must NOT throw.
+        var result = await detector.ExecuteDetectorAsync(scanRequest);
+
+        result.ResultCode.Should().Be(ProcessingResultCode.Success);
+        result.ContainerDetails.Should().BeEmpty();
+        componentRecorder.GetDetectedComponents().Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task ExecuteDetectorAsync_ImageResolveThrowsOce_ReturnsSuccessWithEmptyResults()
+    {
+        // Verifies Fix 2 in the resolve phase: if the timeout fires
+        // during image pull/inspect, the OCE is re-thrown from
+        // ResolveImageAsync and caught by ExecuteDetectorAsync.
+        var componentRecorder = new ComponentRecorder();
+        var detectorArgs = new Dictionary<string, string> { { "Linux.ScanningTimeoutSec", "600" } };
+
+        var scanRequest = new ScanRequest(
+            new DirectoryInfo(Path.GetTempPath()),
+            (_, __) => false,
+            this.mockLogger.Object,
+            detectorArgs,
+            [NodeLatestImage],
+            componentRecorder
+        );
+
+        this.mockDockerService.Setup(service =>
+                service.ImageExistsLocallyAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())
+            )
+            .ThrowsAsync(new OperationCanceledException());
+
+        var detector = new LinuxContainerDetector(
+            this.mockSyftLinuxScanner.Object,
+            this.mockDockerService.Object,
+            this.mockLinuxContainerDetectorLogger.Object
+        );
+
+        var result = await detector.ExecuteDetectorAsync(scanRequest);
+
+        result.ResultCode.Should().Be(ProcessingResultCode.Success);
+        result.ContainerDetails.Should().BeEmpty();
+        componentRecorder.GetDetectedComponents().Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task ExecuteDetectorAsync_ScanThrowsOce_OtherImageStillScanned()
+    {
+        // When scanning multiple images and one times out, the entire
+        // detector should still return Success (not crash).
+        var componentRecorder = new ComponentRecorder();
+        const string secondImage = "alpine:latest";
+        const string secondImageId = "alpine123";
+
+        this.mockDockerService.Setup(service =>
+                service.InspectImageAsync(secondImage, It.IsAny<CancellationToken>())
+            )
+            .ReturnsAsync(
+                new ContainerDetails
+                {
+                    Id = 2,
+                    ImageId = secondImageId,
+                    Layers = [],
+                }
+            );
+
+        // First image scans fine, second throws OCE
+        this.mockSyftLinuxScanner.Setup(scanner =>
+                scanner.ScanLinuxAsync(
+                    secondImageId,
+                    It.IsAny<IEnumerable<DockerLayer>>(),
+                    It.IsAny<int>(),
+                    It.IsAny<ISet<ComponentType>>(),
+                    It.IsAny<LinuxScannerScope>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ThrowsAsync(new OperationCanceledException());
+
+        var scanRequest = new ScanRequest(
+            new DirectoryInfo(Path.GetTempPath()),
+            (_, __) => false,
+            this.mockLogger.Object,
+            null,
+            [NodeLatestImage, secondImage],
+            componentRecorder
+        );
+
+        var detector = new LinuxContainerDetector(
+            this.mockSyftLinuxScanner.Object,
+            this.mockDockerService.Object,
+            this.mockLinuxContainerDetectorLogger.Object
+        );
+
+        var result = await detector.ExecuteDetectorAsync(scanRequest);
+
+        // Must not crash, must return Success
+        result.ResultCode.Should().Be(ProcessingResultCode.Success);
+    }
 }

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/LinuxContainerDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/LinuxContainerDetectorTests.cs
@@ -1297,6 +1297,9 @@ public class LinuxContainerDetectorTests
         // Verifies Fix 2 + OCE catch: when the scanning timeout fires,
         // the OCE propagates out of the scan methods and is caught by
         // ExecuteDetectorAsync, which returns Success with no components.
+        // We pass a pre-cancelled token so the linked timeoutCts is also
+        // cancelled, making the `when (cancellationToken.IsCancellationRequested)`
+        // guard match and re-throw the OCE to ExecuteDetectorAsync.
         var componentRecorder = new ComponentRecorder();
         var detectorArgs = new Dictionary<string, string> { { "Linux.ScanningTimeoutSec", "600" } };
 
@@ -1308,6 +1311,9 @@ public class LinuxContainerDetectorTests
             [NodeLatestImage],
             componentRecorder
         );
+
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
 
         this.mockSyftLinuxScanner.Setup(scanner =>
                 scanner.ScanLinuxAsync(
@@ -1327,7 +1333,7 @@ public class LinuxContainerDetectorTests
             this.mockLinuxContainerDetectorLogger.Object
         );
 
-        var result = await detector.ExecuteDetectorAsync(scanRequest);
+        var result = await detector.ExecuteDetectorAsync(scanRequest, cts.Token);
 
         result.ResultCode.Should().Be(ProcessingResultCode.Success);
         result.ContainerDetails.Should().BeEmpty();
@@ -1383,6 +1389,8 @@ public class LinuxContainerDetectorTests
         // Verifies Fix 2 in the resolve phase: if the timeout fires
         // during image pull/inspect, the OCE is re-thrown from
         // ResolveImageAsync and caught by ExecuteDetectorAsync.
+        // We pass a pre-cancelled token so the linked timeoutCts is also
+        // cancelled, making the `when` guard match.
         var componentRecorder = new ComponentRecorder();
         var detectorArgs = new Dictionary<string, string> { { "Linux.ScanningTimeoutSec", "600" } };
 
@@ -1395,6 +1403,9 @@ public class LinuxContainerDetectorTests
             componentRecorder
         );
 
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
         this.mockDockerService.Setup(service =>
                 service.ImageExistsLocallyAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())
             )
@@ -1406,7 +1417,7 @@ public class LinuxContainerDetectorTests
             this.mockLinuxContainerDetectorLogger.Object
         );
 
-        var result = await detector.ExecuteDetectorAsync(scanRequest);
+        var result = await detector.ExecuteDetectorAsync(scanRequest, cts.Token);
 
         result.ResultCode.Should().Be(ProcessingResultCode.Success);
         result.ContainerDetails.Should().BeEmpty();
@@ -1416,8 +1427,10 @@ public class LinuxContainerDetectorTests
     [TestMethod]
     public async Task ExecuteDetectorAsync_ScanThrowsOce_OtherImageStillScanned()
     {
-        // When scanning multiple images and one times out, the entire
-        // detector should still return Success (not crash).
+        // When scanning multiple images and one fails with an uncancelled OCE,
+        // the generic catch swallows it, so the other image still scans.
+        // Token is NOT cancelled here — this tests multi-image resilience
+        // via the generic catch path, not the timeout re-throw path.
         var componentRecorder = new ComponentRecorder();
         const string secondImage = "alpine:latest";
         const string secondImageId = "alpine123";
@@ -1434,7 +1447,8 @@ public class LinuxContainerDetectorTests
                 }
             );
 
-        // First image scans fine, second throws OCE
+        // First image (NodeLatestImage) scans fine via default mock.
+        // Second image throws OCE (not tied to cancellation, so generic catch handles it).
         this.mockSyftLinuxScanner.Setup(scanner =>
                 scanner.ScanLinuxAsync(
                     secondImageId,
@@ -1466,5 +1480,19 @@ public class LinuxContainerDetectorTests
 
         // Must not crash, must return Success
         result.ResultCode.Should().Be(ProcessingResultCode.Success);
+
+        // The first image should have been scanned successfully
+        this.mockSyftLinuxScanner.Verify(
+            scanner => scanner.ScanLinuxAsync(
+                NodeLatestDigest,
+                It.IsAny<IEnumerable<DockerLayer>>(),
+                It.IsAny<int>(),
+                It.IsAny<ISet<ComponentType>>(),
+                It.IsAny<LinuxScannerScope>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // The first image should have produced components
+        componentRecorder.GetDetectedComponents().Should().NotBeEmpty();
     }
 }


### PR DESCRIPTION
## Problem

Customer pipelines hang indefinitely during Linux container image scanning. Despite PR #1729 adding timeout cancellation to the Docker scan read path, the detector still hangs because:

1. **`RemoveContainerAsync` uses `CancellationToken.None`** — after the scan timeout fires and the read is cancelled, the `finally` block calls `RemoveContainerAsync` with no timeout. If the Docker daemon is slow removing a stuck container, this hangs forever.

2. **`OperationCanceledException` is swallowed** — the generic `catch (Exception e)` catches OCE before it reaches `ExecuteDetectorAsync`, so `LinuxContainerDetectorTimeout` telemetry is never emitted.

3. **`JsonSerializer.Serialize(exception)` throws** — `System.Text.Json` cannot serialize `MethodBase` properties on exceptions.

## Fixes

| Fix | File | What |
|-----|------|------|
| 1 | `DockerService.cs` | 30s timeout on `RemoveContainerAsync` in finally block |
| 2 | `LinuxContainerDetector.cs` | Re-throw OCE before generic catch (3 sites) |
| 3 | `LinuxScanner.cs` | `e.ToString()` instead of `JsonSerializer.Serialize(e)` |
| 4 | `LinuxContainerDetector.cs` | Safety-net `catch (Exception)` in `ExecuteDetectorAsync` |

## Testing

- 4 new unit tests covering timeout propagation, no-crash safety net, resolve-phase OCE, and multi-image scenarios
- All existing tests pass

## Related

- Fixes regression after #1729
