### PR TITLE
chore: drop System.Runtime.Loader package ref (in-box on net8.0)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -43,7 +43,6 @@
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <PackageVersion Include="System.Memory" Version="4.6.3" />
     <PackageVersion Include="System.Reactive" Version="6.1.0" />
-    <PackageVersion Include="System.Runtime.Loader" Version="4.3.0" />
     <PackageVersion Include="System.Text.Json" Version="9.0.13" />
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="8.0.1" />
     <PackageVersion Include="Tomlyn.Signed" Version="0.20.0" />

--- a/src/Microsoft.ComponentDetection.Orchestrator/Microsoft.ComponentDetection.Orchestrator.csproj
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Microsoft.ComponentDetection.Orchestrator.csproj
@@ -18,7 +18,6 @@
         <PackageReference Include="Spectre.Console" />
         <PackageReference Include="Spectre.Console.Cli" />
         <PackageReference Include="Spectre.Console.Cli.Extensions.DependencyInjection" />
-        <PackageReference Include="System.Runtime.Loader" />
         <PackageReference Include="System.Threading.Tasks.Dataflow" />
         <PackageReference Include="System.Reactive" />
     </ItemGroup>


### PR DESCRIPTION
## What
Removes the explicit `PackageReference` for `System.Runtime.Loader` from `Microsoft.ComponentDetection.Orchestrator` and its central `PackageVersion` entry from `Directory.Packages.props`. The type lives in the BCL on net8.0; the explicit ref is noise and occasionally triggers spurious vulnerability alerts.

## Why
The explicit reference dates from the netstandard / netcoreapp3.1 era when `System.Runtime.Loader` was an out-of-band package. On net8.0 it ships with the runtime.

## Note
The original plan also intended to drop explicit `System.Memory` references from net8.0-targeted projects, but a closer look showed `System.Memory` is only referenced by `Microsoft.ComponentDetection.Contracts.csproj`, which still targets `netstandard2.0` — so it must stay. There were no net8.0 `System.Memory` references to remove. This PR therefore only covers `System.Runtime.Loader`.

## Verified
\`dotnet build\` (warnings-as-errors) succeeds with zero warnings/errors.

Part 2 of a 6-PR cleanup series removing .NET-Framework-era anachronisms.