### PR TITLE
Promote MSBuildBinLog Detector to experimental

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,21 +33,34 @@ Component Detection can also be used as a library to detect dependencies in your
 
 ## Features
 
-Component Detection supports detecting libraries from the following ecosystem:
+Component Detection supports detecting libraries from the following ecosystems:
 
 | Ecosystem                                                                        | Scanning                                        | Graph Creation |
 | -------------------------------------------------------------------------------- | ----------------------------------------------- | -------------- |
-| CocoaPods                                                                        | ✔                                               | ✔              |
-| [Go](docs/detectors/go.md)                                                       | ✔                                               | ❌              |
+| [CocoaPods](docs/detectors/cocoapods.md)                                         | ✔                                               | ✔              |
+| [Conan](docs/detectors/conan.md)                                                 | ✔                                               | ❌              |
+| [Conda (Python)](docs/detectors/conda.md)                                        | ✔                                               | ✔              |
+| [Docker Compose](docs/detectors/dockercompose.md)                                | ✔                                               | ❌              |
+| [Dockerfile](docs/detectors/dockerfile.md)                                       | ✔                                               | ❌              |
+| [DotNet SDK](docs/detectors/dotnet.md)                                           | ✔                                               | ❌              |
+| [Go](docs/detectors/go.md)                                                       | ✔                                               | ✔ (with Go 1.11+) |
 | [Gradle (lockfiles only)](docs/detectors/gradle.md)                              | ✔                                               | ❌              |
-| [Linux (Debian, Alpine, Rhel, Centos, Fedora, Ubuntu)](docs/detectors//linux.md) | ✔ (via [syft](https://github.com/anchore/syft)) | ❌              |
+| [Helm](docs/detectors/helm.md)                                                   | ✔                                               | ❌              |
+| [Ivy](docs/detectors/ivy.md)                                                     | ✔                                               | ✔              |
+| [Linux (Debian, Alpine, Rhel, Centos, Fedora, Ubuntu)](docs/detectors/linux.md)  | ✔ (via [syft](https://github.com/anchore/syft)) | ❌              |
 | [Maven](docs/detectors/maven.md)                                                 | ✔                                               | ✔              |
 | [NPM (including Yarn, Pnpm)](docs/detectors/npm.md)                              | ✔                                               | ✔              |
 | [NuGet (including Paket)](docs/detectors/nuget.md)                               | ✔                                               | ✔              |
 | [Pip (Python)](docs/detectors/pip.md)                                            | ✔                                               | ✔              |
 | [Poetry (Python, lockfiles only)](docs/detectors/poetry.md)                      | ✔                                               | ❌              |
-| Ruby                                                                             | ✔                                               | ✔              |
-| Rust                                                                             | ✔                                               | ✔              |
+| [Ruby](docs/detectors/ruby.md)                                                   | ✔                                               | ✔              |
+| [Rust (Cargo)](docs/detectors/rust.md)                                           | ✔                                               | ✔              |
+| [SPDX SBOM](docs/detectors/spdx.md)                                              | ✔                                               | ❌              |
+| [Swift](docs/detectors/swift.md)                                                 | ✔                                               | ❌              |
+| [Uv (Python)](docs/detectors/uv.md)                                              | ✔                                               | ✔              |
+| [Vcpkg](docs/detectors/vcpkg.md)                                                 | ✔                                               | ❌              |
+
+See the [detectors directory](docs/detectors/README.md) for the current status (Stable, Experimental, or DefaultOff) of each individual detector.
 
 For a complete feature overview refer to [feature-overview.md](docs/feature-overview.md)
 

--- a/docs/detectors/README.md
+++ b/docs/detectors/README.md
@@ -87,7 +87,7 @@
 | NuGetComponentDetector                           | Stable     |
 | NuGetPackagesConfigDetector                      | Stable     |
 | NuGetProjectModelProjectCentricComponentDetector | Stable     |
-| MSBuildBinaryLogComponentDetector                | DefaultOff |
+| MSBuildBinaryLogComponentDetector                | Experimental |
 
 - [Pip](pip.md)
 

--- a/docs/detectors/nuget.md
+++ b/docs/detectors/nuget.md
@@ -38,7 +38,9 @@ The `NuGetPackagesConfig` detector raises NuGet components referenced by project
 
 ## MSBuildBinaryLog
 
-The `MSBuildBinaryLog` detector is a **DefaultOff** detector intended to eventually replace both the `NuGetProjectCentric` and `DotNet` detectors. It combines MSBuild binary log (binlog) information with `project.assets.json` to provide enhanced component detection with project-level classifications.
+The `MSBuildBinaryLog` detector is an **Experimental** detector intended to eventually replace both the `NuGetProjectCentric` and `DotNet` detectors. It combines MSBuild binary log (binlog) information with `project.assets.json` to provide enhanced component detection with project-level classifications.
+
+As an experimental detector, it runs automatically whenever a scan is performed, but its results are not reported as part of the normal scan output. Instead, the results are compared against the existing `NuGetProjectCentric` and `DotNet` detectors and recorded as telemetry so maintainers can evaluate parity before promoting the detector to default.
 
 It looks for `project.assets.json` files and separately discovers `*.binlog` files. The binlog provides build-time context that isn't available from `project.assets.json` alone.
 

--- a/docs/feature-overview.md
+++ b/docs/feature-overview.md
@@ -11,7 +11,7 @@
 | NPM | <ul><li>package.json</li><li>package-lock.json</li><li>npm-shrinkwrap.json</li><li>lerna.json</li></ul> | - | ✔ (dev-dependencies in package.json, dev flag in package-lock.json) | ✔ |
 | Yarn (v1, v2) | <ul><li>package.json</li><li>yarn.lock</li></ul> | - | ✔ (dev-dependencies in package.json) | ✔ |
 | Pnpm | <ul><li>shrinkwrap.yaml</li><li>pnpm-lock.yaml</li></ul> | - | ✔ (packages/{package}/dev flag) | ✔ |
-| NuGet | <ul><li>project.assets.json</li><li>*.nupkg</li><li>*.nuspec</li><li>packages.config</li><li>nuget.config</li><li>*.binlog (DefaultOff)</li></ul> | - | - | ✔ (required project.assets.json) |
+| NuGet | <ul><li>project.assets.json</li><li>*.nupkg</li><li>*.nuspec</li><li>packages.config</li><li>nuget.config</li><li>*.binlog (Experimental)</li></ul> | - | - | ✔ (required project.assets.json) |
 | Pip (Python) | <ul><li>setup.py</li><li>requirements.txt</li><li>*setup=distutils.core.run_setup({setup.py}); setup.install_requires*</li><li>dist package METADATA file</li></ul> | <ul><li>Python 2 or Python 3</li><li>Internet connection</li></ul> | ❌ | ✔ |
 | Poetry (Python) | <ul><li>poetry.lock</li><ul> | - | ✔ | ❌ |
 | Ruby | <ul><li>gemfile.lock</li></ul> | - | ❌ | ✔ |

--- a/src/Microsoft.ComponentDetection.Detectors/nuget/MSBuildBinaryLogComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/nuget/MSBuildBinaryLogComponentDetector.cs
@@ -48,7 +48,7 @@ using Task = System.Threading.Tasks.Task;
 /// - Fallback mode: When no binlog info is available, falls back to standard NuGet detection.
 /// </para>
 /// </remarks>
-public class MSBuildBinaryLogComponentDetector : FileComponentDetector, IDefaultOffComponentDetector
+public class MSBuildBinaryLogComponentDetector : FileComponentDetector, IExperimentalDetector
 {
     private readonly IBinLogProcessor binLogProcessor;
     private readonly IFileUtilityService fileUtilityService;


### PR DESCRIPTION
## Context
Promote MSBuildBinLog detector to experimental to capture telemetry and deltas.

Reviewed some runs in toy repository and seems to be capturing the expected metadata as far as I can tell vs the other NuGet detectors.

## Miscellaneous
Update docs to include the new detectors supported by the tool.