### PR TITLE
chore: use ArgumentNullException.ThrowIfNull where applicable

### DIFF
--- a/src/Microsoft.ComponentDetection.Common/PatternMatchingUtility.cs
+++ b/src/Microsoft.ComponentDetection.Common/PatternMatchingUtility.cs
@@ -61,7 +61,7 @@ public static class PatternMatchingUtility
         private readonly string[] patterns;
 
         public CompiledMatcher(IEnumerable<string> patterns)
-            : this(patterns is string[] arr ? arr : (patterns ?? throw new ArgumentNullException(nameof(patterns))).ToArray())
+            : this(ToArray(patterns))
         {
         }
 
@@ -70,6 +70,12 @@ public static class PatternMatchingUtility
             ArgumentNullException.ThrowIfNull(patterns);
             this.patterns = (string[])patterns.Clone();
             ValidatePatternElements(this.patterns);
+        }
+
+        private static string[] ToArray(IEnumerable<string> patterns)
+        {
+            ArgumentNullException.ThrowIfNull(patterns);
+            return patterns as string[] ?? patterns.ToArray();
         }
 
         public bool IsMatch(ReadOnlySpan<char> fileName) => GetFirstMatchingPattern(fileName, this.patterns) is not null;


### PR DESCRIPTION
## What
Replaces a pre-.NET 6 `?? throw new ArgumentNullException(nameof(x))` pattern with `ArgumentNullException.ThrowIfNull(x)` (.NET 6+) in `PatternMatchingUtility.CompiledMatcher`.

The inline `?? throw` was nested in a `: this(...)` constructor chain; it has been hoisted into a small private `ToArray` helper so the null check uses `ArgumentNullException.ThrowIfNull` while preserving identical behavior (same exception type, same `ParamName`).

### Sites intentionally not changed
- **Custom messages**: `DotNetComponent` and `DependencyGraph.AddComponent` (`"Invalid component node id"`) pass a descriptive second argument worth keeping.
- **`IsNullOrWhiteSpace` checks**: `ComponentRecorder.CreateSingleFileComponentRecorder` and `DependencyGraph.GetExplicitReferencedDependencyIds` throw `ArgumentNullException` for null *and* empty/whitespace strings, with explicit tests covering all three cases. `ArgumentNullException.ThrowIfNull` would only handle the null case, so the existing pattern is preserved.
- **netstandard2.0 projects**: `Microsoft.ComponentDetection.Contracts` targets `netstandard2.0`, where `ArgumentNullException.ThrowIfNull` is unavailable. The sites in `NpmAuthor` and `FileComponentDetectorWithCleanup` are left as-is.

## Why
`ArgumentNullException.ThrowIfNull` is the modern, intent-revealing form. It throws the same exception type with the same `ParamName`, so behavior is identical for callers and tests.

Part 5 of a 6-PR cleanup series removing .NET-Framework-era anachronisms.