### PR TITLE
Add missing MSBuildBinaryExperiment DI

### DIFF
--- a/src/Microsoft.ComponentDetection.Orchestrator/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Extensions/ServiceCollectionExtensions.cs
@@ -74,6 +74,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IExperimentConfiguration, SimplePipExperiment>();
         services.AddSingleton<IExperimentConfiguration, UvLockDetectorExperiment>();
         services.AddSingleton<IExperimentConfiguration, LinuxApplicationLayerExperiment>();
+        services.AddSingleton<IExperimentConfiguration, MSBuildBinaryLogExperiment>();
 
         // Detectors
         // CocoaPods


### PR DESCRIPTION
# Context
Recently we promoted MSBuildBinLog to experimental in #1829, so the detector is running and reporting telemetry successfully.

That being said, we didn't have the experimental declared in DI initialization class, hence we are not able to see the deltas introduced. This change ensures the experimental runs also report the relevant diffs.