### PR TITLE
Replace disused version-number reference with mockito

### DIFF
--- a/test/Microsoft.ComponentDetection.VerificationTests/resources/maven/lib/pom.xml
+++ b/test/Microsoft.ComponentDetection.VerificationTests/resources/maven/lib/pom.xml
@@ -9,12 +9,6 @@
   <artifactId>maven-test-lib</artifactId>
   <packaging>jar</packaging>
   <version>1.0-SNAPSHOT</version>
-  <repositories>
-    <repository>
-      <id>jenkins-ci</id>
-      <url>${jenkins-ci.url}</url>
-    </repository>
-  </repositories>
   <dependencies>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -23,9 +17,9 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>org.jenkins-ci</groupId>
-      <artifactId>version-number</artifactId>
-      <version>${version-number.version}</version>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>${mockito.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.beam</groupId>

--- a/test/Microsoft.ComponentDetection.VerificationTests/resources/maven/pom.xml
+++ b/test/Microsoft.ComponentDetection.VerificationTests/resources/maven/pom.xml
@@ -10,9 +10,8 @@
     <module>lib</module>
   </modules>
   <properties>
-    <jenkins-ci.url>https://repo.jenkins-ci.org/releases</jenkins-ci.url>
     <commons-text.version>1.12.0</commons-text.version>
     <junit.version>4.13.2</junit.version>
-    <version-number.version>1.9</version-number.version>
+    <mockito.version>0.10.2</mockito.version>
   </properties>
 </project>


### PR DESCRIPTION
The version-number package was only available from the jenkins-ci maven repo, which currently is having an outage. Since we're not specifically trying to test having alternative repositories there let's select a new library to reference there. mockito seems to have a lot of usage so it seems a good option.