### PR TITLE
Upgrade Contracts to net8

### DIFF
--- a/src/Microsoft.ComponentDetection.Common/Microsoft.ComponentDetection.Common.csproj
+++ b/src/Microsoft.ComponentDetection.Common/Microsoft.ComponentDetection.Common.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
     <ItemGroup>
         <InternalsVisibleTo Include="Microsoft.ComponentDetection.Common.Tests" />
         <InternalsVisibleTo Include="Microsoft.ComponentDetection.Orchestrator" />
@@ -20,5 +19,4 @@
     <ItemGroup Label="Package References">
         <ProjectReference Include="..\Microsoft.ComponentDetection.Contracts\Microsoft.ComponentDetection.Contracts.csproj" />
     </ItemGroup>
-
 </Project>

--- a/src/Microsoft.ComponentDetection.Contracts/FileComponentDetectorWithCleanup.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/FileComponentDetectorWithCleanup.cs
@@ -48,10 +48,7 @@ public abstract class FileComponentDetectorWithCleanup : FileComponentDetector
         bool cleanupCreatedFiles,
         CancellationToken cancellationToken = default)
     {
-        if (process == null)
-        {
-            throw new ArgumentNullException(nameof(process));
-        }
+        ArgumentNullException.ThrowIfNull(process, nameof(process));
 
         // If there are no cleanup patterns, or the relevant file does not have a valid directory, run the process without even
         // determining the files that exist as there will be no subsequent cleanup process.

--- a/src/Microsoft.ComponentDetection.Contracts/IComponentStream.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/IComponentStream.cs
@@ -1,4 +1,3 @@
-#nullable disable
 namespace Microsoft.ComponentDetection.Contracts;
 
 using System.IO;
@@ -11,15 +10,15 @@ public interface IComponentStream
     /// <summary>
     /// Gets the stream object that was discovered by the provided pattern to <see cref="IComponentStreamEnumerableFactory" /> />.
     /// </summary>
-    Stream Stream { get; }
+    public Stream Stream { get; }
 
     /// <summary>
     /// Gets the pattern that this stream matched. Ex: If *.bar was used to match Foo.bar, this field would contain *.bar.
     /// </summary>
-    string Pattern { get; }
+    public string Pattern { get; }
 
     /// <summary>
     /// Gets the location for this stream. Often a file path if not in test circumstances.
     /// </summary>
-    string Location { get; }
+    public string Location { get; }
 }

--- a/src/Microsoft.ComponentDetection.Contracts/Microsoft.ComponentDetection.Contracts.csproj
+++ b/src/Microsoft.ComponentDetection.Contracts/Microsoft.ComponentDetection.Contracts.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="Build">
-    <TargetFramework>netstandard2.0</TargetFramework>
     <NoWarn>$(NoWarn);NU5104</NoWarn>
   </PropertyGroup>
 

--- a/src/Microsoft.ComponentDetection.Contracts/TypedComponent/GitComponent.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/TypedComponent/GitComponent.cs
@@ -100,7 +100,7 @@ public class GitComponent : TypedComponent
         var repoSegment = segments[1];
         if (repoSegment.EndsWith(DotGitSuffix, StringComparison.OrdinalIgnoreCase))
         {
-            repoSegment = repoSegment.Substring(0, repoSegment.Length - DotGitSuffix.Length);
+            repoSegment = repoSegment[..^DotGitSuffix.Length];
         }
 
         if (string.IsNullOrEmpty(ownerSegment) || string.IsNullOrEmpty(repoSegment))

--- a/src/Microsoft.ComponentDetection.Contracts/TypedComponent/GoComponent.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/TypedComponent/GoComponent.cs
@@ -59,7 +59,7 @@ public class GoComponent : TypedComponent, IEquatable<GoComponent>
         var lastSlash = this.Name.LastIndexOf('/');
         if (lastSlash > 0)
         {
-            return (this.Name.Substring(0, lastSlash), this.Name.Substring(lastSlash + 1));
+            return (this.Name[..lastSlash], this.Name[(lastSlash + 1)..]);
         }
 
         return (null, this.Name);


### PR DESCRIPTION
Went to use some newer language features in the Contracts projects and they weren't available because it was still on netstandard. Upgraded to net8 as per https://devblogs.microsoft.com/dotnet/the-future-of-net-standard/ and then fixed the resulting build errors.