### PR TITLE
Upgrade Ant:Ivy to avoid download mirror failure

### DIFF
--- a/.github/workflows/snapshot-publish.yml
+++ b/.github/workflows/snapshot-publish.yml
@@ -50,12 +50,12 @@ jobs:
 
       - name: Install Apache Ivy
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: curl https://downloads.apache.org/ant/ivy/2.5.2/apache-ivy-2.5.2-bin.tar.gz | tar xOz apache-ivy-2.5.2/ivy-2.5.2.jar > /usr/share/ant/lib/ivy.jar
+        run: curl https://downloads.apache.org/ant/ivy/2.5.3/apache-ivy-2.5.3-bin.tar.gz | tar xOz apache-ivy-2.5.3/ivy-2.5.3.jar > /usr/share/ant/lib/ivy.jar
 
       - name: Install Apache Ivy
         if: ${{ matrix.os == 'windows-latest' }}
         shell: bash
-        run: curl https://downloads.apache.org/ant/ivy/2.5.2/apache-ivy-2.5.2-bin.tar.gz | tar xOz apache-ivy-2.5.2/ivy-2.5.2.jar > "$ANT_HOME/lib/ivy.jar"
+        run: curl https://downloads.apache.org/ant/ivy/2.5.3/apache-ivy-2.5.3-bin.tar.gz | tar xOz apache-ivy-2.5.3/ivy-2.5.3.jar > "$ANT_HOME/lib/ivy.jar"
 
       - name: Install Apache Ivy
         if: ${{ matrix.os == 'macos-latest' }}

--- a/.github/workflows/snapshot-verify.yml
+++ b/.github/workflows/snapshot-verify.yml
@@ -74,12 +74,12 @@ jobs:
 
       - name: Install Apache Ivy
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: curl https://downloads.apache.org/ant/ivy/2.5.2/apache-ivy-2.5.2-bin.tar.gz | tar xOz apache-ivy-2.5.2/ivy-2.5.2.jar > /usr/share/ant/lib/ivy.jar
+        run: curl https://downloads.apache.org/ant/ivy/2.5.3/apache-ivy-2.5.3-bin.tar.gz | tar xOz apache-ivy-2.5.3/ivy-2.5.3.jar > /usr/share/ant/lib/ivy.jar
 
       - name: Install Apache Ivy
         if: ${{ matrix.os == 'windows-latest' }}
         shell: bash
-        run: curl https://downloads.apache.org/ant/ivy/2.5.2/apache-ivy-2.5.2-bin.tar.gz | tar xOz apache-ivy-2.5.2/ivy-2.5.2.jar > "$ANT_HOME/lib/ivy.jar"
+        run: curl https://downloads.apache.org/ant/ivy/2.5.3/apache-ivy-2.5.3-bin.tar.gz | tar xOz apache-ivy-2.5.3/ivy-2.5.3.jar > "$ANT_HOME/lib/ivy.jar"
 
       - name: Install Apache Ivy
         if: ${{ matrix.os == 'macos-latest' }}


### PR DESCRIPTION
We've got [some tests failing to acquire Ivy](https://github.com/microsoft/component-detection/actions/runs/29292592261/job/86960627699?pr=1844) right now which is blocker merging. This appears to be an issue with the tar.gz not being available at https://downloads.apache.org/ant/ivy/2.5.2/apache-ivy-2.5.2-bin.tar.gz. That's likely temporary, but 2.5.3 IS available so we may as well upgrade since the most recent version is less likely to be unavailable.