### PR TITLE
Pauldorsch/reduce linux scan time

### DIFF
--- a/src/Microsoft.ComponentDetection.Common/DockerService.cs
+++ b/src/Microsoft.ComponentDetection.Common/DockerService.cs
@@ -2,8 +2,8 @@
 namespace Microsoft.ComponentDetection.Common;
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Threading;
@@ -23,6 +23,15 @@ internal class DockerService : IDockerService
     private const string BaseImageDigestAnnotation = "image.base.digest";
 
     private static readonly DockerClient Client = new DockerClientConfiguration().CreateClient();
+
+    /// <summary>
+    /// Serializes image pull operations so only one pull runs at a time,
+    /// and tracks which images have already been pulled to avoid redundant work.
+    /// </summary>
+    private static readonly SemaphoreSlim PullSemaphore = new(1, 1);
+
+    private static readonly ConcurrentDictionary<string, bool> PulledImages = new();
+
     private static int incrementingContainerId;
 
     private readonly ILogger logger;
@@ -95,6 +104,46 @@ internal class DockerService : IDockerService
     }
 
     public async Task<bool> TryPullImageAsync(string image, CancellationToken cancellationToken = default)
+    {
+        // Fast path: already pulled in this process
+        if (PulledImages.ContainsKey(image))
+        {
+            return true;
+        }
+
+        // Check if already available locally before acquiring the semaphore
+        if (await this.ImageExistsLocallyAsync(image, cancellationToken))
+        {
+            PulledImages.TryAdd(image, true);
+            return true;
+        }
+
+        await PullSemaphore.WaitAsync(cancellationToken);
+        try
+        {
+            // Double-check after acquiring semaphore — another caller may have
+            // pulled this image (or a different image that satisfied the local check)
+            // while we were waiting.
+            if (PulledImages.ContainsKey(image))
+            {
+                return true;
+            }
+
+            var result = await this.PullImageCoreAsync(image, cancellationToken);
+            if (result)
+            {
+                PulledImages.TryAdd(image, true);
+            }
+
+            return result;
+        }
+        finally
+        {
+            PullSemaphore.Release();
+        }
+    }
+
+    private async Task<bool> PullImageCoreAsync(string image, CancellationToken cancellationToken)
     {
         using var record = new DockerServiceTryPullImageTelemetryRecord
         {
@@ -353,7 +402,6 @@ internal class DockerService : IDockerService
         {
             var binds = new List<string>
             {
-                $"{Path.GetTempPath()}:/tmp",
                 "/var/run/docker.sock:/var/run/docker.sock",
             };
 

--- a/src/Microsoft.ComponentDetection.Common/DockerService.cs
+++ b/src/Microsoft.ComponentDetection.Common/DockerService.cs
@@ -84,11 +84,13 @@ internal class DockerService : IDockerService
         {
             var imageInspectResponse = await this.InspectImageAndSanitizeVarsAsync(image, cancellationToken);
             record.ImageInspectResponse = JsonSerializer.Serialize(imageInspectResponse);
+            this.logger.LogDebug("Image {Image} found locally", image);
             return true;
         }
         catch (Exception e)
         {
             record.ExceptionMessage = e.Message;
+            this.logger.LogDebug("Image {Image} not found locally", image);
             cancellationToken.ThrowIfCancellationRequested();
             return false;
         }
@@ -116,18 +118,22 @@ internal class DockerService : IDockerService
         if (existingTask != tcs.Task)
         {
             // Another caller is already pulling this image — await their result.
+            this.logger.LogDebug("Image {Image} is already being pulled by another caller, waiting", image);
             return await existingTask;
         }
 
         // We own this cache entry — perform the actual pull.
         try
         {
+            this.logger.LogDebug("Pulling image {Image}...", image);
             var result = await this.PullImageCoreAsync(image, cancellationToken);
+            this.logger.LogDebug("Pull of image {Image} completed (success={Success})", image, result);
             tcs.SetResult(result);
             return result;
         }
         catch (Exception ex)
         {
+            this.logger.LogDebug(ex, "Pull of image {Image} failed", image);
             PullCache.TryRemove(image, out _);
             tcs.SetException(ex);
             throw;
@@ -253,7 +259,7 @@ internal class DockerService : IDockerService
             var stream = await AttachContainerAsync(container.ID, cancellationToken);
             await StartContainerAsync(container.ID, cancellationToken);
 
-            this.logger.LogInformation("Container {ContainerId} started for image {Image}, reading output...", container.ID, image);
+            this.logger.LogInformation("Container {ContainerId} started with image {Image} to execute {Command}, reading output...", container.ID, image, commandJson);
 
             // Flush telemetry before the long-running ReadOutput so we get mid-scan
             // data in App Insights even if the process hangs during the read.

--- a/src/Microsoft.ComponentDetection.Common/DockerService.cs
+++ b/src/Microsoft.ComponentDetection.Common/DockerService.cs
@@ -108,7 +108,6 @@ internal class DockerService : IDockerService
         // Check if already available locally before attempting a pull
         if (await this.ImageExistsLocallyAsync(image, cancellationToken))
         {
-            PullCache.TryAdd(image, Task.FromResult(true));
             return true;
         }
 
@@ -128,21 +127,21 @@ internal class DockerService : IDockerService
             this.logger.LogDebug("Pulling image {Image}...", image);
             var result = await this.PullImageCoreAsync(image, cancellationToken);
             this.logger.LogDebug("Pull of image {Image} completed (success={Success})", image, result);
-            if (!result)
-            {
-                // Non-exception failure — remove the entry so later callers can retry.
-                PullCache.TryRemove(image, out _);
-            }
-
             tcs.SetResult(result);
             return result;
         }
         catch (Exception ex)
         {
             this.logger.LogDebug(ex, "Pull of image {Image} failed", image);
-            PullCache.TryRemove(image, out _);
             tcs.SetException(ex);
             throw;
+        }
+        finally
+        {
+            // Remove the entry once complete. The cache only deduplicates concurrent
+            // in-flight pulls — subsequent callers will hit ImageExistsLocallyAsync
+            // for images that were already pulled successfully.
+            PullCache.TryRemove(image, out _);
         }
     }
 

--- a/src/Microsoft.ComponentDetection.Common/DockerService.cs
+++ b/src/Microsoft.ComponentDetection.Common/DockerService.cs
@@ -117,9 +117,9 @@ internal class DockerService : IDockerService
 
         if (existingTask != tcs.Task)
         {
-            // Another caller is already pulling this image — await their result.
+            // Another caller is already pulling this image — await their result
             this.logger.LogDebug("Image {Image} is already being pulled by another caller, waiting", image);
-            return await existingTask;
+            return await existingTask.WaitAsync(cancellationToken);
         }
 
         // We own this cache entry — perform the actual pull.
@@ -128,6 +128,12 @@ internal class DockerService : IDockerService
             this.logger.LogDebug("Pulling image {Image}...", image);
             var result = await this.PullImageCoreAsync(image, cancellationToken);
             this.logger.LogDebug("Pull of image {Image} completed (success={Success})", image, result);
+            if (!result)
+            {
+                // Non-exception failure — remove the entry so later callers can retry.
+                PullCache.TryRemove(image, out _);
+            }
+
             tcs.SetResult(result);
             return result;
         }

--- a/src/Microsoft.ComponentDetection.Common/DockerService.cs
+++ b/src/Microsoft.ComponentDetection.Common/DockerService.cs
@@ -25,12 +25,10 @@ internal class DockerService : IDockerService
     private static readonly DockerClient Client = new DockerClientConfiguration().CreateClient();
 
     /// <summary>
-    /// Serializes image pull operations so only one pull runs at a time,
-    /// and tracks which images have already been pulled to avoid redundant work.
+    /// Tracks in-flight and completed image pulls so each image is pulled at most once.
+    /// Concurrent callers for the same image await the same task.
     /// </summary>
-    private static readonly SemaphoreSlim PullSemaphore = new(1, 1);
-
-    private static readonly ConcurrentDictionary<string, bool> PulledImages = new();
+    private static readonly ConcurrentDictionary<string, Task<bool>> PullCache = new();
 
     private static int incrementingContainerId;
 
@@ -105,41 +103,34 @@ internal class DockerService : IDockerService
 
     public async Task<bool> TryPullImageAsync(string image, CancellationToken cancellationToken = default)
     {
-        // Fast path: already pulled in this process
-        if (PulledImages.ContainsKey(image))
-        {
-            return true;
-        }
-
-        // Check if already available locally before acquiring the semaphore
+        // Check if already available locally before attempting a pull
         if (await this.ImageExistsLocallyAsync(image, cancellationToken))
         {
-            PulledImages.TryAdd(image, true);
+            PullCache.TryAdd(image, Task.FromResult(true));
             return true;
         }
 
-        await PullSemaphore.WaitAsync(cancellationToken);
+        var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var existingTask = PullCache.GetOrAdd(image, tcs.Task);
+
+        if (existingTask != tcs.Task)
+        {
+            // Another caller is already pulling this image — await their result.
+            return await existingTask;
+        }
+
+        // We own this cache entry — perform the actual pull.
         try
         {
-            // Double-check after acquiring semaphore — another caller may have
-            // pulled this image (or a different image that satisfied the local check)
-            // while we were waiting.
-            if (PulledImages.ContainsKey(image))
-            {
-                return true;
-            }
-
             var result = await this.PullImageCoreAsync(image, cancellationToken);
-            if (result)
-            {
-                PulledImages.TryAdd(image, true);
-            }
-
+            tcs.SetResult(result);
             return result;
         }
-        finally
+        catch (Exception ex)
         {
-            PullSemaphore.Release();
+            PullCache.TryRemove(image, out _);
+            tcs.SetException(ex);
+            throw;
         }
     }
 

--- a/src/Microsoft.ComponentDetection.Common/DockerService.cs
+++ b/src/Microsoft.ComponentDetection.Common/DockerService.cs
@@ -25,7 +25,7 @@ internal class DockerService : IDockerService
     private static readonly DockerClient Client = new DockerClientConfiguration().CreateClient();
 
     /// <summary>
-    /// Tracks in-flight and completed image pulls so each image is pulled at most once.
+    /// Tracks in-flight image pulls so each image is pulled at most once concurrently.
     /// Concurrent callers for the same image await the same task.
     /// </summary>
     private static readonly ConcurrentDictionary<string, Task<bool>> PullCache = new();

--- a/src/Microsoft.ComponentDetection.Detectors/linux/LinuxContainerDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/linux/LinuxContainerDetector.cs
@@ -662,6 +662,12 @@ public class LinuxContainerDetector(
             refWithDigest,
             cancellationToken
         );
+        this.logger.LogDebug(
+            "Base image {BaseImage} resolved for {ContainerImage} with {LayerCount} layers",
+            refWithDigest,
+            image,
+            baseImageDetails.Layers.Count()
+        );
         if (!ValidateBaseImageLayers(scannedImageDetails, baseImageDetails))
         {
             record.BaseImageLayerMessage =

--- a/src/Microsoft.ComponentDetection.Detectors/linux/LinuxContainerDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/linux/LinuxContainerDetector.cs
@@ -662,12 +662,24 @@ public class LinuxContainerDetector(
             refWithDigest,
             cancellationToken
         );
+
+        if (baseImageDetails == null)
+        {
+            record.BaseImageLayerMessage = "Failed to inspect base image after pull";
+            this.logger.LogInformation(
+                "Failed to inspect base image {BaseImage} after pull. Results will not be mapped to base image layers",
+                refWithDigest
+            );
+            return 0;
+        }
+
         this.logger.LogDebug(
             "Base image {BaseImage} resolved for {ContainerImage} with {LayerCount} layers",
             refWithDigest,
             image,
             baseImageDetails.Layers.Count()
         );
+
         if (!ValidateBaseImageLayers(scannedImageDetails, baseImageDetails))
         {
             record.BaseImageLayerMessage =

--- a/src/Microsoft.ComponentDetection.Detectors/linux/LinuxScanner.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/linux/LinuxScanner.cs
@@ -1,6 +1,7 @@
 namespace Microsoft.ComponentDetection.Detectors.Linux;
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
@@ -30,6 +31,13 @@ internal class LinuxScanner : ILinuxScanner
     private static readonly IList<string> ScopeSquashedParameter = ["--scope", "squashed"];
 
     private static readonly SemaphoreSlim ContainerSemaphore = new SemaphoreSlim(2);
+
+    /// <summary>
+    /// Caches in-flight and completed syft runs keyed by (source, scope).
+    /// When multiple detectors scan the same image concurrently, the second
+    /// caller awaits the already-running task instead of launching a new container.
+    /// </summary>
+    private static readonly ConcurrentDictionary<(string Source, LinuxScannerScope Scope), Task<string>> SyftRunCache = new();
 
     private static readonly int SemaphoreTimeout = Convert.ToInt32(
         TimeSpan.FromHours(1).TotalMilliseconds
@@ -253,8 +261,54 @@ internal class LinuxScanner : ILinuxScanner
 
     /// <summary>
     /// Runs the Syft scanner container and returns the stdout output.
+    /// For Docker image scans (no additional binds), results are cached so that
+    /// concurrent callers scanning the same image+scope share a single container run.
     /// </summary>
     private async Task<string> RunSyftAsync(
+        string syftSource,
+        LinuxScannerScope scope,
+        IList<string> additionalBinds,
+        LinuxScannerTelemetryRecord record,
+        LinuxScannerSyftTelemetryRecord syftTelemetryRecord,
+        CancellationToken cancellationToken)
+    {
+        // Local image scans use additional binds specific to each call, so they
+        // cannot be deduplicated safely — run them directly.
+        if (additionalBinds is { Count: > 0 })
+        {
+            return await this.RunSyftCoreAsync(syftSource, scope, additionalBinds, record, syftTelemetryRecord, cancellationToken);
+        }
+
+        var cacheKey = (syftSource, scope);
+        var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var existingTask = SyftRunCache.GetOrAdd(cacheKey, tcs.Task);
+
+        if (existingTask != tcs.Task)
+        {
+            // Another caller is already running syft for this image+scope — await their result.
+            return await existingTask;
+        }
+
+        // We own this cache entry — run syft and propagate the result.
+        try
+        {
+            var result = await this.RunSyftCoreAsync(syftSource, scope, additionalBinds, record, syftTelemetryRecord, cancellationToken);
+            tcs.SetResult(result);
+            return result;
+        }
+        catch (Exception ex)
+        {
+            // Remove the failed entry so a retry can start fresh.
+            SyftRunCache.TryRemove(cacheKey, out _);
+            tcs.SetException(ex);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Executes the Syft scanner container and returns the stdout output.
+    /// </summary>
+    private async Task<string> RunSyftCoreAsync(
         string syftSource,
         LinuxScannerScope scope,
         IList<string> additionalBinds,
@@ -357,4 +411,9 @@ internal class LinuxScanner : ILinuxScanner
         var layerIds = artifact.Locations?.Select(location => location.LayerId).Distinct() ?? [];
         return (component, layerIds);
     }
+
+    /// <summary>
+    /// Clears the syft run cache. Intended for test isolation only.
+    /// </summary>
+    internal static void ResetCache() => SyftRunCache.Clear();
 }

--- a/src/Microsoft.ComponentDetection.Detectors/linux/LinuxScanner.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/linux/LinuxScanner.cs
@@ -37,7 +37,7 @@ internal class LinuxScanner : ILinuxScanner
     /// When multiple detectors scan the same image concurrently, the second
     /// caller awaits the already-running task instead of launching a new container.
     /// </summary>
-    private static readonly ConcurrentDictionary<(string Source, LinuxScannerScope Scope), Task<string>> SyftRunCache = new();
+    private static readonly ConcurrentDictionary<(string Source, LinuxScannerScope Scope, string Binds), Task<string>> SyftRunCache = new();
 
     private static readonly int SemaphoreTimeout = Convert.ToInt32(
         TimeSpan.FromHours(1).TotalMilliseconds
@@ -261,8 +261,8 @@ internal class LinuxScanner : ILinuxScanner
 
     /// <summary>
     /// Runs the Syft scanner container and returns the stdout output.
-    /// For Docker image scans (no additional binds), results are cached so that
-    /// concurrent callers scanning the same image+scope share a single container run.
+    /// Results are cached by (source, scope, binds) so that concurrent callers
+    /// with identical parameters share a single container run.
     /// </summary>
     private async Task<string> RunSyftAsync(
         string syftSource,
@@ -272,14 +272,8 @@ internal class LinuxScanner : ILinuxScanner
         LinuxScannerSyftTelemetryRecord syftTelemetryRecord,
         CancellationToken cancellationToken)
     {
-        // Local image scans use additional binds specific to each call, so they
-        // cannot be deduplicated safely — run them directly.
-        if (additionalBinds is { Count: > 0 })
-        {
-            return await this.RunSyftCoreAsync(syftSource, scope, additionalBinds, record, syftTelemetryRecord, cancellationToken);
-        }
-
-        var cacheKey = (syftSource, scope);
+        var bindsKey = string.Join(";", (additionalBinds ?? []).OrderBy(b => b, StringComparer.Ordinal));
+        var cacheKey = (syftSource, scope, bindsKey);
         var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
         var existingTask = SyftRunCache.GetOrAdd(cacheKey, tcs.Task);
 
@@ -292,7 +286,7 @@ internal class LinuxScanner : ILinuxScanner
         // We own this cache entry — run syft and propagate the result.
         try
         {
-            var result = await this.RunSyftCoreAsync(syftSource, scope, additionalBinds, record, syftTelemetryRecord, cancellationToken);
+            var result = await this.RunSyftCoreAsync(syftSource, scope, additionalBinds ?? [], record, syftTelemetryRecord, cancellationToken);
             tcs.SetResult(result);
             return result;
         }

--- a/src/Microsoft.ComponentDetection.Detectors/linux/LinuxScanner.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/linux/LinuxScanner.cs
@@ -280,6 +280,7 @@ internal class LinuxScanner : ILinuxScanner
         {
             // Another caller is already running syft for this image+scope — await their result,
             // but allow this caller's cancellation token to abort the wait.
+            this.logger.LogDebug("Syft run for {SyftSource} (scope={Scope}) is already in-flight, reusing existing result", syftSource, scope);
             return await existingTask.WaitAsync(cancellationToken);
         }
 
@@ -292,10 +293,15 @@ internal class LinuxScanner : ILinuxScanner
         }
         catch (Exception ex)
         {
-            // Remove the failed entry so a retry can start fresh.
-            SyftRunCache.TryRemove(cacheKey, out _);
             tcs.SetException(ex);
             throw;
+        }
+        finally
+        {
+            // Remove the entry once complete. The cache only deduplicates concurrent
+            // in-flight calls — keeping completed entries would leak memory for the
+            // lifetime of the process.
+            SyftRunCache.TryRemove(cacheKey, out _);
         }
     }
 

--- a/src/Microsoft.ComponentDetection.Detectors/linux/LinuxScanner.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/linux/LinuxScanner.cs
@@ -33,7 +33,7 @@ internal class LinuxScanner : ILinuxScanner
     private static readonly SemaphoreSlim ContainerSemaphore = new SemaphoreSlim(2);
 
     /// <summary>
-    /// Caches in-flight and completed syft runs keyed by (source, scope).
+    /// Caches in-flight and completed syft runs.
     /// When multiple detectors scan the same image concurrently, the second
     /// caller awaits the already-running task instead of launching a new container.
     /// </summary>
@@ -261,8 +261,7 @@ internal class LinuxScanner : ILinuxScanner
 
     /// <summary>
     /// Runs the Syft scanner container and returns the stdout output.
-    /// Results are cached by (source, scope, binds) so that concurrent callers
-    /// with identical parameters share a single container run.
+    /// Results are cached so that callers with identical parameters share a single container run.
     /// </summary>
     private async Task<string> RunSyftAsync(
         string syftSource,
@@ -279,8 +278,9 @@ internal class LinuxScanner : ILinuxScanner
 
         if (existingTask != tcs.Task)
         {
-            // Another caller is already running syft for this image+scope — await their result.
-            return await existingTask;
+            // Another caller is already running syft for this image+scope — await their result,
+            // but allow this caller's cancellation token to abort the wait.
+            return await existingTask.WaitAsync(cancellationToken);
         }
 
         // We own this cache entry — run syft and propagate the result.

--- a/src/Microsoft.ComponentDetection.Detectors/linux/LinuxScanner.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/linux/LinuxScanner.cs
@@ -33,7 +33,7 @@ internal class LinuxScanner : ILinuxScanner
     private static readonly SemaphoreSlim ContainerSemaphore = new SemaphoreSlim(2);
 
     /// <summary>
-    /// Caches in-flight and completed syft runs.
+    /// Caches in-flight syft runs.
     /// When multiple detectors scan the same image concurrently, the second
     /// caller awaits the already-running task instead of launching a new container.
     /// </summary>

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/LinuxContainerDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/LinuxContainerDetectorTests.cs
@@ -1495,4 +1495,50 @@ public class LinuxContainerDetectorTests
         // The first image should have produced components
         componentRecorder.GetDetectedComponents().Should().NotBeEmpty();
     }
+
+    [TestMethod]
+    public async Task TestLinuxContainerDetector_DuplicateImageReferences_ScansOnlyOnceAsync()
+    {
+        var componentRecorder = new ComponentRecorder();
+
+        // Pass the exact same image reference twice.
+        var scanRequest = new ScanRequest(
+            new DirectoryInfo(Path.GetTempPath()),
+            (_, __) => false,
+            this.mockLogger.Object,
+            null,
+            [NodeLatestImage, NodeLatestImage],
+            componentRecorder
+        );
+
+        var linuxContainerDetector = new LinuxContainerDetector(
+            this.mockSyftLinuxScanner.Object,
+            this.mockDockerService.Object,
+            this.mockLinuxContainerDetectorLogger.Object
+        );
+
+        var scanResult = await linuxContainerDetector.ExecuteDetectorAsync(scanRequest);
+
+        scanResult.ResultCode.Should().Be(ProcessingResultCode.Success);
+        scanResult.ContainerDetails.Should().ContainSingle();
+
+        var detectedComponents = componentRecorder.GetDetectedComponents().ToList();
+        detectedComponents.Should().ContainSingle();
+        detectedComponents.First().Component.Id.Should().Be(BashPackageId);
+
+        // Both references resolve to the same ImageId via InspectImageAsync,
+        // so the ConcurrentDictionary in ProcessImagesAsync deduplicates them.
+        this.mockSyftLinuxScanner.Verify(
+            scanner =>
+                scanner.ScanLinuxAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<IEnumerable<DockerLayer>>(),
+                    It.IsAny<int>(),
+                    It.IsAny<ISet<ComponentType>>(),
+                    It.IsAny<LinuxScannerScope>(),
+                    It.IsAny<CancellationToken>()
+                ),
+            Times.Once
+        );
+    }
 }

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/LinuxScannerTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/LinuxScannerTests.cs
@@ -1274,13 +1274,13 @@ public class LinuxScannerTests
 
         var result1 = await scanner1.GetSyftOutputAsync(
             "oci-dir:/img",
-            new List<string> { "/host/a:/container/a:ro", "/host/b:/container/b:ro" },
+            ["/host/a:/container/a:ro", "/host/b:/container/b:ro"],
             LinuxScannerScope.AllLayers
         );
 
         var result2 = await scanner2.GetSyftOutputAsync(
             "oci-dir:/img",
-            new List<string> { "/host/b:/container/b:ro", "/host/a:/container/a:ro" },
+            ["/host/b:/container/b:ro", "/host/a:/container/a:ro"],
             LinuxScannerScope.AllLayers
         );
 
@@ -1374,5 +1374,78 @@ public class LinuxScannerTests
                 ),
             Times.Exactly(2)
         );
+    }
+
+    [TestMethod]
+    public async Task TestLinuxScanner_CancelledCaller_DoesNotBlockOnInFlightSyftRunAsync()
+    {
+        LinuxScanner.ResetCache();
+
+        // Use a TCS to control when the syft container "completes",
+        // so the first caller's run stays in-flight while we cancel the second.
+        var syftCompletionSource = new TaskCompletionSource<(string, string)>();
+
+        this.mockDockerService.Setup(service =>
+                service.CreateAndRunContainerAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<List<string>>(),
+                    It.IsAny<IList<string>>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .Returns(syftCompletionSource.Task);
+
+        var enabledTypes = new HashSet<ComponentType> { ComponentType.Linux };
+
+        var layers = new[]
+        {
+            new DockerLayer
+            {
+                LayerIndex = 0,
+                DiffId = "sha256:f95fc50d21d981f1efe1f04109c2c3287c271794f5d9e4fdf9888851a174a971",
+            },
+        };
+
+        var scanner1 = new LinuxScanner(
+            this.mockDockerService.Object,
+            this.mockLogger.Object,
+            this.componentFactories,
+            this.artifactFilters
+        );
+        var scanner2 = new LinuxScanner(
+            this.mockDockerService.Object,
+            this.mockLogger.Object,
+            this.componentFactories,
+            this.artifactFilters
+        );
+
+        // First caller starts the syft run (it will block on syftCompletionSource).
+        var task1 = scanner1.ScanLinuxAsync("cancel_hash", layers, 0, enabledTypes, LinuxScannerScope.AllLayers);
+
+        // Second caller with a cancellable token joins the same in-flight run.
+        using var cts = new CancellationTokenSource();
+        var task2 = scanner2.ScanLinuxAsync("cancel_hash", layers, 0, enabledTypes, LinuxScannerScope.AllLayers, cts.Token);
+
+        // Cancel the second caller while the first is still running.
+        await cts.CancelAsync();
+
+        // The second caller should throw OperationCanceledException promptly.
+        try
+        {
+            await task2;
+            Assert.Fail("Expected OperationCanceledException was not thrown");
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected — the second caller was cancelled while waiting for the in-flight run.
+        }
+
+        // The first caller should still be running (not cancelled).
+        task1.IsCompleted.Should().BeFalse();
+
+        // Now let the first caller complete normally.
+        syftCompletionSource.SetResult((SyftOutputNoAuthorOrLicense, string.Empty));
+        var result1 = await task1;
+        result1.Should().NotBeEmpty();
     }
 }

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/LinuxScannerTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/LinuxScannerTests.cs
@@ -228,6 +228,9 @@ public class LinuxScannerTests
 
     public LinuxScannerTests()
     {
+        // Clear the static syft run cache to prevent cross-test interference.
+        LinuxScanner.ResetCache();
+
         this.mockDockerService = new Mock<IDockerService>();
         this.mockDockerService.Setup(service =>
                 service.CanPingDockerAsync(It.IsAny<CancellationToken>())

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/LinuxScannerTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/LinuxScannerTests.cs
@@ -1036,6 +1036,10 @@ public class LinuxScannerTests
     {
         LinuxScanner.ResetCache();
 
+        // Use a TCS so the mock doesn't complete synchronously — both callers
+        // must enter GetOrAdd while the task is still in-flight.
+        var syftTcs = new TaskCompletionSource<(string, string)>();
+
         this.mockDockerService.Setup(service =>
                 service.CreateAndRunContainerAsync(
                     It.IsAny<string>(),
@@ -1044,7 +1048,7 @@ public class LinuxScannerTests
                     It.IsAny<CancellationToken>()
                 )
             )
-            .ReturnsAsync((SyftOutputNoAuthorOrLicense, string.Empty));
+            .Returns(syftTcs.Task);
 
         var enabledTypes = new HashSet<ComponentType>
         {
@@ -1075,8 +1079,12 @@ public class LinuxScannerTests
             this.artifactFilters
         );
 
+        // Both start while the task is still pending — they should share one run.
         var task1 = scanner1.ScanLinuxAsync("same_hash", layers, 0, enabledTypes, LinuxScannerScope.AllLayers);
         var task2 = scanner2.ScanLinuxAsync("same_hash", layers, 0, enabledTypes, LinuxScannerScope.AllLayers);
+
+        // Complete the single syft run.
+        syftTcs.SetResult((SyftOutputNoAuthorOrLicense, string.Empty));
 
         var results = await Task.WhenAll(task1, task2);
 
@@ -1249,6 +1257,10 @@ public class LinuxScannerTests
             }
             """;
 
+        // Use a TCS so the mock doesn't complete synchronously — both callers
+        // must enter GetOrAdd while the task is still in-flight.
+        var syftTcs = new TaskCompletionSource<(string, string)>();
+
         this.mockDockerService.Setup(service =>
                 service.CreateAndRunContainerAsync(
                     It.IsAny<string>(),
@@ -1257,7 +1269,7 @@ public class LinuxScannerTests
                     It.IsAny<CancellationToken>()
                 )
             )
-            .ReturnsAsync((syftOutputWithSource, string.Empty));
+            .Returns(syftTcs.Task);
 
         var scanner1 = new LinuxScanner(
             this.mockDockerService.Object,
@@ -1272,21 +1284,27 @@ public class LinuxScannerTests
             this.artifactFilters
         );
 
-        var result1 = await scanner1.GetSyftOutputAsync(
+        // Both calls start concurrently with binds in different order.
+        var task1 = scanner1.GetSyftOutputAsync(
             "oci-dir:/img",
             ["/host/a:/container/a:ro", "/host/b:/container/b:ro"],
             LinuxScannerScope.AllLayers
         );
-
-        var result2 = await scanner2.GetSyftOutputAsync(
+        var task2 = scanner2.GetSyftOutputAsync(
             "oci-dir:/img",
             ["/host/b:/container/b:ro", "/host/a:/container/a:ro"],
             LinuxScannerScope.AllLayers
         );
 
-        result1.Should().NotBeNull();
-        result2.Should().NotBeNull();
+        // Complete the single syft run.
+        syftTcs.SetResult((syftOutputWithSource, string.Empty));
 
+        var results = await Task.WhenAll(task1, task2);
+
+        results[0].Should().NotBeNull();
+        results[1].Should().NotBeNull();
+
+        // Bind order shouldn't matter — both should share a single container run.
         this.mockDockerService.Verify(
             service =>
                 service.CreateAndRunContainerAsync(

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/LinuxScannerTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/LinuxScannerTests.cs
@@ -1030,4 +1030,349 @@ public class LinuxScannerTests
         entry.Components.Select(c => (c as LinuxComponent)!.Name)
             .Should().Contain("bash").And.Contain("openssl");
     }
+
+    [TestMethod]
+    public async Task TestLinuxScanner_ConcurrentScansSameImage_RunsSyftOnlyOnceAsync()
+    {
+        LinuxScanner.ResetCache();
+
+        this.mockDockerService.Setup(service =>
+                service.CreateAndRunContainerAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<List<string>>(),
+                    It.IsAny<IList<string>>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync((SyftOutputNoAuthorOrLicense, string.Empty));
+
+        var enabledTypes = new HashSet<ComponentType>
+        {
+            ComponentType.Linux,
+            ComponentType.Npm,
+            ComponentType.Pip,
+        };
+
+        var layers = new[]
+        {
+            new DockerLayer
+            {
+                LayerIndex = 0,
+                DiffId = "sha256:f95fc50d21d981f1efe1f04109c2c3287c271794f5d9e4fdf9888851a174a971",
+            },
+        };
+
+        var scanner1 = new LinuxScanner(
+            this.mockDockerService.Object,
+            this.mockLogger.Object,
+            this.componentFactories,
+            this.artifactFilters
+        );
+        var scanner2 = new LinuxScanner(
+            this.mockDockerService.Object,
+            this.mockLogger.Object,
+            this.componentFactories,
+            this.artifactFilters
+        );
+
+        var task1 = scanner1.ScanLinuxAsync("same_hash", layers, 0, enabledTypes, LinuxScannerScope.AllLayers);
+        var task2 = scanner2.ScanLinuxAsync("same_hash", layers, 0, enabledTypes, LinuxScannerScope.AllLayers);
+
+        var results = await Task.WhenAll(task1, task2);
+
+        results[0].Should().NotBeEmpty();
+        results[1].Should().NotBeEmpty();
+        results[0].First().Components.Should().ContainSingle();
+        results[1].First().Components.Should().ContainSingle();
+
+        this.mockDockerService.Verify(
+            service =>
+                service.CreateAndRunContainerAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<List<string>>(),
+                    It.IsAny<IList<string>>(),
+                    It.IsAny<CancellationToken>()
+                ),
+            Times.Once
+        );
+    }
+
+    [TestMethod]
+    public async Task TestLinuxScanner_ConcurrentScansDifferentImages_RunsSyftForEachAsync()
+    {
+        LinuxScanner.ResetCache();
+
+        this.mockDockerService.Setup(service =>
+                service.CreateAndRunContainerAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<List<string>>(),
+                    It.IsAny<IList<string>>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync((SyftOutputNoAuthorOrLicense, string.Empty));
+
+        var enabledTypes = new HashSet<ComponentType>
+        {
+            ComponentType.Linux,
+            ComponentType.Npm,
+            ComponentType.Pip,
+        };
+
+        var layers = new[]
+        {
+            new DockerLayer
+            {
+                LayerIndex = 0,
+                DiffId = "sha256:f95fc50d21d981f1efe1f04109c2c3287c271794f5d9e4fdf9888851a174a971",
+            },
+        };
+
+        var scanner1 = new LinuxScanner(
+            this.mockDockerService.Object,
+            this.mockLogger.Object,
+            this.componentFactories,
+            this.artifactFilters
+        );
+        var scanner2 = new LinuxScanner(
+            this.mockDockerService.Object,
+            this.mockLogger.Object,
+            this.componentFactories,
+            this.artifactFilters
+        );
+
+        var task1 = scanner1.ScanLinuxAsync("image_hash_A", layers, 0, enabledTypes, LinuxScannerScope.AllLayers);
+        var task2 = scanner2.ScanLinuxAsync("image_hash_B", layers, 0, enabledTypes, LinuxScannerScope.AllLayers);
+
+        var results = await Task.WhenAll(task1, task2);
+
+        results[0].Should().NotBeEmpty();
+        results[1].Should().NotBeEmpty();
+
+        this.mockDockerService.Verify(
+            service =>
+                service.CreateAndRunContainerAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<List<string>>(),
+                    It.IsAny<IList<string>>(),
+                    It.IsAny<CancellationToken>()
+                ),
+            Times.Exactly(2)
+        );
+    }
+
+    [TestMethod]
+    public async Task TestLinuxScanner_ConcurrentScansDifferentScopes_RunsSyftForEachAsync()
+    {
+        LinuxScanner.ResetCache();
+
+        this.mockDockerService.Setup(service =>
+                service.CreateAndRunContainerAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<List<string>>(),
+                    It.IsAny<IList<string>>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync((SyftOutputNoAuthorOrLicense, string.Empty));
+
+        var enabledTypes = new HashSet<ComponentType>
+        {
+            ComponentType.Linux,
+            ComponentType.Npm,
+            ComponentType.Pip,
+        };
+
+        var layers = new[]
+        {
+            new DockerLayer
+            {
+                LayerIndex = 0,
+                DiffId = "sha256:f95fc50d21d981f1efe1f04109c2c3287c271794f5d9e4fdf9888851a174a971",
+            },
+        };
+
+        var scanner1 = new LinuxScanner(
+            this.mockDockerService.Object,
+            this.mockLogger.Object,
+            this.componentFactories,
+            this.artifactFilters
+        );
+        var scanner2 = new LinuxScanner(
+            this.mockDockerService.Object,
+            this.mockLogger.Object,
+            this.componentFactories,
+            this.artifactFilters
+        );
+
+        var task1 = scanner1.ScanLinuxAsync("same_hash", layers, 0, enabledTypes, LinuxScannerScope.AllLayers);
+        var task2 = scanner2.ScanLinuxAsync("same_hash", layers, 0, enabledTypes, LinuxScannerScope.Squashed);
+
+        var results = await Task.WhenAll(task1, task2);
+
+        results[0].Should().NotBeEmpty();
+        results[1].Should().NotBeEmpty();
+
+        this.mockDockerService.Verify(
+            service =>
+                service.CreateAndRunContainerAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<List<string>>(),
+                    It.IsAny<IList<string>>(),
+                    It.IsAny<CancellationToken>()
+                ),
+            Times.Exactly(2)
+        );
+    }
+
+    [TestMethod]
+    public async Task TestLinuxScanner_SyftCacheKey_BindOrderDoesNotMatterAsync()
+    {
+        LinuxScanner.ResetCache();
+
+        const string syftOutputWithSource = """
+            {
+                "distro": { "id": "test", "versionID": "1.0" },
+                "artifacts": [],
+                "source": {
+                    "id": "sha256:abc",
+                    "name": "/img",
+                    "type": "image",
+                    "version": "sha256:abc",
+                    "metadata": {
+                        "userInput": "/img",
+                        "imageID": "sha256:img",
+                        "layers": [],
+                        "labels": {}
+                    }
+                }
+            }
+            """;
+
+        this.mockDockerService.Setup(service =>
+                service.CreateAndRunContainerAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<List<string>>(),
+                    It.IsAny<IList<string>>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync((syftOutputWithSource, string.Empty));
+
+        var scanner1 = new LinuxScanner(
+            this.mockDockerService.Object,
+            this.mockLogger.Object,
+            this.componentFactories,
+            this.artifactFilters
+        );
+        var scanner2 = new LinuxScanner(
+            this.mockDockerService.Object,
+            this.mockLogger.Object,
+            this.componentFactories,
+            this.artifactFilters
+        );
+
+        var result1 = await scanner1.GetSyftOutputAsync(
+            "oci-dir:/img",
+            new List<string> { "/host/a:/container/a:ro", "/host/b:/container/b:ro" },
+            LinuxScannerScope.AllLayers
+        );
+
+        var result2 = await scanner2.GetSyftOutputAsync(
+            "oci-dir:/img",
+            new List<string> { "/host/b:/container/b:ro", "/host/a:/container/a:ro" },
+            LinuxScannerScope.AllLayers
+        );
+
+        result1.Should().NotBeNull();
+        result2.Should().NotBeNull();
+
+        this.mockDockerService.Verify(
+            service =>
+                service.CreateAndRunContainerAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<List<string>>(),
+                    It.IsAny<IList<string>>(),
+                    It.IsAny<CancellationToken>()
+                ),
+            Times.Once
+        );
+    }
+
+    [TestMethod]
+    public async Task TestLinuxScanner_FailedSyftRun_RemovesCacheEntry_AllowsRetryAsync()
+    {
+        LinuxScanner.ResetCache();
+
+        var callCount = 0;
+        this.mockDockerService.Setup(service =>
+                service.CreateAndRunContainerAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<List<string>>(),
+                    It.IsAny<IList<string>>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync(() =>
+            {
+                var current = Interlocked.Increment(ref callCount);
+                if (current == 1)
+                {
+                    throw new InvalidOperationException("Simulated Docker failure");
+                }
+
+                return (SyftOutputNoAuthorOrLicense, string.Empty);
+            });
+
+        var enabledTypes = new HashSet<ComponentType>
+        {
+            ComponentType.Linux,
+            ComponentType.Npm,
+            ComponentType.Pip,
+        };
+
+        var layers = new[]
+        {
+            new DockerLayer
+            {
+                LayerIndex = 0,
+                DiffId = "sha256:f95fc50d21d981f1efe1f04109c2c3287c271794f5d9e4fdf9888851a174a971",
+            },
+        };
+
+        // First call should fail.
+        Func<Task> firstCall = async () =>
+            await this.linuxScanner.ScanLinuxAsync(
+                "retry_hash",
+                layers,
+                0,
+                enabledTypes,
+                LinuxScannerScope.AllLayers
+            );
+
+        await firstCall.Should().ThrowAsync<InvalidOperationException>();
+
+        // Second call should succeed because the failed cache entry was removed.
+        var result = await this.linuxScanner.ScanLinuxAsync(
+            "retry_hash",
+            layers,
+            0,
+            enabledTypes,
+            LinuxScannerScope.AllLayers
+        );
+
+        result.Should().NotBeEmpty();
+        result.First().Components.Should().ContainSingle();
+
+        this.mockDockerService.Verify(
+            service =>
+                service.CreateAndRunContainerAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<List<string>>(),
+                    It.IsAny<IList<string>>(),
+                    It.IsAny<CancellationToken>()
+                ),
+            Times.Exactly(2)
+        );
+    }
 }


### PR DESCRIPTION
3 Improvements to Linux Scanning:
1. The larger boost to perf of the 2, removing the `Temp` directory binding from the Syft scans
2. Ensuring that we only pull each image one time
3. Ensuring that we only run `Syft` with the same parameters one time

## Testing the de-duplication:

`dotnet run --project src/Microsoft.ComponentDetection/Microsoft.ComponentDetection.csproj scan --SourceDirectory C:\src\temp --DockerImagesToScan "alpine:3.18,ubuntu:22.04,test-with-base:latest,node:18-bullseye" --LogLevel Debug`
Many images, and since there are 2 Linux scanner happening at the same time, we hit the logic that keeps us from trying to pull the same one more than once:
<img width="1045" height="468" alt="image" src="https://github.com/user-attachments/assets/277f89e0-f8d5-4b85-b4e4-f8ab286ec0b5" />

we can also confirm that we only see the syft scan happening once per image sha:
<img width="2535" height="354" alt="image" src="https://github.com/user-attachments/assets/b071e2e6-efe8-4b08-a7b5-cd4ae98a561a" />

## Testing the performance:

`dotnet run --project src/Microsoft.ComponentDetection/Microsoft.ComponentDetection.csproj scan --SourceDirectory C:\src\temp --DockerImagesToScan "node:18-bullseye"`

Before, ran in over `400s` for `node:18-bullseye` image (and we also see 2 containers starting up to syft scan this single image): 
<img width="2296" height="1330" alt="image" src="https://github.com/user-attachments/assets/32d56ec3-9220-4b5c-8b18-654a2d4ae960" />

After, ran in under `60s` for `node:18-bullseye` image (and we only see a single container start up to run the syft scan): 
<img width="1623" height="961" alt="image" src="https://github.com/user-attachments/assets/fdaa5a28-82c6-418c-9e40-5bfff0a576f6" />

