### PR TITLE
Broaden NPM detection for VS Code extensions

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/npm/NpmComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/npm/NpmComponentDetector.cs
@@ -38,7 +38,7 @@ public class NpmComponentDetector : FileComponentDetector
 
     public override IEnumerable<ComponentType> SupportedComponentTypes { get; } = [ComponentType.Npm];
 
-    public override int Version { get; } = 3;
+    public override int Version { get; } = 4;
 
     protected override async Task OnFileFoundAsync(ProcessRequest processRequest, IDictionary<string, string> detectorArgs, CancellationToken cancellationToken = default)
     {
@@ -79,20 +79,6 @@ public class NpmComponentDetector : FileComponentDetector
         {
             this.Logger.LogWarning("Unable to parse version {NpmPackageVersion} for package {NpmPackageName} found at path {NpmPackageLocation}. This may indicate an invalid npm package component and it will not be registered.", version, name, filePath);
             singleFileComponentRecorder.RegisterPackageParseFailure($"{name} - {version}");
-            return false;
-        }
-
-        // Check for VS Code extensions
-        // See https://code.visualstudio.com/api/working-with-extensions/publishing-extension#visual-studio-code-compatibility
-        var containsVsCodeEngine = false;
-        if (packageJson.Engines is not null && packageJson.Engines.ContainsKey("vscode"))
-        {
-            containsVsCodeEngine = true;
-        }
-
-        if (containsVsCodeEngine)
-        {
-            this.Logger.LogInformation("{NpmPackageName} found at path {NpmPackageLocation} represents a built-in VS Code extension. This package will not be registered.", name, filePath);
             return false;
         }
 

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/NpmDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/NpmDetectorTests.cs
@@ -227,7 +227,7 @@ public class NpmDetectorTests
     }
 
     [TestMethod]
-    public async Task TestNpmDetector_VSCodeEngineCausesSkippedPackageAsync()
+    public async Task TestNpmDetector_VSCodeEnginePackageIsDetectedAsync()
     {
         var componentName = GetRandomString();
         var version = NewRandomVersion();
@@ -239,7 +239,11 @@ public class NpmDetectorTests
             .ExecuteDetectorAsync();
         scanResult.ResultCode.Should().Be(ProcessingResultCode.Success);
         var detectedComponents = componentRecorder.GetDetectedComponents();
-        detectedComponents.Should().BeEmpty();
+        detectedComponents.Should().ContainSingle();
+        detectedComponents.Single().Component.Type.Should().Be(ComponentType.Npm);
+        var detectedNpmComponent = (NpmComponent)detectedComponents.Single().Component;
+        detectedNpmComponent.Name.Should().Be(componentName);
+        detectedNpmComponent.Version.Should().Be(version);
     }
 
     [TestMethod]
@@ -256,7 +260,11 @@ public class NpmDetectorTests
             .ExecuteDetectorAsync();
         scanResult.ResultCode.Should().Be(ProcessingResultCode.Success);
         var detectedComponents = componentRecorder.GetDetectedComponents();
-        detectedComponents.Should().BeEmpty();
+        detectedComponents.Should().ContainSingle();
+        detectedComponents.Single().Component.Type.Should().Be(ComponentType.Npm);
+        var detectedNpmComponent = (NpmComponent)detectedComponents.Single().Component;
+        detectedNpmComponent.Name.Should().Be(packageName);
+        detectedNpmComponent.Version.Should().Be(packageVersion);
     }
 
     [TestMethod]


### PR DESCRIPTION
Context: https://github.com/microsoft/component-detection/pull/1348
Context: https://github.com/microsoft/vscode/pull/295040

Commit a2093939 added logic to ignore NPM dependencies declared in a
package.json file if it belonged to a VS Code extension. This was done
to ignore warnings for out of date package versions that are built
directly into VS Code, however it also limits detection capabilities for
all VS Code extension files.

A change was made to bump the built in package versions in VS Code in
commit https://github.com/microsoft/vscode/commit/e987c5242eb3078429d3a6bb05f4d485c1bf79e5
which should allow us to revert this change and restore broader NPM
detection for VS Code extensions.