### PR TITLE
chore: modernize EnvironmentVariableService

### DIFF
--- a/src/Microsoft.ComponentDetection.Common/EnvironmentVariableService.cs
+++ b/src/Microsoft.ComponentDetection.Common/EnvironmentVariableService.cs
@@ -1,4 +1,3 @@
-#nullable disable
 namespace Microsoft.ComponentDetection.Common;
 
 using System;
@@ -13,14 +12,19 @@ internal class EnvironmentVariableService : IEnvironmentVariableService
         return this.GetEnvironmentVariable(name) != null;
     }
 
-    public string GetEnvironmentVariable(string name)
+    public string? GetEnvironmentVariable(string name)
     {
         // Environment variables are case-insensitive on Windows, and case-sensitive on
         // Linux and MacOS.
         // https://docs.microsoft.com/en-us/dotnet/api/system.environment.getenvironmentvariable
+        if (OperatingSystem.IsWindows())
+        {
+            return Environment.GetEnvironmentVariable(name);
+        }
+
         var caseInsensitiveName = Environment.GetEnvironmentVariables().Keys
             .OfType<string>()
-            .FirstOrDefault(x => string.Compare(x, name, true) == 0);
+            .FirstOrDefault(x => string.Equals(x, name, StringComparison.OrdinalIgnoreCase));
 
         return caseInsensitiveName != null ? Environment.GetEnvironmentVariable(caseInsensitiveName) : null;
     }

--- a/src/Microsoft.ComponentDetection.Contracts/IEnvironmentVariableService.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/IEnvironmentVariableService.cs
@@ -19,7 +19,7 @@ public interface IEnvironmentVariableService
     /// </summary>
     /// <param name="name">Name of the environment variable.</param>
     /// <returns>Returns a string of the environment variable value.</returns>
-    string GetEnvironmentVariable(string name);
+    string? GetEnvironmentVariable(string name);
 
     /// <summary>
     /// Returns the value of an environment variable which is formatted as a delimited list.


### PR DESCRIPTION
## What
Cleans up `EnvironmentVariableService.GetEnvironmentVariable`:
- Replaces `string.Compare(x, name, true) == 0` (a .NET Framework idiom) with `string.Equals(x, name, StringComparison.OrdinalIgnoreCase)`.
- Short-circuits to `Environment.GetEnvironmentVariable(name)` on Windows, where the lookup is already case-insensitive — no need to enumerate every environment variable.
- Drops `#nullable disable` from the file.

## Why
The original implementation predates net8.0 and always paid the cost of enumerating every environment variable, even on Windows where the platform handles case-insensitivity natively.

Part 4 of a 6-PR cleanup series removing .NET-Framework-era anachronisms.