### PR TITLE
Update RubyComponentDetector.cs

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/ruby/RubyComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/ruby/RubyComponentDetector.cs
@@ -70,7 +70,7 @@ public class RubyComponentDetector : FileComponentDetector
 
     public override IEnumerable<ComponentType> SupportedComponentTypes { get; } = [ComponentType.RubyGems];
 
-    public override int Version { get; } = 3;
+    public override int Version { get; } = 4;
 
     public override bool NeedsAutomaticRootDependencyCalculation => true;
 


### PR DESCRIPTION
## Context

Ruby Detector will start reporting different component versions after https://github.com/microsoft/component-detection/pull/1833 got merged. 

We need to bump the version to be able to distinguish the new/updated dependency graphs.