### PR TITLE
Populate conda-lock md5 and sha256 in scan manifests

### DIFF
--- a/src/Microsoft.ComponentDetection.Contracts/TypedComponent/CondaComponent.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/TypedComponent/CondaComponent.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 
 public class CondaComponent : TypedComponent
 {
-    public CondaComponent(string name, string version, string build, string channel, string subdir, string @namespace, string url, string md5)
+    public CondaComponent(string name, string version, string build, string channel, string subdir, string @namespace, string url, string md5, string sha256 = null)
     {
         this.Name = this.ValidateRequiredInput(name, nameof(this.Name), nameof(ComponentType.Conda));
         this.Version = this.ValidateRequiredInput(version, nameof(this.Version), nameof(ComponentType.Conda));
@@ -15,6 +15,7 @@ public class CondaComponent : TypedComponent
         this.Namespace = @namespace;
         this.Url = url;
         this.MD5 = md5;
+        this.Sha256 = sha256;
     }
 
     public CondaComponent()
@@ -46,8 +47,12 @@ public class CondaComponent : TypedComponent
     [JsonPropertyName("mD5")]
     public string MD5 { get; set; }
 
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("sha256")]
+    public string Sha256 { get; set; }
+
     [JsonIgnore]
     public override ComponentType Type => ComponentType.Conda;
 
-    protected override string ComputeBaseId() => $"{this.Name} {this.Version} {this.Build} {this.Channel} {this.Subdir} {this.Namespace} {this.Url} {this.MD5} - {this.Type}";
+    protected override string ComputeBaseId() => $"{this.Name} {this.Version} {this.Build} {this.Channel} {this.Subdir} {this.Namespace} {this.Url} {this.MD5} {this.Sha256} - {this.Type}";
 }

--- a/src/Microsoft.ComponentDetection.Contracts/TypedComponent/PipComponent.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/TypedComponent/PipComponent.cs
@@ -34,6 +34,14 @@ public class PipComponent : TypedComponent
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("license")]
     public string? License { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("mD5")]
+    public string? Md5 { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("sha256")]
+    public string? Sha256 { get; set; }
 #nullable disable
 
     [JsonIgnore]
@@ -43,5 +51,18 @@ public class PipComponent : TypedComponent
     public override PackageURL PackageUrl => new PackageURL("pypi", null, this.Name, this.Version, null, null);
 
     [SuppressMessage("Usage", "CA1308:Normalize String to Uppercase", Justification = "Casing cannot be overwritten.")]
-    protected override string ComputeBaseId() => $"{this.Name} {this.Version} - {this.Type}".ToLowerInvariant();
+    protected override string ComputeBaseId()
+    {
+        var digestSuffix = string.Empty;
+        if (!string.IsNullOrEmpty(this.Sha256))
+        {
+            digestSuffix = $" {this.Sha256}";
+        }
+        else if (!string.IsNullOrEmpty(this.Md5))
+        {
+            digestSuffix = $" {this.Md5}";
+        }
+
+        return $"{this.Name} {this.Version}{digestSuffix} - {this.Type}".ToLowerInvariant();
+    }
 }

--- a/src/Microsoft.ComponentDetection.Detectors/conda/CondaDependencyResolver.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/conda/CondaDependencyResolver.cs
@@ -122,9 +122,47 @@ public static class CondaDependencyResolver
     /// <param name="package">The CondaPackage to convert.</param>
     /// <returns>The TypedComponent.</returns>
     private static TypedComponent CreateComponent(CondaPackage package)
-        => IsPythonPackage(package)
-                ? new PipComponent(package.Name, package.Version)
-                : new CondaComponent(package.Name, package.Version, null, package.Category, null, null, null, null);
+    {
+        var md5 = TryGetHash(package.Hash, "md5");
+        var sha256 = TryGetHash(package.Hash, "sha256");
+
+        if (IsPythonPackage(package))
+        {
+            return new PipComponent(package.Name, package.Version)
+            {
+                Md5 = md5,
+                Sha256 = sha256,
+            };
+        }
+
+        return new CondaComponent(package.Name, package.Version, null, package.Category, null, null, null, md5, sha256);
+    }
+
+    /// <summary>
+    /// Reads a digest value from conda-lock's per-package hash map (YAML keys are typically lowercase md5 / sha256).
+    /// </summary>
+    private static string TryGetHash(Dictionary<string, string> hash, string key)
+    {
+        if (hash is null || key is null)
+        {
+            return null;
+        }
+
+        if (hash.TryGetValue(key, out var exact) && !string.IsNullOrEmpty(exact))
+        {
+            return exact;
+        }
+
+        foreach (var kv in hash)
+        {
+            if (string.Equals(kv.Key, key, StringComparison.OrdinalIgnoreCase) && !string.IsNullOrEmpty(kv.Value))
+            {
+                return kv.Value;
+            }
+        }
+
+        return null;
+    }
 
     /// <summary>
     /// Checks if a package is a python package.

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/CondaLockComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/CondaLockComponentDetectorTests.cs
@@ -102,6 +102,32 @@ package:
         this.AssertPipComponentNameAndVersion(detectedComponents, "requests", "2.31.0");
 
         detectedComponents.Should().HaveCount(4);
+
+        var condaLockTop = detectedComponents.Single(c =>
+            c.Component is CondaComponent cl &&
+            cl.Name.Equals("conda-lock") &&
+            cl.Version.Equals("2.1.0")).Component as CondaComponent;
+        condaLockTop!.MD5.Should().Be("1e07afcf3d3e371fc3a3681fe9b78e90");
+        condaLockTop.Sha256.Should().Be("05319e84cbd36f6a05563954d2dbff041de6ece406a59650784918026080c98c");
+
+        var urllib = detectedComponents.Single(c =>
+            c.Component is CondaComponent u &&
+            u.Name.Equals("urllib3") &&
+            u.Version.Equals("1.26.16")).Component as CondaComponent;
+        urllib!.MD5.Should().Be("4b62a74f7e797800039971833968e23f");
+        urllib.Sha256.Should().Be("b9e919a9bcb4cb291fe60952895bf0c3ce9dbcbeaa3d5706131f862756fabc40");
+
+        var requests = detectedComponents.Single(c =>
+            c.Component is PipComponent r &&
+            r.Name.Equals("requests") &&
+            r.Version.Equals("2.31.0")).Component as PipComponent;
+        requests!.Sha256.Should().Be("58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f");
+
+        var certifi = detectedComponents.Single(c =>
+            c.Component is PipComponent cf &&
+            cf.Name.Equals("certifi") &&
+            cf.Version.Equals("2023.5.7")).Component as PipComponent;
+        certifi!.Sha256.Should().Be("c6c2e98f5c7869efca1f8916fed228dd91539f9f1b444c314c06eef02980c716");
     }
 
     private void AssertCondaLockComponentNameAndVersion(IEnumerable<DetectedComponent> detectedComponents, string name, string version)


### PR DESCRIPTION
Example PR to include sha256 to conda lock file processing and fixes md5 processing.

Current Example of CondaLock Processed Data

```
        {
          "type": "Pip",
          "name": "numpy",
          "version": "2.3.1",
          "mD5": "0171b383099fd3a77ddd04ee03cdd465",
          "sha256": "94ea6881025447d64f931cdd8d7aeb6fc7a6b6546561ef8dd5b594f641c6094b",
          "packageUrl": {
            "Scheme": "pkg",
            "Type": "pypi",
            "Namespace": null,
            "Name": "numpy",
            "Version": "2.3.1",
            "Qualifiers": null,
            "Subpath": null
          },
          "id": "numpy 2.3.1 94ea6881025447d64f931cdd8d7aeb6fc7a6b6546561ef8dd5b594f641c6094b - pip"
        },
```

CondaLock Data with SHA256 added and MD5 included

```
        {
          "type": "Pip",
          "name": "numpy",
          "version": "2.4.4",
          "mD5": "33ccfd78de458154c7a612534714e4b8",
          "sha256": "f632c4226d8954868a4421ca221c630d6282e4607f3fb8c4ad3d018c7a48b543",
          "packageUrl": {
            "Scheme": "pkg",
            "Type": "pypi",
            "Namespace": null,
            "Name": "numpy",
            "Version": "2.4.4",
            "Qualifiers": null,
            "Subpath": null
          },
          "id": "numpy 2.4.4 f632c4226d8954868a4421ca221c630d6282e4607f3fb8c4ad3d018c7a48b543 - pip"
        },
```