### PR TITLE
feat: defensive identity overrides for MavenComponent and GitComponent

### DIFF
--- a/src/Microsoft.ComponentDetection.Contracts/TypedComponent/GitComponent.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/TypedComponent/GitComponent.cs
@@ -2,10 +2,15 @@
 namespace Microsoft.ComponentDetection.Contracts.TypedComponent;
 
 using System;
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
+using PackageUrl;
 
 public class GitComponent : TypedComponent
 {
+    private const string GithubHost = "github.com";
+    private const string DotGitSuffix = ".git";
+
     public GitComponent(Uri repositoryUrl, string commitHash)
     {
         this.RepositoryUrl = this.ValidateRequiredInput(repositoryUrl, nameof(this.RepositoryUrl), nameof(ComponentType.Git));
@@ -32,5 +37,79 @@ public class GitComponent : TypedComponent
     [JsonIgnore]
     public override ComponentType Type => ComponentType.Git;
 
+    /// <summary>
+    /// Gets <c>pkg:github/{owner}/{repo}@{commit}</c> for repositories hosted on github.com whose
+    /// path resolves cleanly to <c>owner/repo</c>; null for any other host (gitlab, bitbucket, ADO,
+    /// GitHub Enterprise, etc.) or malformed paths. Consumers should fall back to
+    /// <see cref="RepositoryUrl"/> when this returns null.
+    /// </summary>
+    [JsonPropertyName("packageUrl")]
+    public override PackageURL PackageUrl
+    {
+        get
+        {
+            if (string.IsNullOrEmpty(this.CommitHash)
+                || !TryGetGithubOwnerAndRepo(this.RepositoryUrl, out var owner, out var repo))
+            {
+                return null;
+            }
+
+            return new PackageURL("github", owner, repo, this.CommitHash, null, null);
+        }
+    }
+
     protected override string ComputeBaseId() => $"{this.RepositoryUrl} : {this.CommitHash} - {this.Type}";
+
+    /// <summary>
+    /// Suppresses the base impl so <see cref="TypedComponent.Id"/> stays stable if a detector later
+    /// populates <see cref="TypedComponent.DownloadUrl"/> or <see cref="TypedComponent.SourceUrl"/>.
+    /// RepositoryUrl and CommitHash are already in BaseId; the GitHub archive download URL is
+    /// deterministic and source URL would duplicate RepositoryUrl.
+    /// </summary>
+    /// <returns>An empty sequence.</returns>
+    protected override IEnumerable<KeyValuePair<string, string>> GetExtendedIdProperties()
+    {
+        yield break;
+    }
+
+    private static bool TryGetGithubOwnerAndRepo(Uri repositoryUrl, out string owner, out string repo)
+    {
+        owner = null;
+        repo = null;
+
+        if (repositoryUrl == null
+            || !repositoryUrl.IsAbsoluteUri
+            || !string.Equals(repositoryUrl.Host, GithubHost, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var trimmedPath = repositoryUrl.AbsolutePath?.Trim('/');
+        if (string.IsNullOrEmpty(trimmedPath))
+        {
+            return false;
+        }
+
+        var segments = trimmedPath.Split('/');
+        if (segments.Length != 2)
+        {
+            return false;
+        }
+
+        var ownerSegment = segments[0];
+        var repoSegment = segments[1];
+        if (repoSegment.EndsWith(DotGitSuffix, StringComparison.OrdinalIgnoreCase))
+        {
+            repoSegment = repoSegment.Substring(0, repoSegment.Length - DotGitSuffix.Length);
+        }
+
+        if (string.IsNullOrEmpty(ownerSegment) || string.IsNullOrEmpty(repoSegment))
+        {
+            return false;
+        }
+
+        owner = ownerSegment;
+        repo = repoSegment;
+        return true;
+    }
 }

--- a/src/Microsoft.ComponentDetection.Contracts/TypedComponent/GitComponent.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/TypedComponent/GitComponent.cs
@@ -48,7 +48,7 @@ public class GitComponent : TypedComponent
     {
         get
         {
-            if (string.IsNullOrEmpty(this.CommitHash)
+            if (string.IsNullOrWhiteSpace(this.CommitHash)
                 || !TryGetGithubOwnerAndRepo(this.RepositoryUrl, out var owner, out var repo))
             {
                 return null;

--- a/src/Microsoft.ComponentDetection.Contracts/TypedComponent/MavenComponent.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/TypedComponent/MavenComponent.cs
@@ -1,6 +1,7 @@
 #nullable disable
 namespace Microsoft.ComponentDetection.Contracts.TypedComponent;
 
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using PackageUrl;
 
@@ -34,4 +35,16 @@ public class MavenComponent : TypedComponent
     public override PackageURL PackageUrl => new PackageURL("maven", this.GroupId, this.ArtifactId, this.Version, null, null);
 
     protected override string ComputeBaseId() => $"{this.GroupId} {this.ArtifactId} {this.Version} - {this.Type}";
+
+    /// <summary>
+    /// Suppresses the base impl so <see cref="TypedComponent.Id"/> stays stable if a detector later
+    /// populates <see cref="TypedComponent.DownloadUrl"/> or <see cref="TypedComponent.SourceUrl"/>.
+    /// GroupId/ArtifactId/Version are already in BaseId; the Maven Central download URL is deterministic
+    /// and source/repo URLs are surfaced server-side from the POM.
+    /// </summary>
+    /// <returns>An empty sequence.</returns>
+    protected override IEnumerable<KeyValuePair<string, string>> GetExtendedIdProperties()
+    {
+        yield break;
+    }
 }

--- a/test/Microsoft.ComponentDetection.Contracts.Tests/PurlGenerationTests.cs
+++ b/test/Microsoft.ComponentDetection.Contracts.Tests/PurlGenerationTests.cs
@@ -1,6 +1,7 @@
 #nullable disable
 namespace Microsoft.ComponentDetection.Contracts.Tests;
 
+using System;
 using AwesomeAssertions;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -109,5 +110,97 @@ public class PurlGenerationTests
         var packageOne = new PodComponent("AFNetworking", "4.0.1", "https://custom_repo.example.com/path/to/repo/specs.git");
 
         packageOne.PackageUrl.ToString().Should().Be("pkg:cocoapods/AFNetworking@4.0.1?repository_url=https:%2F%2Fcustom_repo.example.com%2Fpath%2Fto%2Frepo%2Fspecs.git");
+    }
+
+    [TestMethod]
+    public void MavenComponentShouldGenerateMavenPurl()
+    {
+        // https://github.com/package-url/purl-spec/blob/b8ddd39a6d533b8895f3b741f2e62e2695d82aa4/PURL-TYPES.rst#maven
+        var component = new MavenComponent("com.google.guava", "guava", "33.0-jre");
+
+        component.PackageUrl.Type.Should().Be("maven");
+        component.PackageUrl.Namespace.Should().Be("com.google.guava");
+        component.PackageUrl.Name.Should().Be("guava");
+        component.PackageUrl.Version.Should().Be("33.0-jre");
+        component.PackageUrl.ToString().Should().Be("pkg:maven/com.google.guava/guava@33.0-jre");
+    }
+
+    [TestMethod]
+    public void GitComponentGithubRepositoryShouldGenerateGithubPurl()
+    {
+        // https://github.com/package-url/purl-spec/blob/b8ddd39a6d533b8895f3b741f2e62e2695d82aa4/PURL-TYPES.rst#github
+        var component = new GitComponent(new Uri("https://github.com/google/guava"), "abcdef1234567890");
+
+        component.PackageUrl.Type.Should().Be("github");
+        component.PackageUrl.Namespace.Should().Be("google");
+        component.PackageUrl.Name.Should().Be("guava");
+        component.PackageUrl.Version.Should().Be("abcdef1234567890");
+        component.PackageUrl.ToString().Should().Be("pkg:github/google/guava@abcdef1234567890");
+    }
+
+    [TestMethod]
+    public void GitComponentGithubRepositoryWithDotGitSuffixShouldStripIt()
+    {
+        var component = new GitComponent(new Uri("https://github.com/google/guava.git"), "abcdef1234567890");
+
+        component.PackageUrl.Name.Should().Be("guava", "the .git suffix is not part of the canonical repo name");
+        component.PackageUrl.ToString().Should().Be("pkg:github/google/guava@abcdef1234567890");
+    }
+
+    [TestMethod]
+    public void GitComponentGithubRepositoryWithTrailingSlashShouldBeNormalized()
+    {
+        var component = new GitComponent(new Uri("https://github.com/google/guava/"), "abcdef1234567890");
+
+        component.PackageUrl.ToString().Should().Be("pkg:github/google/guava@abcdef1234567890");
+    }
+
+    [TestMethod]
+    public void GitComponentGithubHostMatchIsCaseInsensitive()
+    {
+        var component = new GitComponent(new Uri("https://GitHub.com/google/guava"), "abcdef1234567890");
+
+        component.PackageUrl.ToString().Should().Be("pkg:github/google/guava@abcdef1234567890");
+    }
+
+    [TestMethod]
+    public void GitComponentNonGithubRepositoryShouldHaveNoPackageUrl()
+    {
+        // GitLab / Bitbucket / Azure DevOps / GitHub Enterprise have no canonical PURL representation today.
+        // Consumers should fall back to RepositoryUrl in this case.
+        var gitlab = new GitComponent(new Uri("https://gitlab.com/foo/bar"), "abcdef1234567890");
+        var bitbucket = new GitComponent(new Uri("https://bitbucket.org/foo/bar"), "abcdef1234567890");
+        var ado = new GitComponent(new Uri("https://dev.azure.com/org/proj/_git/repo"), "abcdef1234567890");
+        var ghEnterprise = new GitComponent(new Uri("https://github.contoso.com/foo/bar"), "abcdef1234567890");
+
+        gitlab.PackageUrl.Should().BeNull();
+        bitbucket.PackageUrl.Should().BeNull();
+        ado.PackageUrl.Should().BeNull();
+        ghEnterprise.PackageUrl.Should().BeNull();
+    }
+
+    [TestMethod]
+    public void GitComponentMalformedGithubUrlShouldHaveNoPackageUrl()
+    {
+        // Owner only, or paths deeper than owner/repo (e.g. browse URLs) — not canonical repository URLs.
+        var ownerOnly = new GitComponent(new Uri("https://github.com/google"), "abcdef1234567890");
+        var tooDeep = new GitComponent(new Uri("https://github.com/google/guava/tree/main"), "abcdef1234567890");
+        var rootOnly = new GitComponent(new Uri("https://github.com/"), "abcdef1234567890");
+
+        ownerOnly.PackageUrl.Should().BeNull();
+        tooDeep.PackageUrl.Should().BeNull();
+        rootOnly.PackageUrl.Should().BeNull();
+    }
+
+    [TestMethod]
+    public void GitComponentMissingCommitHashShouldHaveNoPackageUrl()
+    {
+        // CommitHash is required via the public ctor, but the parameterless deserialization ctor allows null.
+        var component = new GitComponent
+        {
+            RepositoryUrl = new Uri("https://github.com/google/guava"),
+        };
+
+        component.PackageUrl.Should().BeNull();
     }
 }

--- a/test/Microsoft.ComponentDetection.Contracts.Tests/PurlGenerationTests.cs
+++ b/test/Microsoft.ComponentDetection.Contracts.Tests/PurlGenerationTests.cs
@@ -203,4 +203,17 @@ public class PurlGenerationTests
 
         component.PackageUrl.Should().BeNull();
     }
+
+    [TestMethod]
+    public void GitComponentWhitespaceCommitHashShouldHaveNoPackageUrl()
+    {
+        // CommitHash is required via the public ctor, but the parameterless deserialization ctor can carry whitespace.
+        var component = new GitComponent
+        {
+            RepositoryUrl = new Uri("https://github.com/google/guava"),
+            CommitHash = "   ",
+        };
+
+        component.PackageUrl.Should().BeNull();
+    }
 }

--- a/test/Microsoft.ComponentDetection.Contracts.Tests/TypedComponentSerializationTests.cs
+++ b/test/Microsoft.ComponentDetection.Contracts.Tests/TypedComponentSerializationTests.cs
@@ -504,4 +504,36 @@ public class TypedComponentSerializationTests
         tc.BaseId.Should().Be("TestPackage 1.0.0 - NuGet");
         tc.Id.Should().Be("TestPackage 1.0.0 - NuGet [DownloadUrl:https://example.com/package/1.0.0 SourceUrl:https://github.com/test-org/TestPackage]");
     }
+
+    [TestMethod]
+    public void MavenComponent_Id_ExcludesDownloadUrlAndSourceUrl_WhenSet()
+    {
+        // MavenComponent overrides GetExtendedIdProperties to keep Id stable across detectors that
+        // may or may not populate DownloadUrl / SourceUrl (e.g. CDS surfaces SourceUrl from the POM,
+        // and DownloadUrl is deterministic from GAV — neither should affect identity).
+        var tc = new MavenComponent("com.google.guava", "guava", "33.0-jre")
+        {
+            DownloadUrl = new Uri("https://repo1.maven.org/maven2/com/google/guava/guava/33.0-jre/guava-33.0-jre.jar"),
+            SourceUrl = new Uri("https://github.com/google/guava"),
+        };
+
+        tc.BaseId.Should().Be("com.google.guava guava 33.0-jre - Maven");
+        tc.Id.Should().Be(tc.BaseId, "DownloadUrl and SourceUrl must not affect MavenComponent identity");
+    }
+
+    [TestMethod]
+    public void GitComponent_Id_ExcludesDownloadUrlAndSourceUrl_WhenSet()
+    {
+        // GitComponent overrides GetExtendedIdProperties for the same reason as MavenComponent:
+        // SourceUrl would duplicate RepositoryUrl, and DownloadUrl (the github archive URL) is deterministic.
+        var repo = new Uri("https://github.com/google/guava");
+        var tc = new GitComponent(repo, "abcdef1234567890")
+        {
+            DownloadUrl = new Uri("https://github.com/google/guava/archive/abcdef1234567890.zip"),
+            SourceUrl = repo,
+        };
+
+        tc.BaseId.Should().Be("https://github.com/google/guava : abcdef1234567890 - Git");
+        tc.Id.Should().Be(tc.BaseId, "DownloadUrl and SourceUrl must not affect GitComponent identity");
+    }
 }

--- a/test/Microsoft.ComponentDetection.VerificationTests/resources/maven/lib/pom.xml
+++ b/test/Microsoft.ComponentDetection.VerificationTests/resources/maven/lib/pom.xml
@@ -34,11 +34,6 @@
       <type>pom</type>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <version>3.12.0</version>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>${junit.version}</version>

--- a/test/Microsoft.ComponentDetection.VerificationTests/resources/maven/lib/pom.xml
+++ b/test/Microsoft.ComponentDetection.VerificationTests/resources/maven/lib/pom.xml
@@ -1,5 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
+  <groupId>com.microsoft</groupId>
   <parent>
     <groupId>com.microsoft</groupId>
     <artifactId>maven-test-parent</artifactId>
@@ -31,6 +32,11 @@
       <artifactId>beam-parent</artifactId>
       <version>2.3.0</version>
       <type>pom</type>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.12.0</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
## Summary

Two small defensive identity overrides on `TypedComponent` subclasses, plus a `PackageUrl` override on `GitComponent` so github.com repositories get a canonical `pkg:github/...` PURL.

| Component | Change |
|---|---|
| `MavenComponent` | Override `GetExtendedIdProperties()` to return empty (suppress `DownloadUrl`/`SourceUrl` from `Id`). |
| `GitComponent` | Same `GetExtendedIdProperties()` override + new `PackageUrl` override returning `pkg:github/{owner}/{repo}@{commit}` for github.com URLs and `null` for other hosts. |

## Why

Today no detector populates `DownloadUrl`/`SourceUrl` on `MavenComponent` or `GitComponent`, so `Id == BaseId`. Upcoming SBOM-enrichment work in `microsoft/component-detection-internal` will start emitting deterministic download URLs through the Maven/Git converters. Without these overrides, `Id` would change shape to `"BaseId [DownloadUrl:... SourceUrl:...]"`, creating bare-vs-rich identity-merge conflicts between:

- the two `MvnCli` internal paths (mvn-CLI output vs. static pom.xml parser), and
- the multiple Git submitters (CocoaPods / Poetry / Pip / Swift / Ruby / cgmanifest).

`GitComponent.PackageUrl` was the only typed component returning `null`. Adding the github PURL aligns it with every other type and lets downstream tooling (SBOM, AzDO Governance) dedupe github coords by PURL instead of by raw repository URL.

## Behavior changes

- **Maven** — `Id` already equaled `BaseId` for every existing detector; the override locks the contract going forward. No observable change today.
- **Git** — `Id` likewise unchanged today. `PackageUrl` goes from `null` → `"pkg:github/owner/repo@commit"` for **github.com** repositories only. Other hosts (GitLab / Bitbucket / Azure DevOps / GitHub Enterprise) keep returning `null` — consumers should continue to fall back to `RepositoryUrl` for those.
  - Searched both this repo and `microsoft/component-detection-internal` for callers that assert `GitComponent.PackageUrl == null` — none found. `VerificationTests` uses `PackageUrl` in a dedup key but both sides of the intersection run the same binary, so keys still match.

## Edge cases covered

| URL shape | Result |
|---|---|
| `https://github.com/google/guava` | `pkg:github/google/guava@<commit>` |
| `https://github.com/google/guava.git` | `.git` suffix stripped |
| `https://github.com/google/guava/` | trailing slash normalised |
| `https://GitHub.com/google/guava` | host match is case-insensitive |
| `https://github.com:443/google/guava` | port stripped via `Uri.Host` |
| `https://github.com/google/guava?utm=x#readme` | query/fragment ignored via `Uri.AbsolutePath` |
| `https://gitlab.com/foo/bar`, `https://bitbucket.org/foo/bar`, `https://dev.azure.com/...`, `https://github.contoso.com/foo/bar` | `null` |
| `https://github.com/onlyowner`, `https://github.com/owner/repo/tree/main`, `https://github.com/` | `null` (not canonical owner/repo paths) |
| SSH-style `git@github.com:owner/repo.git` | not a parseable absolute `Uri`; rejected upstream |
| `RepositoryUrl == null` or `CommitHash` null/empty (deserialization path) | `null` |

## Tests

`Microsoft.ComponentDetection.Contracts.Tests` — **+10 tests, 84/84 passing**:

- **`PurlGenerationTests`** — explicit `MavenComponentShouldGenerateMavenPurl` plus 7 GitHub PURL cases: canonical, `.git` suffix, trailing slash, case-insensitive host, non-github hosts (gitlab + bitbucket + ADO + GHE in one test), malformed paths (owner-only + too-deep + root-only in one test), missing commit hash.
- **`TypedComponentSerializationTests`** — `MavenComponent_Id_ExcludesDownloadUrlAndSourceUrl_WhenSet` and `GitComponent_Id_ExcludesDownloadUrlAndSourceUrl_WhenSet` prove the overrides exclude both URLs even when set.

Broader regression check (all run locally on this branch):

| Project | Result |
|---|---|
| `Contracts.Tests` | **84 / 84 passed** (incl. 10 new) |
| `Detectors.Tests` | **910 / 910 passed** — `GradleComponentDetectorTests` and others that inspect `Id` strings like `"... - Maven"` still match because only `GetExtendedIdProperties()` changed, not `ComputeBaseId()`. |
| `Orchestrator.Tests` | **151 / 151 passed** |
| `Common.Tests` | 213 / 221 passed (1 pre-existing flake: `DockerService_CanPingDocker` needs a Docker daemon; the other 7 skips are platform-conditioned) |

## Out of scope

- The CD-Internal converter changes (consume the new `GitComponent.PackageUrl`, emit deterministic `DownloadURL` for both Maven and Git) ship in a follow-up PR in `microsoft/component-detection-internal` once a new CD-public NuGet drops.
- A pre-existing bug at `GitComponentConverter.cs:28` in CD-Internal (literal `Replace("https://github.com/", "")` that produces garbage `owner`/`repo` for non-github URLs) — same follow-up PR.
