### PR TITLE
Reorder search patterns for Pnpm component detection

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/pnpm/PnpmComponentDetectorFactory.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/pnpm/PnpmComponentDetectorFactory.cs
@@ -38,7 +38,7 @@ internal class PnpmComponentDetectorFactory : FileComponentDetector
 
     public override IEnumerable<string> Categories => [Enum.GetName(typeof(DetectorClass), DetectorClass.Npm)];
 
-    public override IList<string> SearchPatterns { get; } = ["shrinkwrap.yaml", "pnpm-lock.yaml"];
+    public override IList<string> SearchPatterns { get; } = ["pnpm-lock.yaml", "shrinkwrap.yaml"];
 
     public override IEnumerable<ComponentType> SupportedComponentTypes { get; } = [ComponentType.Npm];
 


### PR DESCRIPTION
As a part of the change in #1770, I updated `SearchPatterns` so that the earlier in the list, the higher the priority. And `shrinkwrap.yaml` is the old name for `pnpm-lock.yaml` so it shouldn't be first in the order anymore: https://github.com/orgs/pnpm/discussions/8595#discussioncomment-10813709