### PR TITLE
Add option to exclude base image components

### DIFF
--- a/docs/detectors/linux.md
+++ b/docs/detectors/linux.md
@@ -54,3 +54,15 @@ For example:
 
 - Windows container scanning is not supported
 - Multiplatform images are not supported
+
+## Excluding Base Image Components
+
+When scanning container images, many detected components may originate from the base image rather than from layers added by the user's Dockerfile. The `--ExcludeBaseImageComponents` flag filters out components that exist exclusively in base image layers, so only components introduced by the user's own layers are reported.
+
+```sh
+--ExcludeBaseImageComponents
+```
+
+A component is excluded only if **all** of its associated container layers are marked as base image layers. If a component appears in at least one non-base-image layer, it is retained.
+
+This flag has no effect on non-container scans (i.e., directory-based detection).

--- a/src/Microsoft.ComponentDetection.Detectors/linux/LinuxScanner.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/linux/LinuxScanner.cs
@@ -30,6 +30,21 @@ internal class LinuxScanner : ILinuxScanner
 
     private static readonly IList<string> ScopeSquashedParameter = ["--scope", "squashed"];
 
+    /// <summary>
+    /// Well-known package manager database paths whose layer attribution should be ignored
+    /// when determining which layer a system package belongs to. These files are shared across
+    /// all packages managed by the same package manager and get updated whenever any package is
+    /// installed or removed, causing unrelated packages to appear as modified in later layers.
+    /// </summary>
+    private static readonly HashSet<string> PackageManagerDatabasePaths = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "/var/lib/dpkg/status",
+        "/lib/apk/db/installed",
+        "/var/lib/rpm/Packages",
+        "/var/lib/rpm/Packages.db",
+        "/var/lib/rpm/rpmdb.sqlite",
+    };
+
     private static readonly SemaphoreSlim ContainerSemaphore = new SemaphoreSlim(2);
 
     /// <summary>
@@ -179,11 +194,16 @@ internal class LinuxScanner : ILinuxScanner
             }
         }
 
+        // Build a file path → layerID map from the top-level files listing.
+        // This allows us to determine layer attribution for files owned by a package
+        // even when the artifact's locations only reference the package manager database.
+        var filePathToLayerId = BuildFilePathToLayerMap(syftOutput.Files);
+
         // Create components using only enabled factories
         var componentsWithLayers = validArtifacts
             .DistinctBy(artifact => (artifact.Name, artifact.Version, artifact.Type))
             .Select(artifact =>
-                this.CreateComponentWithLayers(artifact, syftOutput.Distro, enabledFactories)
+                this.CreateComponentWithLayers(artifact, syftOutput.Distro, enabledFactories, filePathToLayerId)
             )
             .Where(result => result.Component != null)
             .Select(result => (Component: result.Component!, result.LayerIds))
@@ -388,7 +408,8 @@ internal class LinuxScanner : ILinuxScanner
     private (TypedComponent? Component, IEnumerable<string> LayerIds) CreateComponentWithLayers(
         ArtifactElement artifact,
         Distro distro,
-        HashSet<IArtifactComponentFactory> enabledFactories
+        HashSet<IArtifactComponentFactory> enabledFactories,
+        Dictionary<string, string> filePathToLayerId
     )
     {
         if (!this.artifactTypeToFactoryLookup.TryGetValue(artifact.Type, out var factory))
@@ -408,12 +429,93 @@ internal class LinuxScanner : ILinuxScanner
             return (null, []);
         }
 
-        var layerIds = artifact.Locations?.Select(location => location.LayerId).Distinct() ?? [];
-        return (component, layerIds);
+        // Collect layer IDs from the artifact's locations.
+        var locationLayerIds = artifact.Locations?
+            .Select(location => (location.Path, location.LayerId))
+            .ToList() ?? [];
+
+        // Also consult the metadata files property to find additional owned files,
+        // and look up their layer IDs from the top-level file listing.
+        if (artifact.Metadata?.Files != null)
+        {
+            foreach (var file in artifact.Metadata.Files)
+            {
+                var filePath = file.FileFile?.Path;
+                if (!string.IsNullOrEmpty(filePath) && filePathToLayerId.TryGetValue(filePath, out var layerId))
+                {
+                    locationLayerIds.Add((filePath, layerId));
+                }
+            }
+        }
+
+        // Exclude well-known package manager database paths from layer attribution,
+        // unless they are the only known locations for this component.
+        var nonDbLayerIds = locationLayerIds
+            .Where(loc => !IsPackageManagerDatabasePath(loc.Path))
+            .Select(loc => loc.LayerId)
+            .Distinct()
+            .ToList();
+
+        if (nonDbLayerIds.Count > 0)
+        {
+            return (component, nonDbLayerIds);
+        }
+
+        // Fall back to database path layer IDs if no other locations are available.
+        var allLayerIds = locationLayerIds
+            .Select(loc => loc.LayerId)
+            .Distinct()
+            .ToList();
+        return (component, allLayerIds);
     }
 
     /// <summary>
     /// Clears the syft run cache. Intended for test isolation only.
     /// </summary>
     internal static void ResetCache() => SyftRunCache.Clear();
+
+    /// <summary>
+    /// Builds a dictionary mapping file paths to their layer IDs from the top-level
+    /// files listing in the syft output. This enables layer attribution for files
+    /// owned by a package even when the artifact's locations only reference the
+    /// package manager database.
+    /// </summary>
+    private static Dictionary<string, string> BuildFilePathToLayerMap(FileElement[] files)
+    {
+        var map = new Dictionary<string, string>(StringComparer.Ordinal);
+        if (files == null)
+        {
+            return map;
+        }
+
+        foreach (var file in files)
+        {
+            if (file.Location != null && !string.IsNullOrEmpty(file.Location.Path) && !string.IsNullOrEmpty(file.Location.LayerId))
+            {
+                map.TryAdd(file.Location.Path, file.Location.LayerId);
+            }
+        }
+
+        return map;
+    }
+
+    /// <summary>
+    /// Determines whether a file path is a well-known package manager database file
+    /// that should be excluded from layer attribution.
+    /// </summary>
+    private static bool IsPackageManagerDatabasePath(string path)
+    {
+        if (string.IsNullOrEmpty(path))
+        {
+            return false;
+        }
+
+        if (PackageManagerDatabasePaths.Contains(path))
+        {
+            return true;
+        }
+
+        // Cover any file under /var/lib/rpm/ (RPM database can use multiple files)
+        return path.StartsWith("/var/lib/rpm/", StringComparison.OrdinalIgnoreCase);
+    }
 }

--- a/src/Microsoft.ComponentDetection.Detectors/linux/LinuxScanner.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/linux/LinuxScanner.cs
@@ -429,8 +429,9 @@ internal class LinuxScanner : ILinuxScanner
             return (null, []);
         }
 
-        // Collect layer IDs from the artifact's locations.
+        // Collect layer IDs from the artifact's locations, filtering out entries with null/empty layer IDs.
         var locationLayerIds = artifact.Locations?
+            .Where(location => !string.IsNullOrEmpty(location.Path) && !string.IsNullOrEmpty(location.LayerId))
             .Select(location => (location.Path, location.LayerId))
             .ToList() ?? [];
 
@@ -440,7 +441,8 @@ internal class LinuxScanner : ILinuxScanner
         {
             foreach (var file in artifact.Metadata.Files)
             {
-                var filePath = file.FileFile?.Path;
+                // The File union type can be either a FileFile object or a plain string path.
+                var filePath = file.FileFile?.Path ?? file.String;
                 if (!string.IsNullOrEmpty(filePath) && filePathToLayerId.TryGetValue(filePath, out var layerId))
                 {
                     locationLayerIds.Add((filePath, layerId));
@@ -464,6 +466,7 @@ internal class LinuxScanner : ILinuxScanner
         // Fall back to database path layer IDs if no other locations are available.
         var allLayerIds = locationLayerIds
             .Select(loc => loc.LayerId)
+            .Where(id => !string.IsNullOrEmpty(id))
             .Distinct()
             .ToList();
         return (component, allLayerIds);

--- a/src/Microsoft.ComponentDetection.Orchestrator/Commands/ScanSettings.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Commands/ScanSettings.cs
@@ -86,9 +86,9 @@ public class ScanSettings : BaseSettings
     [Description("Whether or not to cleanup files that are created during detection, based on the rules provided in each detector. Defaults to 'true'.")]
     public bool? CleanupCreatedFiles { get; set; }
 
-    [CommandOption("--FilterBaseImageComponents")]
+    [CommandOption("--ExcludeBaseImageComponents")]
     [Description("When enabled, filters out components that originate exclusively from base image layers when scanning containers.")]
-    public bool FilterBaseImageComponents { get; set; }
+    public bool ExcludeBaseImageComponents { get; set; }
 
     /// <inheritdoc />
     public override ValidationResult Validate()

--- a/src/Microsoft.ComponentDetection.Orchestrator/Commands/ScanSettings.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Commands/ScanSettings.cs
@@ -86,6 +86,10 @@ public class ScanSettings : BaseSettings
     [Description("Whether or not to cleanup files that are created during detection, based on the rules provided in each detector. Defaults to 'true'.")]
     public bool? CleanupCreatedFiles { get; set; }
 
+    [CommandOption("--FilterBaseImageComponents")]
+    [Description("When enabled, filters out components that originate exclusively from base image layers when scanning containers.")]
+    public bool FilterBaseImageComponents { get; set; }
+
     /// <inheritdoc />
     public override ValidationResult Validate()
     {

--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/GraphTranslation/DefaultGraphTranslationService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/GraphTranslation/DefaultGraphTranslationService.cs
@@ -45,6 +45,7 @@ internal class DefaultGraphTranslationService : IGraphTranslationService
         if (settings.FilterBaseImageComponents)
         {
             componentsToOutput = FilterOutBaseImageComponents(componentsToOutput, detectorProcessingResult.ContainersDetailsMap);
+            PruneFilteredComponentsFromGraphs(dependencyGraphs, componentsToOutput);
         }
 
         return new DefaultGraphScanResult
@@ -74,10 +75,20 @@ internal class DefaultGraphTranslationService : IGraphTranslationService
             return components;
         }
 
-        return components.Where(component => !IsExclusivelyFromBaseImage(component, containerDetailsMap)).ToList();
+        // Build an indexed lookup: containerDetailId → (layerIndex → DockerLayer)
+        var layerLookup = new Dictionary<int, Dictionary<int, DockerLayer>>();
+        foreach (var (id, details) in containerDetailsMap)
+        {
+            if (details.Layers != null)
+            {
+                layerLookup[id] = details.Layers.ToDictionary(l => l.LayerIndex);
+            }
+        }
+
+        return components.Where(component => !IsExclusivelyFromBaseImage(component, layerLookup)).ToList();
     }
 
-    private static bool IsExclusivelyFromBaseImage(DetectedComponent component, Dictionary<int, ContainerDetails> containerDetailsMap)
+    private static bool IsExclusivelyFromBaseImage(DetectedComponent component, Dictionary<int, Dictionary<int, DockerLayer>> layerLookup)
     {
         // Components without container layer references are not from a container scan - keep them.
         if (component.ContainerLayerIds == null || component.ContainerLayerIds.Count == 0)
@@ -87,18 +98,15 @@ internal class DefaultGraphTranslationService : IGraphTranslationService
 
         foreach (var (containerDetailId, layerIndices) in component.ContainerLayerIds)
         {
-            if (!containerDetailsMap.TryGetValue(containerDetailId, out var containerDetails) || containerDetails.Layers == null)
+            if (!layerLookup.TryGetValue(containerDetailId, out var layersByIndex))
             {
                 // If we can't resolve the container details, assume it's not a base image component.
                 return false;
             }
 
-            var layersList = containerDetails.Layers.ToList();
-
             foreach (var layerIndex in layerIndices)
             {
-                var layer = layersList.FirstOrDefault(l => l.LayerIndex == layerIndex);
-                if (layer == null || !layer.IsBaseImage)
+                if (!layersByIndex.TryGetValue(layerIndex, out var layer) || !layer.IsBaseImage)
                 {
                     // Layer not found or not from base image. Keep this component.
                     return false;
@@ -107,6 +115,42 @@ internal class DefaultGraphTranslationService : IGraphTranslationService
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// Removes component IDs from dependency graphs that are no longer present in the output components list.
+    /// </summary>
+    private static void PruneFilteredComponentsFromGraphs(DependencyGraphCollection graphs, List<DetectedComponent> retainedComponents)
+    {
+        if (graphs == null || graphs.Count == 0)
+        {
+            return;
+        }
+
+        var retainedIds = new HashSet<string>(retainedComponents.Select(c => c.Component.Id));
+
+        foreach (var graphWithMetadata in graphs.Values)
+        {
+            var graph = graphWithMetadata.Graph;
+
+            // Remove nodes that are no longer in retained components.
+            var idsToRemove = graph.Keys.Where(id => !retainedIds.Contains(id)).ToList();
+            foreach (var id in idsToRemove)
+            {
+                graph.Remove(id);
+            }
+
+            // Remove references to removed IDs from remaining nodes' dependency sets.
+            foreach (var edges in graph.Values)
+            {
+                edges?.RemoveWhere(id => !retainedIds.Contains(id));
+            }
+
+            // Clean up metadata sets.
+            graphWithMetadata.ExplicitlyReferencedComponentIds?.RemoveWhere(id => !retainedIds.Contains(id));
+            graphWithMetadata.DevelopmentDependencies?.RemoveWhere(id => !retainedIds.Contains(id));
+            graphWithMetadata.Dependencies?.RemoveWhere(id => !retainedIds.Contains(id));
+        }
     }
 
     private static ConcurrentHashSet<string> MergeTargetFrameworks(ConcurrentHashSet<string> left, ConcurrentHashSet<string> right)

--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/GraphTranslation/DefaultGraphTranslationService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/GraphTranslation/DefaultGraphTranslationService.cs
@@ -141,9 +141,18 @@ internal class DefaultGraphTranslationService : IGraphTranslationService
             }
 
             // Remove references to removed IDs from remaining nodes' dependency sets.
-            foreach (var edges in graph.Values)
+            // Normalize empty edge sets to null for consistent leaf-node serialization.
+            foreach (var nodeId in graph.Keys.ToList())
             {
-                edges?.RemoveWhere(id => !retainedIds.Contains(id));
+                var edges = graph[nodeId];
+                if (edges != null)
+                {
+                    edges.RemoveWhere(id => !retainedIds.Contains(id));
+                    if (edges.Count == 0)
+                    {
+                        graph[nodeId] = null;
+                    }
+                }
             }
 
             // Clean up metadata sets.

--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/GraphTranslation/DefaultGraphTranslationService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/GraphTranslation/DefaultGraphTranslationService.cs
@@ -46,6 +46,7 @@ internal class DefaultGraphTranslationService : IGraphTranslationService
         {
             componentsToOutput = FilterOutBaseImageComponents(componentsToOutput, detectorProcessingResult.ContainersDetailsMap);
             PruneFilteredComponentsFromGraphs(dependencyGraphs, componentsToOutput);
+            PruneFilteredComponentReferrers(componentsToOutput);
         }
 
         return new DefaultGraphScanResult
@@ -159,6 +160,22 @@ internal class DefaultGraphTranslationService : IGraphTranslationService
             graphWithMetadata.ExplicitlyReferencedComponentIds?.RemoveWhere(id => !retainedIds.Contains(id));
             graphWithMetadata.DevelopmentDependencies?.RemoveWhere(id => !retainedIds.Contains(id));
             graphWithMetadata.Dependencies?.RemoveWhere(id => !retainedIds.Contains(id));
+        }
+    }
+
+    /// <summary>
+    /// Removes references to filtered-out components from the DependencyRoots and AncestralDependencyRoots
+    /// of retained components, so that TopLevelReferrers and AncestralReferrers in the output don't
+    /// reference components that were removed from ComponentsFound.
+    /// </summary>
+    private static void PruneFilteredComponentReferrers(List<DetectedComponent> retainedComponents)
+    {
+        var retainedIds = new HashSet<string>(retainedComponents.Select(c => c.Component.Id));
+
+        foreach (var component in retainedComponents)
+        {
+            component.DependencyRoots?.RemoveWhere(root => !retainedIds.Contains(root.Id));
+            component.AncestralDependencyRoots?.RemoveWhere(root => !retainedIds.Contains(root.Id));
         }
     }
 

--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/GraphTranslation/DefaultGraphTranslationService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/GraphTranslation/DefaultGraphTranslationService.cs
@@ -41,13 +41,72 @@ internal class DefaultGraphTranslationService : IGraphTranslationService
 
         ReconcileDependencyGraphIds(dependencyGraphs, mergedComponents);
 
+        var componentsToOutput = mergedComponents;
+        if (settings.FilterBaseImageComponents)
+        {
+            componentsToOutput = FilterOutBaseImageComponents(componentsToOutput, detectorProcessingResult.ContainersDetailsMap);
+        }
+
         return new DefaultGraphScanResult
         {
-            ComponentsFound = mergedComponents.Select(x => this.ConvertToContract(x)).ToList(),
+            ComponentsFound = componentsToOutput.Select(x => this.ConvertToContract(x)).ToList(),
             ContainerDetailsMap = detectorProcessingResult.ContainersDetailsMap,
             DependencyGraphs = dependencyGraphs,
             SourceDirectory = settings.SourceDirectory.ToString(),
         };
+    }
+
+    /// <summary>
+    /// Filters out components that originate exclusively from base image layers.
+    /// A component is removed only if it has container layer references and every referenced
+    /// layer across all containers has <see cref="DockerLayer.IsBaseImage"/> set to true.
+    /// Components with no container references or with at least one non-base-image layer are retained.
+    /// </summary>
+    /// <param name="components">The list of detected components to filter.</param>
+    /// <param name="containerDetailsMap">The map of container details with layer information.</param>
+    /// <returns>A filtered list of components excluding those exclusively from base image layers.</returns>
+    internal static List<DetectedComponent> FilterOutBaseImageComponents(
+        List<DetectedComponent> components,
+        Dictionary<int, ContainerDetails> containerDetailsMap)
+    {
+        if (containerDetailsMap == null || containerDetailsMap.Count == 0)
+        {
+            return components;
+        }
+
+        return components.Where(component => !IsExclusivelyFromBaseImage(component, containerDetailsMap)).ToList();
+    }
+
+    private static bool IsExclusivelyFromBaseImage(DetectedComponent component, Dictionary<int, ContainerDetails> containerDetailsMap)
+    {
+        // Components without container layer references are not from a container scan - keep them.
+        if (component.ContainerLayerIds == null || component.ContainerLayerIds.Count == 0)
+        {
+            return false;
+        }
+
+        foreach (var (containerDetailId, layerIndices) in component.ContainerLayerIds)
+        {
+            if (!containerDetailsMap.TryGetValue(containerDetailId, out var containerDetails) || containerDetails.Layers == null)
+            {
+                // If we can't resolve the container details, assume it's not a base image component.
+                return false;
+            }
+
+            var layersList = containerDetails.Layers.ToList();
+
+            foreach (var layerIndex in layerIndices)
+            {
+                var layer = layersList.FirstOrDefault(l => l.LayerIndex == layerIndex);
+                if (layer == null || !layer.IsBaseImage)
+                {
+                    // Layer not found or not from base image. Keep this component.
+                    return false;
+                }
+            }
+        }
+
+        return true;
     }
 
     private static ConcurrentHashSet<string> MergeTargetFrameworks(ConcurrentHashSet<string> left, ConcurrentHashSet<string> right)

--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/GraphTranslation/DefaultGraphTranslationService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/GraphTranslation/DefaultGraphTranslationService.cs
@@ -42,7 +42,7 @@ internal class DefaultGraphTranslationService : IGraphTranslationService
         ReconcileDependencyGraphIds(dependencyGraphs, mergedComponents);
 
         var componentsToOutput = mergedComponents;
-        if (settings.FilterBaseImageComponents)
+        if (settings.ExcludeBaseImageComponents)
         {
             var originalCount = mergedComponents.Count;
             componentsToOutput = this.FilterOutBaseImageComponents(componentsToOutput, detectorProcessingResult.ContainersDetailsMap);

--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/GraphTranslation/DefaultGraphTranslationService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/GraphTranslation/DefaultGraphTranslationService.cs
@@ -105,6 +105,12 @@ internal class DefaultGraphTranslationService : IGraphTranslationService
                 return false;
             }
 
+            if (layerIndices == null)
+            {
+                // No layer indices for this container detail - keep the component.
+                return false;
+            }
+
             foreach (var layerIndex in layerIndices)
             {
                 if (!layersByIndex.TryGetValue(layerIndex, out var layer) || !layer.IsBaseImage)

--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/GraphTranslation/DefaultGraphTranslationService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/GraphTranslation/DefaultGraphTranslationService.cs
@@ -94,7 +94,7 @@ internal class DefaultGraphTranslationService : IGraphTranslationService
         {
             if (details.Layers != null)
             {
-                layerLookup[id] = details.Layers.ToDictionary(l => l.LayerIndex);
+                layerLookup[id] = details.Layers.GroupBy(l => l.LayerIndex).ToDictionary(g => g.Key, g => g.First());
             }
         }
 

--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/GraphTranslation/DefaultGraphTranslationService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/GraphTranslation/DefaultGraphTranslationService.cs
@@ -105,7 +105,7 @@ internal class DefaultGraphTranslationService : IGraphTranslationService
                 return false;
             }
 
-            if (layerIndices == null)
+            if (layerIndices == null || !layerIndices.Any())
             {
                 // No layer indices for this container detail - keep the component.
                 return false;

--- a/src/Microsoft.ComponentDetection.Orchestrator/Services/GraphTranslation/DefaultGraphTranslationService.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Services/GraphTranslation/DefaultGraphTranslationService.cs
@@ -44,7 +44,19 @@ internal class DefaultGraphTranslationService : IGraphTranslationService
         var componentsToOutput = mergedComponents;
         if (settings.FilterBaseImageComponents)
         {
-            componentsToOutput = FilterOutBaseImageComponents(componentsToOutput, detectorProcessingResult.ContainersDetailsMap);
+            var originalCount = mergedComponents.Count;
+            componentsToOutput = this.FilterOutBaseImageComponents(componentsToOutput, detectorProcessingResult.ContainersDetailsMap);
+            var filteredCount = originalCount - componentsToOutput.Count;
+
+            if (filteredCount > 0)
+            {
+                this.logger.LogInformation("Filtered out {FilteredCount} of {TotalCount} components that originate exclusively from base image layers. {RetainedCount} components remain.", filteredCount, originalCount, componentsToOutput.Count);
+            }
+            else
+            {
+                this.logger.LogInformation("Base image component filtering is enabled but no components were filtered out ({TotalCount} total).", originalCount);
+            }
+
             PruneFilteredComponentsFromGraphs(dependencyGraphs, componentsToOutput);
             PruneFilteredComponentReferrers(componentsToOutput);
         }
@@ -67,7 +79,7 @@ internal class DefaultGraphTranslationService : IGraphTranslationService
     /// <param name="components">The list of detected components to filter.</param>
     /// <param name="containerDetailsMap">The map of container details with layer information.</param>
     /// <returns>A filtered list of components excluding those exclusively from base image layers.</returns>
-    internal static List<DetectedComponent> FilterOutBaseImageComponents(
+    internal List<DetectedComponent> FilterOutBaseImageComponents(
         List<DetectedComponent> components,
         Dictionary<int, ContainerDetails> containerDetailsMap)
     {
@@ -86,7 +98,20 @@ internal class DefaultGraphTranslationService : IGraphTranslationService
             }
         }
 
-        return components.Where(component => !IsExclusivelyFromBaseImage(component, layerLookup)).ToList();
+        var retained = new List<DetectedComponent>();
+        foreach (var component in components)
+        {
+            if (IsExclusivelyFromBaseImage(component, layerLookup))
+            {
+                this.logger.LogDebug("Filtering out component {ComponentId} because all associated layers are from the base image.", component.Component.Id);
+            }
+            else
+            {
+                retained.Add(component);
+            }
+        }
+
+        return retained;
     }
 
     private static bool IsExclusivelyFromBaseImage(DetectedComponent component, Dictionary<int, Dictionary<int, DockerLayer>> layerLookup)

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/LinuxScannerTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/LinuxScannerTests.cs
@@ -97,6 +97,10 @@ public class LinuxScannerTests
                     "type":"deb",
                     "locations": [
                         {
+                            "path": "/usr/bin/test",
+                            "layerID": "sha256:f95fc50d21d981f1efe1f04109c2c3287c271794f5d9e4fdf9888851a174a971"
+                        },
+                        {
                             "path": "/var/lib/dpkg/status",
                             "layerID": "sha256:f95fc50d21d981f1efe1f04109c2c3287c271794f5d9e4fdf9888851a174a971"
                         }
@@ -1465,5 +1469,187 @@ public class LinuxScannerTests
         syftCompletionSource.SetResult((SyftOutputNoAuthorOrLicense, string.Empty));
         var result1 = await task1;
         result1.Should().NotBeEmpty();
+    }
+
+    [TestMethod]
+    public void TestLinuxScanner_ProcessSyftOutput_ExcludesPackageManagerDatabasePathsFromLayerAttribution()
+    {
+        // Simulates a scenario where a package (curl) is installed in layer1,
+        // but the dpkg status file is also modified in layer2 by a different package install.
+        // curl should only be attributed to layer1.
+        var syftOutputJson = """
+            {
+                "distro": { "id": "ubuntu", "versionID": "22.04" },
+                "artifacts": [
+                    {
+                        "name": "curl",
+                        "version": "7.81.0",
+                        "type": "deb",
+                        "locations": [
+                            {
+                                "path": "/usr/bin/curl",
+                                "layerID": "sha256:layer1"
+                            },
+                            {
+                                "path": "/var/lib/dpkg/status",
+                                "layerID": "sha256:layer2"
+                            }
+                        ]
+                    }
+                ],
+                "source": {
+                    "id": "sha256:abc",
+                    "name": "test-image",
+                    "type": "image",
+                    "version": "sha256:abc"
+                }
+            }
+            """;
+        var syftOutput = SyftOutput.FromJson(syftOutputJson);
+        var containerLayers = new List<DockerLayer>
+        {
+            new() { DiffId = "sha256:layer1", LayerIndex = 0, IsBaseImage = true },
+            new() { DiffId = "sha256:layer2", LayerIndex = 1, IsBaseImage = false },
+        };
+        var enabledTypes = new HashSet<ComponentType> { ComponentType.Linux };
+
+        var result = this.linuxScanner.ProcessSyftOutput(syftOutput, containerLayers, enabledTypes).ToList();
+
+        // curl should only appear in layer1, not layer2
+        var layer1Entry = result.FirstOrDefault(r => r.DockerLayer.DiffId == "sha256:layer1");
+        var layer2Entry = result.FirstOrDefault(r => r.DockerLayer.DiffId == "sha256:layer2");
+
+        layer1Entry.Should().NotBeNull();
+        layer1Entry.Components.Should().ContainSingle();
+        ((LinuxComponent)layer1Entry.Components.First()).Name.Should().Be("curl");
+
+        // layer2 should have no components (or not exist in results)
+        layer2Entry?.Components.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public void TestLinuxScanner_ProcessSyftOutput_PackageWithOnlyDatabasePath_FallsBackToDatabaseLayer()
+    {
+        // If a package only has the database path as its location (no real file paths
+        // and no metadata files), the database path layer is used as a fallback.
+        var syftOutputJson = """
+            {
+                "distro": { "id": "alpine", "versionID": "3.18" },
+                "artifacts": [
+                    {
+                        "name": "musl",
+                        "version": "1.2.4",
+                        "type": "apk",
+                        "locations": [
+                            {
+                                "path": "/lib/apk/db/installed",
+                                "layerID": "sha256:layer1"
+                            }
+                        ]
+                    }
+                ],
+                "source": {
+                    "id": "sha256:abc",
+                    "name": "test-image",
+                    "type": "image",
+                    "version": "sha256:abc"
+                }
+            }
+            """;
+        var syftOutput = SyftOutput.FromJson(syftOutputJson);
+        var containerLayers = new List<DockerLayer>
+        {
+            new() { DiffId = "sha256:layer1", LayerIndex = 0, IsBaseImage = true },
+        };
+        var enabledTypes = new HashSet<ComponentType> { ComponentType.Linux };
+
+        var result = this.linuxScanner.ProcessSyftOutput(syftOutput, containerLayers, enabledTypes).ToList();
+
+        // The component should fall back to the database path's layer
+        var layer1Entry = result.FirstOrDefault(r => r.DockerLayer.DiffId == "sha256:layer1");
+        layer1Entry.Should().NotBeNull();
+        layer1Entry.Components.Should().ContainSingle();
+        ((LinuxComponent)layer1Entry.Components.First()).Name.Should().Be("musl");
+    }
+
+    [TestMethod]
+    public void TestLinuxScanner_ProcessSyftOutput_UsesMetadataFilesForLayerAttribution()
+    {
+        // Simulates a scenario where a package (curl) only has the package DB in its
+        // artifact locations, but has owned files in metadata.files. The top-level files[]
+        // listing provides the layer mapping for those owned files. The component should
+        // be attributed to the layer of its owned files, not the DB layer.
+        var syftOutputJson = """
+            {
+                "distro": { "id": "mariner", "versionID": "3.0" },
+                "artifacts": [
+                    {
+                        "name": "curl",
+                        "version": "8.11.1",
+                        "type": "rpm",
+                        "locations": [
+                            {
+                                "path": "/var/lib/rpm/rpmdb.sqlite",
+                                "layerID": "sha256:layer2"
+                            }
+                        ],
+                        "metadata": {
+                            "files": [
+                                { "path": "/usr/bin/curl" },
+                                { "path": "/usr/lib/libcurl.so" }
+                            ]
+                        }
+                    }
+                ],
+                "files": [
+                    {
+                        "id": "file1",
+                        "location": {
+                            "path": "/usr/bin/curl",
+                            "layerID": "sha256:layer1"
+                        }
+                    },
+                    {
+                        "id": "file2",
+                        "location": {
+                            "path": "/usr/lib/libcurl.so",
+                            "layerID": "sha256:layer1"
+                        }
+                    },
+                    {
+                        "id": "file3",
+                        "location": {
+                            "path": "/var/lib/rpm/rpmdb.sqlite",
+                            "layerID": "sha256:layer2"
+                        }
+                    }
+                ],
+                "source": {
+                    "id": "sha256:abc",
+                    "name": "test-image",
+                    "type": "image",
+                    "version": "sha256:abc"
+                }
+            }
+            """;
+        var syftOutput = SyftOutput.FromJson(syftOutputJson);
+        var containerLayers = new List<DockerLayer>
+        {
+            new() { DiffId = "sha256:layer1", LayerIndex = 0, IsBaseImage = true },
+            new() { DiffId = "sha256:layer2", LayerIndex = 1, IsBaseImage = false },
+        };
+        var enabledTypes = new HashSet<ComponentType> { ComponentType.Linux };
+
+        var result = this.linuxScanner.ProcessSyftOutput(syftOutput, containerLayers, enabledTypes).ToList();
+
+        // curl should be attributed to layer1 (where its real files are), not layer2 (DB layer)
+        var layer1Entry = result.FirstOrDefault(r => r.DockerLayer.DiffId == "sha256:layer1");
+        var layer2Entry = result.FirstOrDefault(r => r.DockerLayer.DiffId == "sha256:layer2");
+
+        layer1Entry.Should().NotBeNull();
+        layer1Entry.Components.Should().ContainSingle();
+        ((LinuxComponent)layer1Entry.Components.First()).Name.Should().Be("curl");
+
+        layer2Entry?.Components.Should().BeEmpty();
     }
 }

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/LinuxScannerTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/LinuxScannerTests.cs
@@ -1652,4 +1652,70 @@ public class LinuxScannerTests
 
         layer2Entry?.Components.Should().BeEmpty();
     }
+
+    [TestMethod]
+    public void TestLinuxScanner_ProcessSyftOutput_HandlesMultipleLayersWithSameDiffId()
+    {
+        // When layers have the same content (e.g., empty layers), they share the same DiffId.
+        // The scanner should handle this without throwing and correctly attribute components.
+        var syftOutputJson = """
+            {
+                "distro": { "id": "ubuntu", "versionID": "22.04" },
+                "artifacts": [
+                    {
+                        "name": "curl",
+                        "version": "7.81.0",
+                        "type": "deb",
+                        "locations": [
+                            {
+                                "path": "/usr/bin/curl",
+                                "layerID": "sha256:duplicated-layer"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "wget",
+                        "version": "1.21",
+                        "type": "deb",
+                        "locations": [
+                            {
+                                "path": "/usr/bin/wget",
+                                "layerID": "sha256:unique-layer"
+                            }
+                        ]
+                    }
+                ],
+                "source": {
+                    "id": "sha256:abc",
+                    "name": "test-image",
+                    "type": "image",
+                    "version": "sha256:abc"
+                }
+            }
+            """;
+        var syftOutput = SyftOutput.FromJson(syftOutputJson);
+
+        // Two layers share the same DiffId ("sha256:duplicated-layer") but have different indexes
+        var containerLayers = new List<DockerLayer>
+        {
+            new() { DiffId = "sha256:duplicated-layer", LayerIndex = 0, IsBaseImage = true },
+            new() { DiffId = "sha256:duplicated-layer", LayerIndex = 1, IsBaseImage = true },
+            new() { DiffId = "sha256:unique-layer", LayerIndex = 2, IsBaseImage = false },
+        };
+        var enabledTypes = new HashSet<ComponentType> { ComponentType.Linux };
+
+        var result = this.linuxScanner.ProcessSyftOutput(syftOutput, containerLayers, enabledTypes).ToList();
+
+        // Should not throw; should produce entries for the two distinct DiffIds
+        result.Should().HaveCount(2);
+
+        var duplicatedLayerEntry = result.First(r => r.DockerLayer.DiffId == "sha256:duplicated-layer");
+        duplicatedLayerEntry.DockerLayer.LayerIndex.Should().Be(0, "the first occurrence of the duplicate DiffId should be used");
+        duplicatedLayerEntry.Components.Should().ContainSingle();
+        ((LinuxComponent)duplicatedLayerEntry.Components.First()).Name.Should().Be("curl");
+
+        var uniqueLayerEntry = result.First(r => r.DockerLayer.DiffId == "sha256:unique-layer");
+        uniqueLayerEntry.Components.Should().ContainSingle();
+        ((LinuxComponent)uniqueLayerEntry.Components.First()).Name.Should().Be("wget");
+    }
 }

--- a/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/DefaultGraphTranslationServiceTests.cs
+++ b/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/DefaultGraphTranslationServiceTests.cs
@@ -568,7 +568,7 @@ public class DefaultGraphTranslationServiceTests
     [TestMethod]
     public void FilterBaseImageComponents_RemovesComponentsExclusivelyFromBaseImageLayers()
     {
-        var singleFileRecorder = this.componentRecorder.CreateSingleFileComponentRecorder(Path.Join(this.sourceDirectory.FullName, "/file1"));
+        var singleFileRecorder = this.componentRecorder.CreateSingleFileComponentRecorder(Path.Join(this.sourceDirectory.FullName, "file1"));
 
         var baseImageComponent = new DetectedComponent(new NpmComponent("base-pkg", "1.0.0"), containerDetailsId: 1, containerLayerId: 0);
         singleFileRecorder.RegisterUsage(baseImageComponent);
@@ -598,7 +598,7 @@ public class DefaultGraphTranslationServiceTests
     [TestMethod]
     public void FilterBaseImageComponents_RetainsComponentsWithMixedLayers()
     {
-        var singleFileRecorder = this.componentRecorder.CreateSingleFileComponentRecorder(Path.Join(this.sourceDirectory.FullName, "/file1"));
+        var singleFileRecorder = this.componentRecorder.CreateSingleFileComponentRecorder(Path.Join(this.sourceDirectory.FullName, "file1"));
 
         var mixedComponent = new DetectedComponent(new NpmComponent("mixed-pkg", "1.0.0"), containerDetailsId: 1, containerLayerId: 0);
         mixedComponent.ContainerLayerIds[1] = [0, 1];
@@ -630,7 +630,7 @@ public class DefaultGraphTranslationServiceTests
     [TestMethod]
     public void FilterBaseImageComponents_RetainsComponentsWithNoContainerReferences()
     {
-        var singleFileRecorder = this.componentRecorder.CreateSingleFileComponentRecorder(Path.Join(this.sourceDirectory.FullName, "/file1"));
+        var singleFileRecorder = this.componentRecorder.CreateSingleFileComponentRecorder(Path.Join(this.sourceDirectory.FullName, "file1"));
 
         var filesystemComponent = new DetectedComponent(new NpmComponent("fs-pkg", "2.0.0"));
         singleFileRecorder.RegisterUsage(filesystemComponent);
@@ -661,7 +661,7 @@ public class DefaultGraphTranslationServiceTests
     [TestMethod]
     public void FilterBaseImageComponents_NoOpWhenFlagIsDisabled()
     {
-        var singleFileRecorder = this.componentRecorder.CreateSingleFileComponentRecorder(Path.Join(this.sourceDirectory.FullName, "/file1"));
+        var singleFileRecorder = this.componentRecorder.CreateSingleFileComponentRecorder(Path.Join(this.sourceDirectory.FullName, "file1"));
 
         var baseImageComponent = new DetectedComponent(new NpmComponent("base-pkg", "1.0.0"), containerDetailsId: 1, containerLayerId: 0);
         singleFileRecorder.RegisterUsage(baseImageComponent);
@@ -687,5 +687,95 @@ public class DefaultGraphTranslationServiceTests
 
         result.ComponentsFound.Should().HaveCount(1);
         ((NpmComponent)result.ComponentsFound.Single().Component).Name.Should().Be("base-pkg");
+    }
+
+    [TestMethod]
+    public void FilterBaseImageComponents_PrunesFilteredComponentsFromDependencyGraphs()
+    {
+        var filePath = Path.Join(this.sourceDirectory.FullName, "file1");
+        var singleFileRecorder = this.componentRecorder.CreateSingleFileComponentRecorder(filePath);
+
+        // Register a retained (non-base-image) component and a base-image component with a dependency edge.
+        var retainedComponent = new DetectedComponent(new NpmComponent("app-pkg", "1.0.0"), containerDetailsId: 1, containerLayerId: 1);
+        var baseImageComponent = new DetectedComponent(new NpmComponent("base-pkg", "2.0.0"), containerDetailsId: 1, containerLayerId: 0);
+
+        singleFileRecorder.RegisterUsage(retainedComponent, isExplicitReferencedDependency: true);
+        singleFileRecorder.RegisterUsage(baseImageComponent, parentComponentId: retainedComponent.Component.Id);
+
+        var containerDetailsMap = new Dictionary<int, ContainerDetails>
+        {
+            [1] = new ContainerDetails
+            {
+                Id = 1,
+                Layers = [new DockerLayer { LayerIndex = 0, IsBaseImage = true }, new DockerLayer { LayerIndex = 1, IsBaseImage = false }],
+            },
+        };
+
+        var processingResult = new DetectorProcessingResult
+        {
+            ResultCode = ProcessingResultCode.Success,
+            ContainersDetailsMap = containerDetailsMap,
+            ComponentRecorders = [(this.componentDetectorMock.Object, this.componentRecorder)],
+        };
+
+        var result = (DefaultGraphScanResult)this.serviceUnderTest.GenerateScanResultFromProcessingResult(
+            processingResult, new ScanSettings { SourceDirectory = this.sourceDirectory, FilterBaseImageComponents = true });
+
+        // Only the non-base-image component should remain.
+        result.ComponentsFound.Should().HaveCount(1);
+        ((NpmComponent)result.ComponentsFound.Single().Component).Name.Should().Be("app-pkg");
+
+        // The dependency graph should not reference the filtered component.
+        var graphEntry = result.DependencyGraphs.Should().ContainSingle().Which;
+        var graph = graphEntry.Value.Graph;
+        graph.Should().ContainKey(retainedComponent.Component.Id);
+        graph.Should().NotContainKey(baseImageComponent.Component.Id);
+
+        // The retained component's edge set should not reference the removed component.
+        var retainedEdges = graph[retainedComponent.Component.Id];
+        retainedEdges?.Should().NotContain(baseImageComponent.Component.Id);
+
+        // Metadata sets should also be cleaned.
+        graphEntry.Value.ExplicitlyReferencedComponentIds.Should().NotContain(baseImageComponent.Component.Id);
+    }
+
+    [TestMethod]
+    public void FilterBaseImageComponents_DependencyGraphsUnchangedWhenFlagDisabled()
+    {
+        var filePath = Path.Join(this.sourceDirectory.FullName, "file1");
+        var singleFileRecorder = this.componentRecorder.CreateSingleFileComponentRecorder(filePath);
+
+        var retainedComponent = new DetectedComponent(new NpmComponent("app-pkg", "1.0.0"), containerDetailsId: 1, containerLayerId: 1);
+        var baseImageComponent = new DetectedComponent(new NpmComponent("base-pkg", "2.0.0"), containerDetailsId: 1, containerLayerId: 0);
+
+        singleFileRecorder.RegisterUsage(retainedComponent, isExplicitReferencedDependency: true);
+        singleFileRecorder.RegisterUsage(baseImageComponent, parentComponentId: retainedComponent.Component.Id);
+
+        var containerDetailsMap = new Dictionary<int, ContainerDetails>
+        {
+            [1] = new ContainerDetails
+            {
+                Id = 1,
+                Layers = [new DockerLayer { LayerIndex = 0, IsBaseImage = true }, new DockerLayer { LayerIndex = 1, IsBaseImage = false }],
+            },
+        };
+
+        var processingResult = new DetectorProcessingResult
+        {
+            ResultCode = ProcessingResultCode.Success,
+            ContainersDetailsMap = containerDetailsMap,
+            ComponentRecorders = [(this.componentDetectorMock.Object, this.componentRecorder)],
+        };
+
+        var result = (DefaultGraphScanResult)this.serviceUnderTest.GenerateScanResultFromProcessingResult(
+            processingResult, new ScanSettings { SourceDirectory = this.sourceDirectory, FilterBaseImageComponents = false });
+
+        // Both components should be present.
+        result.ComponentsFound.Should().HaveCount(2);
+
+        // The dependency graph should still contain both component IDs.
+        var graph = result.DependencyGraphs.Single().Value.Graph;
+        graph.Should().ContainKey(retainedComponent.Component.Id);
+        graph.Should().ContainKey(baseImageComponent.Component.Id);
     }
 }

--- a/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/DefaultGraphTranslationServiceTests.cs
+++ b/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/DefaultGraphTranslationServiceTests.cs
@@ -731,9 +731,9 @@ public class DefaultGraphTranslationServiceTests
         graph.Should().ContainKey(retainedComponent.Component.Id);
         graph.Should().NotContainKey(baseImageComponent.Component.Id);
 
-        // The retained component's edge set should not reference the removed component.
+        // The retained component should be a leaf node (null edges) after its only dependency was pruned.
         var retainedEdges = graph[retainedComponent.Component.Id];
-        retainedEdges?.Should().NotContain(baseImageComponent.Component.Id);
+        retainedEdges.Should().BeNull();
 
         // Metadata sets should also be cleaned.
         graphEntry.Value.ExplicitlyReferencedComponentIds.Should().NotContain(baseImageComponent.Component.Id);

--- a/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/DefaultGraphTranslationServiceTests.cs
+++ b/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/DefaultGraphTranslationServiceTests.cs
@@ -564,4 +564,128 @@ public class DefaultGraphTranslationServiceTests
         // Both rich entries should have the bare graph's file path (package.json)
         lodashResults.Should().OnlyContain(c => c.LocationsFoundAt.Any(l => l.Contains("package.json")));
     }
+
+    [TestMethod]
+    public void FilterBaseImageComponents_RemovesComponentsExclusivelyFromBaseImageLayers()
+    {
+        var singleFileRecorder = this.componentRecorder.CreateSingleFileComponentRecorder(Path.Join(this.sourceDirectory.FullName, "/file1"));
+
+        var baseImageComponent = new DetectedComponent(new NpmComponent("base-pkg", "1.0.0"), containerDetailsId: 1, containerLayerId: 0);
+        singleFileRecorder.RegisterUsage(baseImageComponent);
+
+        var containerDetailsMap = new Dictionary<int, ContainerDetails>
+        {
+            [1] = new ContainerDetails
+            {
+                Id = 1,
+                Layers = [new DockerLayer { LayerIndex = 0, IsBaseImage = true }, new DockerLayer { LayerIndex = 1, IsBaseImage = false }],
+            },
+        };
+
+        var processingResult = new DetectorProcessingResult
+        {
+            ResultCode = ProcessingResultCode.Success,
+            ContainersDetailsMap = containerDetailsMap,
+            ComponentRecorders = [(this.componentDetectorMock.Object, this.componentRecorder)],
+        };
+
+        var result = this.serviceUnderTest.GenerateScanResultFromProcessingResult(
+            processingResult, new ScanSettings { SourceDirectory = this.sourceDirectory, FilterBaseImageComponents = true });
+
+        result.ComponentsFound.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public void FilterBaseImageComponents_RetainsComponentsWithMixedLayers()
+    {
+        var singleFileRecorder = this.componentRecorder.CreateSingleFileComponentRecorder(Path.Join(this.sourceDirectory.FullName, "/file1"));
+
+        var mixedComponent = new DetectedComponent(new NpmComponent("mixed-pkg", "1.0.0"), containerDetailsId: 1, containerLayerId: 0);
+        mixedComponent.ContainerLayerIds[1] = [0, 1];
+        singleFileRecorder.RegisterUsage(mixedComponent);
+
+        var containerDetailsMap = new Dictionary<int, ContainerDetails>
+        {
+            [1] = new ContainerDetails
+            {
+                Id = 1,
+                Layers = [new DockerLayer { LayerIndex = 0, IsBaseImage = true }, new DockerLayer { LayerIndex = 1, IsBaseImage = false }],
+            },
+        };
+
+        var processingResult = new DetectorProcessingResult
+        {
+            ResultCode = ProcessingResultCode.Success,
+            ContainersDetailsMap = containerDetailsMap,
+            ComponentRecorders = [(this.componentDetectorMock.Object, this.componentRecorder)],
+        };
+
+        var result = this.serviceUnderTest.GenerateScanResultFromProcessingResult(
+            processingResult, new ScanSettings { SourceDirectory = this.sourceDirectory, FilterBaseImageComponents = true });
+
+        result.ComponentsFound.Should().HaveCount(1);
+        ((NpmComponent)result.ComponentsFound.Single().Component).Name.Should().Be("mixed-pkg");
+    }
+
+    [TestMethod]
+    public void FilterBaseImageComponents_RetainsComponentsWithNoContainerReferences()
+    {
+        var singleFileRecorder = this.componentRecorder.CreateSingleFileComponentRecorder(Path.Join(this.sourceDirectory.FullName, "/file1"));
+
+        var filesystemComponent = new DetectedComponent(new NpmComponent("fs-pkg", "2.0.0"));
+        singleFileRecorder.RegisterUsage(filesystemComponent);
+
+        var containerDetailsMap = new Dictionary<int, ContainerDetails>
+        {
+            [1] = new ContainerDetails
+            {
+                Id = 1,
+                Layers = [new DockerLayer { LayerIndex = 0, IsBaseImage = true }],
+            },
+        };
+
+        var processingResult = new DetectorProcessingResult
+        {
+            ResultCode = ProcessingResultCode.Success,
+            ContainersDetailsMap = containerDetailsMap,
+            ComponentRecorders = [(this.componentDetectorMock.Object, this.componentRecorder)],
+        };
+
+        var result = this.serviceUnderTest.GenerateScanResultFromProcessingResult(
+            processingResult, new ScanSettings { SourceDirectory = this.sourceDirectory, FilterBaseImageComponents = true });
+
+        result.ComponentsFound.Should().HaveCount(1);
+        ((NpmComponent)result.ComponentsFound.Single().Component).Name.Should().Be("fs-pkg");
+    }
+
+    [TestMethod]
+    public void FilterBaseImageComponents_NoOpWhenFlagIsDisabled()
+    {
+        var singleFileRecorder = this.componentRecorder.CreateSingleFileComponentRecorder(Path.Join(this.sourceDirectory.FullName, "/file1"));
+
+        var baseImageComponent = new DetectedComponent(new NpmComponent("base-pkg", "1.0.0"), containerDetailsId: 1, containerLayerId: 0);
+        singleFileRecorder.RegisterUsage(baseImageComponent);
+
+        var containerDetailsMap = new Dictionary<int, ContainerDetails>
+        {
+            [1] = new ContainerDetails
+            {
+                Id = 1,
+                Layers = [new DockerLayer { LayerIndex = 0, IsBaseImage = true }],
+            },
+        };
+
+        var processingResult = new DetectorProcessingResult
+        {
+            ResultCode = ProcessingResultCode.Success,
+            ContainersDetailsMap = containerDetailsMap,
+            ComponentRecorders = [(this.componentDetectorMock.Object, this.componentRecorder)],
+        };
+
+        var result = this.serviceUnderTest.GenerateScanResultFromProcessingResult(
+            processingResult, new ScanSettings { SourceDirectory = this.sourceDirectory, FilterBaseImageComponents = false });
+
+        result.ComponentsFound.Should().HaveCount(1);
+        ((NpmComponent)result.ComponentsFound.Single().Component).Name.Should().Be("base-pkg");
+    }
 }

--- a/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/DefaultGraphTranslationServiceTests.cs
+++ b/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/DefaultGraphTranslationServiceTests.cs
@@ -566,7 +566,7 @@ public class DefaultGraphTranslationServiceTests
     }
 
     [TestMethod]
-    public void FilterBaseImageComponents_RemovesComponentsExclusivelyFromBaseImageLayers()
+    public void ExcludeBaseImageComponents_RemovesComponentsExclusivelyFromBaseImageLayers()
     {
         var singleFileRecorder = this.componentRecorder.CreateSingleFileComponentRecorder(Path.Join(this.sourceDirectory.FullName, "file1"));
 
@@ -590,13 +590,13 @@ public class DefaultGraphTranslationServiceTests
         };
 
         var result = this.serviceUnderTest.GenerateScanResultFromProcessingResult(
-            processingResult, new ScanSettings { SourceDirectory = this.sourceDirectory, FilterBaseImageComponents = true });
+            processingResult, new ScanSettings { SourceDirectory = this.sourceDirectory, ExcludeBaseImageComponents = true });
 
         result.ComponentsFound.Should().BeEmpty();
     }
 
     [TestMethod]
-    public void FilterBaseImageComponents_RetainsComponentsWithMixedLayers()
+    public void ExcludeBaseImageComponents_RetainsComponentsWithMixedLayers()
     {
         var singleFileRecorder = this.componentRecorder.CreateSingleFileComponentRecorder(Path.Join(this.sourceDirectory.FullName, "file1"));
 
@@ -621,14 +621,14 @@ public class DefaultGraphTranslationServiceTests
         };
 
         var result = this.serviceUnderTest.GenerateScanResultFromProcessingResult(
-            processingResult, new ScanSettings { SourceDirectory = this.sourceDirectory, FilterBaseImageComponents = true });
+            processingResult, new ScanSettings { SourceDirectory = this.sourceDirectory, ExcludeBaseImageComponents = true });
 
         result.ComponentsFound.Should().HaveCount(1);
         ((NpmComponent)result.ComponentsFound.Single().Component).Name.Should().Be("mixed-pkg");
     }
 
     [TestMethod]
-    public void FilterBaseImageComponents_RetainsComponentsWithNoContainerReferences()
+    public void ExcludeBaseImageComponents_RetainsComponentsWithNoContainerReferences()
     {
         var singleFileRecorder = this.componentRecorder.CreateSingleFileComponentRecorder(Path.Join(this.sourceDirectory.FullName, "file1"));
 
@@ -652,14 +652,14 @@ public class DefaultGraphTranslationServiceTests
         };
 
         var result = this.serviceUnderTest.GenerateScanResultFromProcessingResult(
-            processingResult, new ScanSettings { SourceDirectory = this.sourceDirectory, FilterBaseImageComponents = true });
+            processingResult, new ScanSettings { SourceDirectory = this.sourceDirectory, ExcludeBaseImageComponents = true });
 
         result.ComponentsFound.Should().HaveCount(1);
         ((NpmComponent)result.ComponentsFound.Single().Component).Name.Should().Be("fs-pkg");
     }
 
     [TestMethod]
-    public void FilterBaseImageComponents_NoOpWhenFlagIsDisabled()
+    public void ExcludeBaseImageComponents_NoOpWhenFlagIsDisabled()
     {
         var singleFileRecorder = this.componentRecorder.CreateSingleFileComponentRecorder(Path.Join(this.sourceDirectory.FullName, "file1"));
 
@@ -683,14 +683,14 @@ public class DefaultGraphTranslationServiceTests
         };
 
         var result = this.serviceUnderTest.GenerateScanResultFromProcessingResult(
-            processingResult, new ScanSettings { SourceDirectory = this.sourceDirectory, FilterBaseImageComponents = false });
+            processingResult, new ScanSettings { SourceDirectory = this.sourceDirectory, ExcludeBaseImageComponents = false });
 
         result.ComponentsFound.Should().HaveCount(1);
         ((NpmComponent)result.ComponentsFound.Single().Component).Name.Should().Be("base-pkg");
     }
 
     [TestMethod]
-    public void FilterBaseImageComponents_PrunesFilteredComponentsFromDependencyGraphs()
+    public void ExcludeBaseImageComponents_PrunesFilteredComponentsFromDependencyGraphs()
     {
         var filePath = Path.Join(this.sourceDirectory.FullName, "file1");
         var singleFileRecorder = this.componentRecorder.CreateSingleFileComponentRecorder(filePath);
@@ -719,7 +719,7 @@ public class DefaultGraphTranslationServiceTests
         };
 
         var result = (DefaultGraphScanResult)this.serviceUnderTest.GenerateScanResultFromProcessingResult(
-            processingResult, new ScanSettings { SourceDirectory = this.sourceDirectory, FilterBaseImageComponents = true });
+            processingResult, new ScanSettings { SourceDirectory = this.sourceDirectory, ExcludeBaseImageComponents = true });
 
         // Only the non-base-image component should remain.
         result.ComponentsFound.Should().HaveCount(1);
@@ -740,7 +740,7 @@ public class DefaultGraphTranslationServiceTests
     }
 
     [TestMethod]
-    public void FilterBaseImageComponents_DependencyGraphsUnchangedWhenFlagDisabled()
+    public void ExcludeBaseImageComponents_DependencyGraphsUnchangedWhenFlagDisabled()
     {
         var filePath = Path.Join(this.sourceDirectory.FullName, "file1");
         var singleFileRecorder = this.componentRecorder.CreateSingleFileComponentRecorder(filePath);
@@ -768,7 +768,7 @@ public class DefaultGraphTranslationServiceTests
         };
 
         var result = (DefaultGraphScanResult)this.serviceUnderTest.GenerateScanResultFromProcessingResult(
-            processingResult, new ScanSettings { SourceDirectory = this.sourceDirectory, FilterBaseImageComponents = false });
+            processingResult, new ScanSettings { SourceDirectory = this.sourceDirectory, ExcludeBaseImageComponents = false });
 
         // Both components should be present.
         result.ComponentsFound.Should().HaveCount(2);
@@ -780,7 +780,7 @@ public class DefaultGraphTranslationServiceTests
     }
 
     [TestMethod]
-    public void FilterBaseImageComponents_PrunesReferrersToFilteredComponents()
+    public void ExcludeBaseImageComponents_PrunesReferrersToFilteredComponents()
     {
         var filePath = Path.Join(this.sourceDirectory.FullName, "file1");
         var singleFileRecorder = this.componentRecorder.CreateSingleFileComponentRecorder(filePath);
@@ -809,7 +809,7 @@ public class DefaultGraphTranslationServiceTests
         };
 
         var result = this.serviceUnderTest.GenerateScanResultFromProcessingResult(
-            processingResult, new ScanSettings { SourceDirectory = this.sourceDirectory, FilterBaseImageComponents = true });
+            processingResult, new ScanSettings { SourceDirectory = this.sourceDirectory, ExcludeBaseImageComponents = true });
 
         // Only child-pkg should remain (base-pkg is exclusively from base image layer).
         result.ComponentsFound.Should().HaveCount(1);

--- a/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/DefaultGraphTranslationServiceTests.cs
+++ b/test/Microsoft.ComponentDetection.Orchestrator.Tests/Services/DefaultGraphTranslationServiceTests.cs
@@ -778,4 +778,48 @@ public class DefaultGraphTranslationServiceTests
         graph.Should().ContainKey(retainedComponent.Component.Id);
         graph.Should().ContainKey(baseImageComponent.Component.Id);
     }
+
+    [TestMethod]
+    public void FilterBaseImageComponents_PrunesReferrersToFilteredComponents()
+    {
+        var filePath = Path.Join(this.sourceDirectory.FullName, "file1");
+        var singleFileRecorder = this.componentRecorder.CreateSingleFileComponentRecorder(filePath);
+
+        // base-pkg is a root that depends on child-pkg (non-base-image).
+        var baseImageComponent = new DetectedComponent(new NpmComponent("base-pkg", "1.0.0"), containerDetailsId: 1, containerLayerId: 0);
+        var childComponent = new DetectedComponent(new NpmComponent("child-pkg", "1.0.0"), containerDetailsId: 1, containerLayerId: 1);
+
+        singleFileRecorder.RegisterUsage(baseImageComponent, isExplicitReferencedDependency: true);
+        singleFileRecorder.RegisterUsage(childComponent, parentComponentId: baseImageComponent.Component.Id);
+
+        var containerDetailsMap = new Dictionary<int, ContainerDetails>
+        {
+            [1] = new ContainerDetails
+            {
+                Id = 1,
+                Layers = [new DockerLayer { LayerIndex = 0, IsBaseImage = true }, new DockerLayer { LayerIndex = 1, IsBaseImage = false }],
+            },
+        };
+
+        var processingResult = new DetectorProcessingResult
+        {
+            ResultCode = ProcessingResultCode.Success,
+            ContainersDetailsMap = containerDetailsMap,
+            ComponentRecorders = [(this.componentDetectorMock.Object, this.componentRecorder)],
+        };
+
+        var result = this.serviceUnderTest.GenerateScanResultFromProcessingResult(
+            processingResult, new ScanSettings { SourceDirectory = this.sourceDirectory, FilterBaseImageComponents = true });
+
+        // Only child-pkg should remain (base-pkg is exclusively from base image layer).
+        result.ComponentsFound.Should().HaveCount(1);
+        var child = result.ComponentsFound.Single();
+        ((NpmComponent)child.Component).Name.Should().Be("child-pkg");
+
+        // TopLevelReferrers should not reference the filtered base-image component.
+        child.TopLevelReferrers?.Should().NotContain(c => c.Id == baseImageComponent.Component.Id);
+
+        // AncestralReferrers should not reference the filtered base-image component.
+        child.AncestralReferrers?.Should().NotContain(c => c.Id == baseImageComponent.Component.Id);
+    }
 }


### PR DESCRIPTION
This PR makes two changes:

### Improve the way components from container images are mapped to layers

Prior to this, the Syft output's "Locations" field was the sole source of a component's file and layer information. This was undesirable because, for packages installed by the system package manager, the only location would be the system package manager database. As a result, any changes to system packages in later layers would result in every system package being mapped to the last layer where the database was modified.

Now, the Syft output's "Metadata.Files" field is used to augment the "Locations" data about files and layers associated with a component, and any known system package manager database files are ignored in favor of other file mappings, if present. This leads to more accurate mappings of components to image layers.

The expected result of this change is that some components which were previously mapped to layers above the base image may now be properly mapped to base image layers.

### Add a new option to exclude components which solely originate from the base image when scanning a container image.

The flag `--ExcludeBaseImageComponents` can be specified to filter out components from the base image.