### PR TITLE
Promote the DockerCompose, Dockerfile, and Helm detectors to default on.

### DIFF
--- a/docs/detectors/dockercompose.md
+++ b/docs/detectors/dockercompose.md
@@ -6,8 +6,6 @@ Docker Compose detection depends on the following to successfully run:
 
 - One or more Docker Compose files matching the patterns: `docker-compose.yml`, `docker-compose.yaml`, `docker-compose.*.yml`, `docker-compose.*.yaml`, `compose.yml`, `compose.yaml`, `compose.*.yml`, `compose.*.yaml`
 
-The `DockerComposeComponentDetector` is an **Experimental** detector. It runs automatically during scans, but its output is not included in the final scan results. To include its output, pass `--DetectorArgs DockerCompose=Enable` (the key is the detector Id `DockerCompose`, not the class name).
-
 ## Detection strategy
 
 The Docker Compose detector parses YAML compose files to extract Docker image references from service definitions.
@@ -42,7 +40,6 @@ Images containing unresolved variables (e.g., `${TAG}` or `${REGISTRY:-docker.io
 
 ## Known limitations
 
-- **Experimental Status**: This detector runs automatically but its output is not included in scan results by default. To opt in, pass `--DetectorArgs DockerCompose=Enable`
 - **Variable Resolution**: Image references containing unresolved environment variables or template expressions are not reported, which may lead to under-reporting in compose files that heavily use variable substitution
 - **Build-Only Services**: Services that only specify a `build` directive without an `image` field are not reported
 - **No Dependency Graph**: All detected images are registered as independent components without parent-child relationships

--- a/docs/detectors/dockerfile.md
+++ b/docs/detectors/dockerfile.md
@@ -6,8 +6,6 @@ Dockerfile detection depends on the following to successfully run:
 
 - One or more Dockerfile files matching the patterns: `dockerfile`, `dockerfile.*`, or `*.dockerfile`
 
-The `DockerfileComponentDetector` is an **Experimental** detector. It runs automatically during scans, but its output is not included in the final scan results. To include its output, pass `--DetectorArgs DockerReference=Enable` (the key is the detector Id `DockerReference`, not the class name).
-
 ## Detection strategy
 
 The Dockerfile detector parses Dockerfile syntax to extract Docker image references from `FROM` and `COPY --from` instructions. It uses the [Valleysoft.DockerfileModel](https://github.com/mthalman/DockerfileModel) library to parse Dockerfile syntax.
@@ -32,7 +30,6 @@ The detector supports the full Docker reference grammar via `DockerReferenceUtil
 
 ## Known limitations
 
-- **Experimental Status**: This detector runs automatically but its output is not included in scan results by default. To opt in, pass `--DetectorArgs DockerReference=Enable`
 - **Variable Resolution**: Image references containing unresolved Dockerfile `ARG` or `ENV` variables are not reported, which may lead to under-reporting in Dockerfiles that heavily use build-time variables
 - **No Version Pinning Validation**: The detector does not warn about unpinned image versions (e.g., `latest` tags), which are generally discouraged in production Dockerfiles
 - **Untagged Images Skipped**: Image references with neither a tag nor a digest (e.g. `FROM nginx`) are skipped because they cannot be uniquely identified

--- a/docs/detectors/helm.md
+++ b/docs/detectors/helm.md
@@ -8,8 +8,6 @@ Helm detection depends on the following to successfully run:
 - A chart metadata file named `Chart.yaml` or `Chart.yml` must exist in the same directory for file discovery/co-location checks; only values files are parsed for image references
   - Lowercase `chart.yaml` and `chart.yml` do not satisfy this requirement; the detector requires an uppercase `Chart.*` file name.
 
-The `HelmComponentDetector` is an **Experimental** detector. It runs automatically during scans, but its output is not included in the final scan results. To include its output, pass `--DetectorArgs Helm=Enable` (the key is the detector Id `Helm`, not the class name).
-
 ## Detection strategy
 
 The Helm detector parses Helm values YAML files to extract Docker image references. It recursively walks the YAML tree looking for `image` keys.
@@ -45,7 +43,6 @@ Images containing unresolved variables (e.g., `{{ .Values.tag }}`) are skipped t
 
 ## Known limitations
 
-- **Experimental Status**: This detector runs automatically but its output is not included in scan results by default. To opt in, pass `--DetectorArgs Helm=Enable`
 - **Values Files Only**: Only files with `values` in the name are parsed for image references. Chart.yaml files are matched but not processed
 - **Same-Directory Co-location**: Values files are only processed when a `Chart.yaml` (or `Chart.yml`) exists in the **same directory**. Values files in subdirectories of a chart root (e.g., `mychart/subdir/values.yaml`) will not be detected, even if a `Chart.yaml` exists in the parent directory
 - **Variable Resolution**: Image references containing unresolved Helm template expressions are not reported

--- a/src/Microsoft.ComponentDetection.Detectors/dockercompose/DockerComposeComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/dockercompose/DockerComposeComponentDetector.cs
@@ -12,7 +12,7 @@ using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.Extensions.Logging;
 using YamlDotNet.RepresentationModel;
 
-public class DockerComposeComponentDetector : FileComponentDetector, IExperimentalDetector
+public class DockerComposeComponentDetector : FileComponentDetector
 {
     public DockerComposeComponentDetector(
         IComponentStreamEnumerableFactory componentStreamEnumerableFactory,

--- a/src/Microsoft.ComponentDetection.Detectors/dockerfile/DockerfileComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/dockerfile/DockerfileComponentDetector.cs
@@ -12,7 +12,7 @@ using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.Extensions.Logging;
 using Valleysoft.DockerfileModel;
 
-public class DockerfileComponentDetector : FileComponentDetector, IExperimentalDetector
+public class DockerfileComponentDetector : FileComponentDetector
 {
     private readonly ICommandLineInvocationService commandLineInvocationService;
     private readonly IEnvironmentVariableService envVarService;

--- a/src/Microsoft.ComponentDetection.Detectors/helm/HelmComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/helm/HelmComponentDetector.cs
@@ -15,7 +15,7 @@ using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.Extensions.Logging;
 using YamlDotNet.RepresentationModel;
 
-public class HelmComponentDetector : FileComponentDetector, IExperimentalDetector
+public class HelmComponentDetector : FileComponentDetector
 {
     public HelmComponentDetector(
         IComponentStreamEnumerableFactory componentStreamEnumerableFactory,


### PR DESCRIPTION
This pull request removes the "experimental" status from three component detectors: Docker Compose, Dockerfile, and Helm. The detectors are now considered stable, and their outputs are included in scan results by default, without requiring special command-line arguments. Documentation has been updated to reflect this change, and the `IExperimentalDetector` interface has been removed from the relevant classes.

**Detector status changes:**

* Removed the `IExperimentalDetector` interface from `DockerComposeComponentDetector`, `DockerfileComponentDetector`, and `HelmComponentDetector`, making them standard detectors. [[1]](diffhunk://#diff-a9b40d15d378b0e871e2fb2b8f6098c78b9096b32760fdb3317944a617325c53L15-R15) [[2]](diffhunk://#diff-2de1c0753c5780a690053247597268c988843a0c22e4a6857e48844c11e854f6L15-R15) [[3]](diffhunk://#diff-859d89abc3cb4cad8e2029c9a1cfb79fa2f558b19fbe90bcbf8cc6c5d91dbf5cL18-R18)

**Documentation updates:**

* Updated `docs/detectors/dockercompose.md` to remove references to experimental status and the need for `--DetectorArgs DockerCompose=Enable`. [[1]](diffhunk://#diff-116f7957753a1c73494d995ee199145f02019e5eee4323d8065fb7099ba62829L9-L10) [[2]](diffhunk://#diff-116f7957753a1c73494d995ee199145f02019e5eee4323d8065fb7099ba62829L45)
* Updated `docs/detectors/dockerfile.md` to remove references to experimental status and the need for `--DetectorArgs DockerReference=Enable`. [[1]](diffhunk://#diff-e99ec66af6522e522cce6ac3ab44c517a6638650f9d32eb4743112c3a0e9cb42L9-L10) [[2]](diffhunk://#diff-e99ec66af6522e522cce6ac3ab44c517a6638650f9d32eb4743112c3a0e9cb42L35)
* Updated `docs/detectors/helm.md` to remove references to experimental status and the need for `--DetectorArgs Helm=Enable`. [[1]](diffhunk://#diff-066851a732aff661102b7a1005f923beffbe621282f3b982087b25a07da8ed22L11-L12) [[2]](diffhunk://#diff-066851a732aff661102b7a1005f923beffbe621282f3b982087b25a07da8ed22L48)

These changes mean that users will now see Docker Compose, Dockerfile, and Helm detection results in their scans by default, improving usability and reducing configuration complexity.