### PR TITLE
Promote the Conda ComponentDetector to experimental

### DIFF
--- a/docs/detectors/README.md
+++ b/docs/detectors/README.md
@@ -16,7 +16,7 @@
 
 | Detector                   | Status     |
 | -------------------------- | ---------- |
-| CondaLockComponentDetector | DefaultOff |
+| CondaLockComponentDetector | Experimental |
 
 - [Docker Compose](dockercompose.md)
 

--- a/src/Microsoft.ComponentDetection.Detectors/conda/CondaLockComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/conda/CondaLockComponentDetector.cs
@@ -14,7 +14,7 @@ using Microsoft.ComponentDetection.Detectors.CondaLock.Contracts;
 using Microsoft.Extensions.Logging;
 using YamlDotNet.Serialization;
 
-public class CondaLockComponentDetector : FileComponentDetector, IDefaultOffComponentDetector
+public class CondaLockComponentDetector : FileComponentDetector, IExperimentalDetector
 {
     public CondaLockComponentDetector(
         IComponentStreamEnumerableFactory componentStreamEnumerableFactory,

--- a/src/Microsoft.ComponentDetection.Orchestrator/Experiments/Configs/CondaLockDetectorExperiment.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Experiments/Configs/CondaLockDetectorExperiment.cs
@@ -1,0 +1,23 @@
+namespace Microsoft.ComponentDetection.Orchestrator.Experiments.Configs;
+
+using Microsoft.ComponentDetection.Contracts;
+using Microsoft.ComponentDetection.Detectors.Pip;
+using Microsoft.ComponentDetection.Detectors.Poetry;
+
+/// <summary>
+/// Experiment to validate CondaLockComponentDetector against PipReportComponentDetector.
+/// </summary>
+public class CondaLockDetectorExperiment : IExperimentConfiguration
+{
+    /// <inheritdoc />
+    public string Name => "CondaLockDetectorExperiment";
+
+    /// <inheritdoc />
+    public bool IsInControlGroup(IComponentDetector componentDetector) => componentDetector is PipReportComponentDetector;
+
+    /// <inheritdoc />
+    public bool IsInExperimentGroup(IComponentDetector componentDetector) => componentDetector is CondaLockComponentDetector;
+
+    /// <inheritdoc />
+    public bool ShouldRecord(IComponentDetector componentDetector, int numComponents) => true;
+}

--- a/src/Microsoft.ComponentDetection.Orchestrator/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Extensions/ServiceCollectionExtensions.cs
@@ -73,6 +73,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IExperimentProcessor, DefaultExperimentProcessor>();
         services.AddSingleton<IExperimentConfiguration, SimplePipExperiment>();
         services.AddSingleton<IExperimentConfiguration, UvLockDetectorExperiment>();
+        services.AddSingleton<IExperimentConfiguration, CondaLockDetectorExperiment>();
         services.AddSingleton<IExperimentConfiguration, LinuxApplicationLayerExperiment>();
         services.AddSingleton<IExperimentConfiguration, MSBuildBinaryLogExperiment>();
 

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/ComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/ComponentDetectorTests.cs
@@ -72,4 +72,13 @@ public class ComponentDetectorTests
         uvLockDetector.Should().NotBeNull("because UvLockComponentDetector should be registered");
         uvLockDetector.Should().BeAssignableTo<IExperimentalDetector>("because UvLockComponentDetector should implement IExperimentalDetector");
     }
+
+    [TestMethod]
+    public void CondaLockComponentDetector_ImplementsIExperimentalDetector()
+    {
+        var condaLockDetector = this.detectors.SingleOrDefault(d => d.Id == "CondaLock");
+
+        condaLockDetector.Should().NotBeNull("because CondaLockComponentDetector should be registered");
+        condaLockDetector.Should().BeAssignableTo<IExperimentalDetector>("because CondaLockComponentDetector should implement IExperimentalDetector");
+    }
 }


### PR DESCRIPTION
Promote the Conda ComponentDetector to experimental and create an experiment to start gathering telemetry so we know if this is ready for on-by-default promotion.