### PR TITLE
Bump ivy 2.5.2 -> 2.5.3

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -53,7 +53,7 @@ jobs:
 
           echo "Ant installed successfully. Installing Ivy plugin..."
           sudo chmod 777 /usr/share/ant/lib
-          curl https://downloads.apache.org/ant/ivy/2.5.3/apache-ivy-2.5.3-bin.tar.gz | tar xOz apache-ivy-2.5.3/ivy-2.5.3.jar > /usr/share/ant/lib/ivy.jar
+          curl -fsSL https://downloads.apache.org/ant/ivy/2.5.3/apache-ivy-2.5.3-bin.tar.gz | tar xOz apache-ivy-2.5.3/ivy-2.5.3.jar > /usr/share/ant/lib/ivy.jar
 
       - name: Checkout Smoke Test Repos
         run: |

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -53,7 +53,7 @@ jobs:
 
           echo "Ant installed successfully. Installing Ivy plugin..."
           sudo chmod 777 /usr/share/ant/lib
-          curl https://downloads.apache.org/ant/ivy/2.5.2/apache-ivy-2.5.2-bin.tar.gz | tar xOz apache-ivy-2.5.2/ivy-2.5.2.jar > /usr/share/ant/lib/ivy.jar
+          curl https://downloads.apache.org/ant/ivy/2.5.3/apache-ivy-2.5.3-bin.tar.gz | tar xOz apache-ivy-2.5.3/ivy-2.5.3.jar > /usr/share/ant/lib/ivy.jar
 
       - name: Checkout Smoke Test Repos
         run: |

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -53,7 +53,7 @@ jobs:
 
           echo "Ant installed successfully. Installing Ivy plugin..."
           sudo chmod 777 /usr/share/ant/lib
-          curl -fsSL https://downloads.apache.org/ant/ivy/2.5.3/apache-ivy-2.5.3-bin.tar.gz | tar xOz apache-ivy-2.5.3/ivy-2.5.3.jar > /usr/share/ant/lib/ivy.jar
+          curl -fsSL https://archive.apache.org/dist/ant/ivy/2.5.3/apache-ivy-2.5.3-bin.tar.gz | tar xOz apache-ivy-2.5.3/ivy-2.5.3.jar > /usr/share/ant/lib/ivy.jar
 
       - name: Checkout Smoke Test Repos
         run: |

--- a/.github/workflows/snapshot-publish.yml
+++ b/.github/workflows/snapshot-publish.yml
@@ -50,12 +50,12 @@ jobs:
 
       - name: Install Apache Ivy
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: curl https://downloads.apache.org/ant/ivy/2.5.3/apache-ivy-2.5.3-bin.tar.gz | tar xOz apache-ivy-2.5.3/ivy-2.5.3.jar > /usr/share/ant/lib/ivy.jar
+        run: curl -fsSL https://downloads.apache.org/ant/ivy/2.5.3/apache-ivy-2.5.3-bin.tar.gz | tar xOz apache-ivy-2.5.3/ivy-2.5.3.jar > /usr/share/ant/lib/ivy.jar
 
       - name: Install Apache Ivy
         if: ${{ matrix.os == 'windows-latest' }}
         shell: bash
-        run: curl https://downloads.apache.org/ant/ivy/2.5.3/apache-ivy-2.5.3-bin.tar.gz | tar xOz apache-ivy-2.5.3/ivy-2.5.3.jar > "$ANT_HOME/lib/ivy.jar"
+        run: curl -fsSL https://downloads.apache.org/ant/ivy/2.5.3/apache-ivy-2.5.3-bin.tar.gz | tar xOz apache-ivy-2.5.3/ivy-2.5.3.jar > "$ANT_HOME/lib/ivy.jar"
 
       - name: Install Apache Ivy
         if: ${{ matrix.os == 'macos-latest' }}

--- a/.github/workflows/snapshot-publish.yml
+++ b/.github/workflows/snapshot-publish.yml
@@ -50,12 +50,12 @@ jobs:
 
       - name: Install Apache Ivy
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: curl -fsSL https://downloads.apache.org/ant/ivy/2.5.3/apache-ivy-2.5.3-bin.tar.gz | tar xOz apache-ivy-2.5.3/ivy-2.5.3.jar > /usr/share/ant/lib/ivy.jar
+        run: curl -fsSL https://archive.apache.org/dist/ant/ivy/2.5.3/apache-ivy-2.5.3-bin.tar.gz | tar xOz apache-ivy-2.5.3/ivy-2.5.3.jar > /usr/share/ant/lib/ivy.jar
 
       - name: Install Apache Ivy
         if: ${{ matrix.os == 'windows-latest' }}
         shell: bash
-        run: curl -fsSL https://downloads.apache.org/ant/ivy/2.5.3/apache-ivy-2.5.3-bin.tar.gz | tar xOz apache-ivy-2.5.3/ivy-2.5.3.jar > "$ANT_HOME/lib/ivy.jar"
+        run: curl -fsSL https://archive.apache.org/dist/ant/ivy/2.5.3/apache-ivy-2.5.3-bin.tar.gz | tar xOz apache-ivy-2.5.3/ivy-2.5.3.jar > "$ANT_HOME/lib/ivy.jar"
 
       - name: Install Apache Ivy
         if: ${{ matrix.os == 'macos-latest' }}

--- a/.github/workflows/snapshot-publish.yml
+++ b/.github/workflows/snapshot-publish.yml
@@ -50,12 +50,12 @@ jobs:
 
       - name: Install Apache Ivy
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: curl https://downloads.apache.org/ant/ivy/2.5.2/apache-ivy-2.5.2-bin.tar.gz | tar xOz apache-ivy-2.5.2/ivy-2.5.2.jar > /usr/share/ant/lib/ivy.jar
+        run: curl https://downloads.apache.org/ant/ivy/2.5.3/apache-ivy-2.5.3-bin.tar.gz | tar xOz apache-ivy-2.5.3/ivy-2.5.3.jar > /usr/share/ant/lib/ivy.jar
 
       - name: Install Apache Ivy
         if: ${{ matrix.os == 'windows-latest' }}
         shell: bash
-        run: curl https://downloads.apache.org/ant/ivy/2.5.2/apache-ivy-2.5.2-bin.tar.gz | tar xOz apache-ivy-2.5.2/ivy-2.5.2.jar > "$ANT_HOME/lib/ivy.jar"
+        run: curl https://downloads.apache.org/ant/ivy/2.5.3/apache-ivy-2.5.3-bin.tar.gz | tar xOz apache-ivy-2.5.3/ivy-2.5.3.jar > "$ANT_HOME/lib/ivy.jar"
 
       - name: Install Apache Ivy
         if: ${{ matrix.os == 'macos-latest' }}

--- a/.github/workflows/snapshot-verify.yml
+++ b/.github/workflows/snapshot-verify.yml
@@ -74,12 +74,12 @@ jobs:
 
       - name: Install Apache Ivy
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: curl https://downloads.apache.org/ant/ivy/2.5.3/apache-ivy-2.5.3-bin.tar.gz | tar xOz apache-ivy-2.5.3/ivy-2.5.3.jar > /usr/share/ant/lib/ivy.jar
+        run: curl -fsSL https://downloads.apache.org/ant/ivy/2.5.3/apache-ivy-2.5.3-bin.tar.gz | tar xOz apache-ivy-2.5.3/ivy-2.5.3.jar > /usr/share/ant/lib/ivy.jar
 
       - name: Install Apache Ivy
         if: ${{ matrix.os == 'windows-latest' }}
         shell: bash
-        run: curl https://downloads.apache.org/ant/ivy/2.5.3/apache-ivy-2.5.3-bin.tar.gz | tar xOz apache-ivy-2.5.3/ivy-2.5.3.jar > "$ANT_HOME/lib/ivy.jar"
+        run: curl -fsSL https://downloads.apache.org/ant/ivy/2.5.3/apache-ivy-2.5.3-bin.tar.gz | tar xOz apache-ivy-2.5.3/ivy-2.5.3.jar > "$ANT_HOME/lib/ivy.jar"
 
       - name: Install Apache Ivy
         if: ${{ matrix.os == 'macos-latest' }}

--- a/.github/workflows/snapshot-verify.yml
+++ b/.github/workflows/snapshot-verify.yml
@@ -74,12 +74,12 @@ jobs:
 
       - name: Install Apache Ivy
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: curl https://downloads.apache.org/ant/ivy/2.5.2/apache-ivy-2.5.2-bin.tar.gz | tar xOz apache-ivy-2.5.2/ivy-2.5.2.jar > /usr/share/ant/lib/ivy.jar
+        run: curl https://downloads.apache.org/ant/ivy/2.5.3/apache-ivy-2.5.3-bin.tar.gz | tar xOz apache-ivy-2.5.3/ivy-2.5.3.jar > /usr/share/ant/lib/ivy.jar
 
       - name: Install Apache Ivy
         if: ${{ matrix.os == 'windows-latest' }}
         shell: bash
-        run: curl https://downloads.apache.org/ant/ivy/2.5.2/apache-ivy-2.5.2-bin.tar.gz | tar xOz apache-ivy-2.5.2/ivy-2.5.2.jar > "$ANT_HOME/lib/ivy.jar"
+        run: curl https://downloads.apache.org/ant/ivy/2.5.3/apache-ivy-2.5.3-bin.tar.gz | tar xOz apache-ivy-2.5.3/ivy-2.5.3.jar > "$ANT_HOME/lib/ivy.jar"
 
       - name: Install Apache Ivy
         if: ${{ matrix.os == 'macos-latest' }}

--- a/.github/workflows/snapshot-verify.yml
+++ b/.github/workflows/snapshot-verify.yml
@@ -74,12 +74,12 @@ jobs:
 
       - name: Install Apache Ivy
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: curl -fsSL https://downloads.apache.org/ant/ivy/2.5.3/apache-ivy-2.5.3-bin.tar.gz | tar xOz apache-ivy-2.5.3/ivy-2.5.3.jar > /usr/share/ant/lib/ivy.jar
+        run: curl -fsSL https://archive.apache.org/dist/ant/ivy/2.5.3/apache-ivy-2.5.3-bin.tar.gz | tar xOz apache-ivy-2.5.3/ivy-2.5.3.jar > /usr/share/ant/lib/ivy.jar
 
       - name: Install Apache Ivy
         if: ${{ matrix.os == 'windows-latest' }}
         shell: bash
-        run: curl -fsSL https://downloads.apache.org/ant/ivy/2.5.3/apache-ivy-2.5.3-bin.tar.gz | tar xOz apache-ivy-2.5.3/ivy-2.5.3.jar > "$ANT_HOME/lib/ivy.jar"
+        run: curl -fsSL https://archive.apache.org/dist/ant/ivy/2.5.3/apache-ivy-2.5.3-bin.tar.gz | tar xOz apache-ivy-2.5.3/ivy-2.5.3.jar > "$ANT_HOME/lib/ivy.jar"
 
       - name: Install Apache Ivy
         if: ${{ matrix.os == 'macos-latest' }}


### PR DESCRIPTION
The build is failing due a 404 error when retrieving v2.5.2 of Apache Ivy. Bump to latest 2.5.3.