### PR TITLE
Update packageurl-dotnet to 2.0.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,7 +27,7 @@
     <PackageVersion Include="Newtonsoft.Json.Schema" Version="4.0.1" />
     <PackageVersion Include="NuGet.ProjectModel" Version="7.3.0" />
     <PackageVersion Include="NuGet.Versioning" Version="7.3.0" />
-    <PackageVersion Include="packageurl-dotnet" Version="2.0.0-rc.3" />
+    <PackageVersion Include="packageurl-dotnet" Version="2.0.0" />
     <PackageVersion Include="Polly" Version="8.6.6" />
     <PackageVersion Include="SemanticVersioning" Version="2.0.2" />
     <PackageVersion Include="Serilog" Version="4.3.1" />

--- a/docs/creating-a-new-detector.md
+++ b/docs/creating-a-new-detector.md
@@ -104,7 +104,7 @@ public class YourEcosystemComponent : TypedComponent
     public string Version { get; set; }
 
     public override ComponentType Type => ComponentType.YourType;
-    public override PackageUrl PackageUrl => new PackageUrl("your-type", null, this.Name, this.Version, null, null);
+    public override PackageURL PackageUrl => new PackageURL("your-type", null, this.Name, this.Version, null, null);
     protected override string ComputeId() => $"{this.Name} {this.Version} - {this.Type}";
 }
 ```

--- a/src/Microsoft.ComponentDetection.Contracts/TypedComponent/CargoComponent.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/TypedComponent/CargoComponent.cs
@@ -44,7 +44,7 @@ public class CargoComponent : TypedComponent
     public override ComponentType Type => ComponentType.Cargo;
 
     [JsonPropertyName("packageUrl")]
-    public override PackageUrl PackageUrl => new PackageUrl("cargo", string.Empty, this.Name, this.Version, null, string.Empty);
+    public override PackageURL PackageUrl => new PackageURL("cargo", string.Empty, this.Name, this.Version, null, string.Empty);
 
     protected override string ComputeBaseId() => $"{this.Name} {this.Version} - {this.Type}";
 }

--- a/src/Microsoft.ComponentDetection.Contracts/TypedComponent/ConanComponent.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/TypedComponent/ConanComponent.cs
@@ -38,7 +38,7 @@ public class ConanComponent : TypedComponent
     public override ComponentType Type => ComponentType.Conan;
 
     [JsonPropertyName("packageUrl")]
-    public override PackageUrl PackageUrl => new PackageUrl("conan", string.Empty, this.Name, this.Version, null, string.Empty);
+    public override PackageURL PackageUrl => new PackageURL("conan", string.Empty, this.Name, this.Version, null, string.Empty);
 
     protected override string ComputeBaseId() => $"{this.Name} {this.Version} - {this.Type}";
 }

--- a/src/Microsoft.ComponentDetection.Contracts/TypedComponent/CppSdkComponent.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/TypedComponent/CppSdkComponent.cs
@@ -39,7 +39,7 @@ public class CppSdkComponent : TypedComponent
     public override ComponentType Type => ComponentType.CppSdk;
 
     [JsonPropertyName("packageUrl")]
-    public override PackageUrl PackageUrl
+    public override PackageURL PackageUrl
     {
         get
         {
@@ -47,7 +47,7 @@ public class CppSdkComponent : TypedComponent
             {
                 { "type", "cppsdk" },
             };
-            return new PackageUrl("generic", null, this.Name, this.Version, qualifiers, null);
+            return new PackageURL("generic", null, this.Name, this.Version, qualifiers, null);
         }
     }
 

--- a/src/Microsoft.ComponentDetection.Contracts/TypedComponent/GoComponent.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/TypedComponent/GoComponent.cs
@@ -39,13 +39,13 @@ public class GoComponent : TypedComponent, IEquatable<GoComponent>
     // https://github.com/package-url/purl-spec/blame/180c46d266c45aa2bd81a2038af3f78e87bb4a25/README.rst#L610
     // The golang purl spec requires a namespace: https://github.com/package-url/purl-spec/blob/master/types/golang-definition.json
     [JsonPropertyName("packageUrl")]
-    public override PackageUrl PackageUrl
+    public override PackageURL PackageUrl
     {
         get
         {
             var version = string.IsNullOrWhiteSpace(this.Hash) ? this.Version : this.Hash;
             var (ns, name) = this.GetNamespaceAndName();
-            return new PackageUrl("golang", ns, name, version, null, null);
+            return new PackageURL("golang", ns, name, version, null, null);
         }
     }
 

--- a/src/Microsoft.ComponentDetection.Contracts/TypedComponent/LinuxComponent.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/TypedComponent/LinuxComponent.cs
@@ -46,7 +46,7 @@ public class LinuxComponent : TypedComponent
     public override ComponentType Type => ComponentType.Linux;
 
     [JsonPropertyName("packageUrl")]
-    public override PackageUrl PackageUrl
+    public override PackageURL PackageUrl
     {
         get
         {
@@ -63,7 +63,7 @@ public class LinuxComponent : TypedComponent
 
             if (packageType != null)
             {
-                return new PackageUrl(packageType, this.Distribution, this.Name, this.Version, null, null);
+                return new PackageURL(packageType, this.Distribution, this.Name, this.Version, null, null);
             }
 
             return null;

--- a/src/Microsoft.ComponentDetection.Contracts/TypedComponent/MavenComponent.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/TypedComponent/MavenComponent.cs
@@ -31,7 +31,7 @@ public class MavenComponent : TypedComponent
     public override ComponentType Type => ComponentType.Maven;
 
     [JsonPropertyName("packageUrl")]
-    public override PackageUrl PackageUrl => new PackageUrl("maven", this.GroupId, this.ArtifactId, this.Version, null, null);
+    public override PackageURL PackageUrl => new PackageURL("maven", this.GroupId, this.ArtifactId, this.Version, null, null);
 
     protected override string ComputeBaseId() => $"{this.GroupId} {this.ArtifactId} {this.Version} - {this.Type}";
 }

--- a/src/Microsoft.ComponentDetection.Contracts/TypedComponent/NpmComponent.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/TypedComponent/NpmComponent.cs
@@ -36,7 +36,7 @@ public class NpmComponent : TypedComponent
     public override ComponentType Type => ComponentType.Npm;
 
     [JsonPropertyName("packageUrl")]
-    public override PackageUrl PackageUrl => new PackageUrl("npm", null, this.Name, this.Version, null, null);
+    public override PackageURL PackageUrl => new PackageURL("npm", null, this.Name, this.Version, null, null);
 
     protected override string ComputeBaseId() => $"{this.Name} {this.Version} - {this.Type}";
 }

--- a/src/Microsoft.ComponentDetection.Contracts/TypedComponent/NugetComponent.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/TypedComponent/NugetComponent.cs
@@ -31,7 +31,7 @@ public class NuGetComponent : TypedComponent
     public override ComponentType Type => ComponentType.NuGet;
 
     [JsonPropertyName("packageUrl")]
-    public override PackageUrl PackageUrl => new PackageUrl("nuget", null, this.Name, this.Version, null, null);
+    public override PackageURL PackageUrl => new PackageURL("nuget", null, this.Name, this.Version, null, null);
 
     protected override string ComputeBaseId() => $"{this.Name} {this.Version} - {this.Type}";
 }

--- a/src/Microsoft.ComponentDetection.Contracts/TypedComponent/PipComponent.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/TypedComponent/PipComponent.cs
@@ -40,7 +40,7 @@ public class PipComponent : TypedComponent
     public override ComponentType Type => ComponentType.Pip;
 
     [JsonPropertyName("packageUrl")]
-    public override PackageUrl PackageUrl => new PackageUrl("pypi", null, this.Name, this.Version, null, null);
+    public override PackageURL PackageUrl => new PackageURL("pypi", null, this.Name, this.Version, null, null);
 
     [SuppressMessage("Usage", "CA1308:Normalize String to Uppercase", Justification = "Casing cannot be overwritten.")]
     protected override string ComputeBaseId() => $"{this.Name} {this.Version} - {this.Type}".ToLowerInvariant();

--- a/src/Microsoft.ComponentDetection.Contracts/TypedComponent/PodComponent.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/TypedComponent/PodComponent.cs
@@ -32,7 +32,7 @@ public class PodComponent : TypedComponent
     public override ComponentType Type => ComponentType.Pod;
 
     [JsonPropertyName("packageUrl")]
-    public override PackageUrl PackageUrl
+    public override PackageURL PackageUrl
     {
         get
         {
@@ -42,7 +42,7 @@ public class PodComponent : TypedComponent
                 qualifiers.Add("repository_url", this.SpecRepo);
             }
 
-            return new PackageUrl("cocoapods", null, this.Name, this.Version, qualifiers, null);
+            return new PackageURL("cocoapods", null, this.Name, this.Version, qualifiers, null);
         }
     }
 

--- a/src/Microsoft.ComponentDetection.Contracts/TypedComponent/RubyGemsComponent.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/TypedComponent/RubyGemsComponent.cs
@@ -31,7 +31,7 @@ public class RubyGemsComponent : TypedComponent
     public override ComponentType Type => ComponentType.RubyGems;
 
     [JsonPropertyName("packageUrl")]
-    public override PackageUrl PackageUrl => new PackageUrl("gem", null, this.Name, this.Version, null, null);
+    public override PackageURL PackageUrl => new PackageURL("gem", null, this.Name, this.Version, null, null);
 
     protected override string ComputeBaseId() => $"{this.Name} {this.Version} - {this.Type}";
 }

--- a/src/Microsoft.ComponentDetection.Contracts/TypedComponent/SwiftComponent.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/TypedComponent/SwiftComponent.cs
@@ -45,7 +45,7 @@ public class SwiftComponent : TypedComponent
     // namespace: github.com/apple
     // name: swift-asn1
     [JsonPropertyName("packageUrl")]
-    public override PackageUrl PackageUrl => new PackageUrl(
+    public override PackageURL PackageUrl => new PackageURL(
         type: "swift",
         @namespace: this.GetNamespaceFromPackageUrl(),
         name: this.Name,

--- a/src/Microsoft.ComponentDetection.Contracts/TypedComponent/TypedComponent.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/TypedComponent/TypedComponent.cs
@@ -61,7 +61,7 @@ public abstract class TypedComponent
     public string BaseId => this.baseId ??= this.ComputeBaseId();
 
     [SystemTextJson.JsonPropertyName("packageUrl")]
-    public virtual PackageUrl PackageUrl { get; }
+    public virtual PackageURL PackageUrl { get; }
 
     /// <summary>Gets or sets SPDX license expression(s) declared by the package author.</summary>
     [JsonProperty("licenses", NullValueHandling = NullValueHandling.Ignore)]

--- a/src/Microsoft.ComponentDetection.Contracts/TypedComponent/VcpkgComponent.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/TypedComponent/VcpkgComponent.cs
@@ -50,7 +50,7 @@ public class VcpkgComponent : TypedComponent
     public override ComponentType Type => ComponentType.Vcpkg;
 
     [JsonPropertyName("packageUrl")]
-    public override PackageUrl PackageUrl
+    public override PackageURL PackageUrl
     {
         get
         {
@@ -58,7 +58,7 @@ public class VcpkgComponent : TypedComponent
                 ? new SortedDictionary<string, string> { { "port_version", this.PortVersion.ToString() } }
                 : null;
 
-            return new PackageUrl("vcpkg", null, this.Name, this.Version, qualifiers, null);
+            return new PackageURL("vcpkg", null, this.Name, this.Version, qualifiers, null);
         }
     }
 

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/SwiftComponentTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/SwiftComponentTests.cs
@@ -102,7 +102,7 @@ public class SwiftComponentTests
 
         var component = new SwiftComponent(name, version, packageUrl, hash);
 
-        var expectedPackageURL = new PackageUrl(
+        var expectedPackageURL = new PackageURL(
             type: "swift",
             @namespace: "github.com/Alamofire",
             name: name,
@@ -124,7 +124,7 @@ public class SwiftComponentTests
 
         var component = new SwiftComponent(name, version, packageUrl, hash);
 
-        var expectedPackageURL = new PackageUrl(
+        var expectedPackageURL = new PackageURL(
             type: "swift",
             @namespace: "github.com/Alamofire",
             name: name,
@@ -149,7 +149,7 @@ public class SwiftComponentTests
 
         var component = new SwiftComponent(name, version, packageUrl, hash);
 
-        var expectedPackageURL = new PackageUrl(
+        var expectedPackageURL = new PackageURL(
             type: "swift",
             @namespace: "otherhostname.com",
             name: name,


### PR DESCRIPTION
Bumps `packageurl-dotnet` from `2.0.0-rc.3` to `2.0.0`. The stable release renamed the `PackageUrl` class to `PackageURL`, so this PR updates all references across the TypedComponent classes, docs, and tests to match.