### PR TITLE
Increase parallelism in smoketest yaml + reduce iterations in PR

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -10,6 +10,11 @@ on:
   pull_request:
     paths:
       - "src/**"
+      - "Directory.Build.props"
+      - "Directory.Build.targets"
+      - "Directory.Packages.props"
+      - "global.json"
+      - ".github/workflows/smoke-test.yml"
   schedule:
     - cron: "0 0 * * *" # every day at midnight
 

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -20,26 +20,7 @@ jobs:
   smoke-test:
     if: github.repository == 'microsoft/component-detection' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     runs-on: ["self-hosted", "1ES.Pool=1ES-OSE-GH-Pool"]
-    strategy:
-      matrix:
-        language:
-          [
-            { name: "CocoaPods", repo: "realm/realm-swift" },
-            { name: "Gradle", repo: "microsoft/ApplicationInsights-Java" },
-            { name: "Go", repo: "kubernetes/kubernetes" },
-            { name: "Maven", repo: "apache/kafka" },
-            { name: "NPM", repo: "axios/axios" },
-            { name: "NuGet", repo: "Radarr/Radarr" },
-            { name: "Pip", repo: "django/django" },
-            { name: "Pnpm", repo: "pnpm/pnpm" },
-            { name: "Poetry", repo: "Textualize/rich" },
-            { name: "Ruby", repo: "rails/rails" },
-            { name: "Rust", repo: "alacritty/alacritty" },
-            { name: "Yarn", repo: "gatsbyjs/gatsby" },
-          ]
-      fail-fast: false
-      max-parallel: 6
-    name: ${{ matrix.language.name }}
+    name: Smoke Test
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
@@ -69,16 +50,31 @@ jobs:
           sudo chmod 777 /usr/share/ant/lib
           curl https://downloads.apache.org/ant/ivy/2.5.2/apache-ivy-2.5.2-bin.tar.gz | tar xOz apache-ivy-2.5.2/ivy-2.5.2.jar > /usr/share/ant/lib/ivy.jar
 
-      - name: Checkout Smoke Test Repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-          repository: ${{ matrix.language.repo }}
-          path: smoke-test-repo
+      - name: Checkout Smoke Test Repos
+        run: |
+          mkdir -p smoke-test-repos
+          repos=(
+            "realm/realm-swift"                    # CocoaPods
+            "microsoft/ApplicationInsights-Java"   # Gradle
+            "kubernetes/kubernetes"                # Go
+            "apache/kafka"                         # Maven
+            "axios/axios"                          # NPM
+            "Radarr/Radarr"                        # NuGet
+            "django/django"                        # Pip
+            "pnpm/pnpm"                            # Pnpm
+            "Textualize/rich"                      # Poetry
+            "rails/rails"                          # Ruby
+            "alacritty/alacritty"                  # Rust
+            "gatsbyjs/gatsby"                      # Yarn
+          )
+          for repo in "${repos[@]}"; do
+            dir="smoke-test-repos/$(basename "$repo")"
+            echo "Cloning $repo into $dir..."
+            git clone --depth 1 "https://github.com/$repo.git" "$dir"
+          done
 
       - name: Restore Smoke Test NuGet Packages
-        if: ${{ matrix.language.name == 'NuGet'}}
-        working-directory: smoke-test-repo/src
+        working-directory: smoke-test-repos/Radarr/src
         run: dotnet restore
 
       - name: Run Smoke Test
@@ -86,7 +82,7 @@ jobs:
         run: |
           ITERATIONS=${{ github.event_name == 'schedule' && 10 || 1 }}
           for i in $(seq 1 $ITERATIONS); do
-              dotnet run -c Release -- scan --SourceDirectory ${{ github.workspace }}/smoke-test-repo --Verbosity Verbose || exit 1
+              dotnet run -c Release -- scan --SourceDirectory ${{ github.workspace }}/smoke-test-repos --Verbosity Verbose || exit 1
           done
 
   create-issue:

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -8,6 +8,8 @@ on:
     branches:
       - main
   pull_request:
+    paths:
+      - "src/**"
   schedule:
     - cron: "0 0 * * *" # every day at midnight
 
@@ -16,7 +18,7 @@ permissions:
 
 jobs:
   smoke-test:
-    if: github.repository == 'microsoft/component-detection'
+    if: github.repository == 'microsoft/component-detection' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     runs-on: ["self-hosted", "1ES.Pool=1ES-OSE-GH-Pool"]
     strategy:
       matrix:
@@ -36,7 +38,7 @@ jobs:
             { name: "Yarn", repo: "gatsbyjs/gatsby" },
           ]
       fail-fast: false
-      max-parallel: 4 # limit the total number of running jobs to avoid rate limiting
+      max-parallel: 6
     name: ${{ matrix.language.name }}
     steps:
       - name: Harden Runner
@@ -82,7 +84,8 @@ jobs:
       - name: Run Smoke Test
         working-directory: src/Microsoft.ComponentDetection
         run: |
-          for i in $(seq 1 10); do
+          ITERATIONS=${{ github.event_name == 'schedule' && 10 || 1 }}
+          for i in $(seq 1 $ITERATIONS); do
               dotnet run -c Release -- scan --SourceDirectory ${{ github.workspace }}/smoke-test-repo --Verbosity Verbose || exit 1
           done
 


### PR DESCRIPTION
## Context
We have seen these smoke test runs take forever to be provisioned. I increased parallelism + reduce number of dotnet scans in PR builds to make them finish faster and made them skip execution for draft PRs.