### PR TITLE
Fix Yarn detector perf

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/yarn/YarnLockComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/yarn/YarnLockComponentDetector.cs
@@ -263,29 +263,49 @@ public class YarnLockComponentDetector : FileComponentDetector
             ? StringComparison.OrdinalIgnoreCase
             : StringComparison.Ordinal;
 
+        // Resolve all workspace package.json files in a SINGLE filesystem traversal to improve perf.
+        var unionMatcher = new Matcher(comparison);
+        foreach (var workspacePattern in yarnWorkspaces)
+        {
+            unionMatcher.AddInclude($"{workspacePattern}/package.json");
+        }
+
+        var componentStreams = this.ComponentStreamEnumerableFactory.GetComponentStreams(
+            root,
+            ["package.json"],
+            null,
+            recursivelyScanDirectories: true);
+
+        var workspaceCandidates = new List<(string RelativePath, string Location, IDictionary<string, IDictionary<string, bool>> Dependencies)>();
+        foreach (var stream in componentStreams)
+        {
+            var relativePath = Path.GetRelativePath(root.FullName, stream.Location).Replace('\\', '/');
+            if (!unionMatcher.Match(relativePath).HasMatches)
+            {
+                continue;
+            }
+
+            var combinedDependencies = NpmComponentUtilities.TryGetAllPackageJsonDependencies(stream.Stream, out _);
+            workspaceCandidates.Add((relativePath, stream.Location, combinedDependencies));
+        }
+
         foreach (var workspacePattern in yarnWorkspaces)
         {
             var matcher = new Matcher(comparison);
             matcher.AddInclude($"{workspacePattern}/package.json");
 
-            var componentStreams = this.ComponentStreamEnumerableFactory.GetComponentStreams(
-                root,
-                (file) =>
-                {
-                    var relativePath = Path.GetRelativePath(root.FullName, file.FullName).Replace('\\', '/');
-                    return matcher.Match(relativePath).HasMatches;
-                },
-                null,
-                true);
-
-            foreach (var stream in componentStreams)
+            foreach (var (candidateRelativePath, candidateLocation, candidateDependencies) in workspaceCandidates)
             {
-                this.Logger.LogInformation("{ComponentLocation} found for workspace {WorkspacePattern}", stream.Location, workspacePattern);
-                var combinedDependencies = NpmComponentUtilities.TryGetAllPackageJsonDependencies(stream.Stream, out _);
-
-                foreach (var dependency in combinedDependencies)
+                if (!matcher.Match(candidateRelativePath).HasMatches)
                 {
-                    this.ProcessWorkspaceDependency(dependencies, dependency, workspaceDependencyVsLocationMap, stream.Location);
+                    continue;
+                }
+
+                this.Logger.LogInformation("{ComponentLocation} found for workspace {WorkspacePattern}", candidateLocation, workspacePattern);
+
+                foreach (var dependency in candidateDependencies)
+                {
+                    this.ProcessWorkspaceDependency(dependencies, dependency, workspaceDependencyVsLocationMap, candidateLocation);
                 }
             }
         }

--- a/src/Microsoft.ComponentDetection.Orchestrator/Experiments/Configs/CondaLockDetectorExperiment.cs
+++ b/src/Microsoft.ComponentDetection.Orchestrator/Experiments/Configs/CondaLockDetectorExperiment.cs
@@ -1,8 +1,8 @@
 namespace Microsoft.ComponentDetection.Orchestrator.Experiments.Configs;
 
 using Microsoft.ComponentDetection.Contracts;
+using Microsoft.ComponentDetection.Detectors.CondaLock;
 using Microsoft.ComponentDetection.Detectors.Pip;
-using Microsoft.ComponentDetection.Detectors.Poetry;
 
 /// <summary>
 /// Experiment to validate CondaLockComponentDetector against PipReportComponentDetector.

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/YarnLockDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/YarnLockDetectorTests.cs
@@ -428,6 +428,133 @@ public class YarnLockDetectorTests
     }
 
     [TestMethod]
+    public async Task WellFormedYarnLockWithMultipleWorkspaces_FindsAllComponentsAsync()
+    {
+        // Regression test for the workspace resolution performance fix: a single
+        // filesystem traversal must still discover every workspace package.json that a
+        // glob workspace pattern expands to, and register the dependencies declared in
+        // each of them.
+        var version0 = NewRandomVersion();
+        var version1 = NewRandomVersion();
+        var version2 = NewRandomVersion();
+
+        var componentA = new YarnTestComponentDefinition { ActualVersion = version0, RequestedVersion = $"^{version0}", ResolvedVersion = "https://resolved0/a/resolved", Name = Guid.NewGuid().ToString("N") };
+        var componentB = new YarnTestComponentDefinition { ActualVersion = version1, RequestedVersion = $"^{version1}", ResolvedVersion = "https://resolved1/b/resolved", Name = Guid.NewGuid().ToString("N") };
+        var componentC = new YarnTestComponentDefinition { ActualVersion = version2, RequestedVersion = $"^{version2}", ResolvedVersion = "https://resolved2/c/resolved", Name = Guid.NewGuid().ToString("N") };
+
+        var yarnLockStream = YarnTestUtilities.GetMockedYarnLockStream("yarn.lock", this.CreateYarnLockV1FileContent([componentA, componentB, componentC]));
+
+        var rootJson = JsonSerializer.Serialize(new
+        {
+            name = "testworkspace",
+            version = "1.0.0",
+            @private = true,
+            workspaces = new[] { "packages/*" },
+        });
+
+        var app1Json = JsonSerializer.Serialize(new
+        {
+            name = "app1",
+            version = "1.0.0",
+            dependencies = new Dictionary<string, string> { [componentA.Name] = componentA.RequestedVersion },
+        });
+
+        var app2Json = JsonSerializer.Serialize(new
+        {
+            name = "app2",
+            version = "1.0.0",
+            dependencies = new Dictionary<string, string>
+            {
+                [componentB.Name] = componentB.RequestedVersion,
+                [componentC.Name] = componentC.RequestedVersion,
+            },
+        });
+
+        var app1Path = Path.Combine(Path.GetTempPath(), "packages", "app1", "package.json");
+        var app2Path = Path.Combine(Path.GetTempPath(), "packages", "app2", "package.json");
+
+        var (scanResult, componentRecorder) = await this.detectorTestUtility
+            .WithFile("yarn.lock", yarnLockStream.Stream)
+            .WithFile("package.json", rootJson.ToStream(), ["package.json"], Path.Combine(Path.GetTempPath(), "package.json"))
+            .WithFile("package.json", app1Json.ToStream(), ["package.json"], app1Path)
+            .WithFile("package.json", app2Json.ToStream(), ["package.json"], app2Path)
+            .ExecuteDetectorAsync();
+
+        scanResult.ResultCode.Should().Be(ProcessingResultCode.Success);
+
+        var detectedComponents = componentRecorder.GetDetectedComponents().ToList();
+        detectedComponents.Should().HaveCount(3);
+
+        var detectedA = detectedComponents.Single(x => ((NpmComponent)x.Component).Name == componentA.Name);
+        var detectedB = detectedComponents.Single(x => ((NpmComponent)x.Component).Name == componentB.Name);
+        var detectedC = detectedComponents.Single(x => ((NpmComponent)x.Component).Name == componentC.Name);
+
+        ((NpmComponent)detectedA.Component).Version.Should().Be(version0);
+        ((NpmComponent)detectedB.Component).Version.Should().Be(version1);
+        ((NpmComponent)detectedC.Component).Version.Should().Be(version2);
+
+        // Each component is an explicitly referenced (root) dependency of its workspace.
+        componentRecorder.AssertAllExplicitlyReferencedComponents<NpmComponent>(detectedA.Component.Id, parent => parent.Name == componentA.Name);
+        componentRecorder.AssertAllExplicitlyReferencedComponents<NpmComponent>(detectedB.Component.Id, parent => parent.Name == componentB.Name);
+        componentRecorder.AssertAllExplicitlyReferencedComponents<NpmComponent>(detectedC.Component.Id, parent => parent.Name == componentC.Name);
+
+        // The dependency's file path must point at the workspace package.json that declared it.
+        detectedA.FilePaths.Should().Contain(app1Path);
+        detectedB.FilePaths.Should().Contain(app2Path);
+        detectedC.FilePaths.Should().Contain(app2Path);
+    }
+
+    [TestMethod]
+    public async Task WellFormedYarnLockWithWorkspaceSharedDependency_AttributesFirstWorkspaceAsync()
+    {
+        // Regression test guarding that the single-traversal workspace resolution preserves
+        // the original resolution order (workspace pattern order, then discovery order) so
+        // that first-wins location attribution stays deterministic when the same dependency
+        // is declared by more than one workspace.
+        var version0 = NewRandomVersion();
+        var componentA = new YarnTestComponentDefinition { ActualVersion = version0, RequestedVersion = $"^{version0}", ResolvedVersion = "https://resolved0/a/resolved", Name = Guid.NewGuid().ToString("N") };
+
+        var yarnLockStream = YarnTestUtilities.GetMockedYarnLockStream("yarn.lock", this.CreateYarnLockV1FileContent([componentA]));
+
+        var rootJson = JsonSerializer.Serialize(new
+        {
+            name = "testworkspace",
+            version = "1.0.0",
+            @private = true,
+            workspaces = new[] { "packages/app1", "packages/app2" },
+        });
+
+        var memberJson = JsonSerializer.Serialize(new
+        {
+            name = "member",
+            version = "1.0.0",
+            dependencies = new Dictionary<string, string> { [componentA.Name] = componentA.RequestedVersion },
+        });
+
+        var app1Path = Path.Combine(Path.GetTempPath(), "packages", "app1", "package.json");
+        var app2Path = Path.Combine(Path.GetTempPath(), "packages", "app2", "package.json");
+
+        var (scanResult, componentRecorder) = await this.detectorTestUtility
+            .WithFile("yarn.lock", yarnLockStream.Stream)
+            .WithFile("package.json", rootJson.ToStream(), ["package.json"], Path.Combine(Path.GetTempPath(), "package.json"))
+            .WithFile("package.json", memberJson.ToStream(), ["package.json"], app1Path)
+            .WithFile("package.json", memberJson.ToStream(), ["package.json"], app2Path)
+            .ExecuteDetectorAsync();
+
+        scanResult.ResultCode.Should().Be(ProcessingResultCode.Success);
+
+        var detectedComponents = componentRecorder.GetDetectedComponents();
+        detectedComponents.Should().ContainSingle();
+
+        var detectedA = detectedComponents.Single();
+        ((NpmComponent)detectedA.Component).Name.Should().Be(componentA.Name);
+
+        // The first workspace pattern (packages/app1) wins the location attribution.
+        detectedA.FilePaths.Should().ContainSingle();
+        detectedA.FilePaths.Should().Contain(app1Path);
+    }
+
+    [TestMethod]
     public async Task WellFormedYarnLockV1WithMoreThanOneComponent_FindsComponentsAsync()
     {
         var version0 = NewRandomVersion();


### PR DESCRIPTION
## Context
We got reports from a couple of mono repos using Yarn that the performance was incredibly slow, which is surprising given the detector is only reading files from disk without any CLI nor network calls, we had a bottleneck somewhere.

## Summary

On a Yarn Berry monorepo with a 2.2 MB / ~55k-line yarn.lock, 4,809 lockfile entries, and 594 workspace patterns a Yarn-only scan took ~94 minutes.

After a targeted fix scoped exclusively to the Yarn detector, the same scan completes in ~15 seconds while producing byte-identical results.

## Root cause
`YarnLockComponentDetector.GetWorkspaceDependencies` ran a full recursive filesystem walk once per workspace pattern. With 594 workspace patterns, it walked the entire monorepo tree, including a very large node_modules, 594 times. Cost was O(patterns × filesystem size).

## Fix
Update `src/Microsoft.ComponentDetection.Detectors/yarn/YarnLockComponentDetector.cs` to perform a single recursive filesystem traversal, discovering and parsing each candidate package.json exactly once, matched against a union matcher of all workspace globs.

Replay dependency resolution in the original order (workspace-pattern order, then discovery order) so the "first-wins" location attribution stays identical to the previous per-pattern behavior.

Net effect: 594 filesystem walks → 1 walk. No change to which components, graph edges, dev flags, or roots are produced.

## Results
| Run                              | Detection time     |
| -------------------------------- | ------------------ |
| Baseline (before fix)            | **5652.6 s (~94 min)** |
| Improved ( filesystem cache) | 15.5 s         |
