### PR TITLE
Use DTO for uv.lock parsing

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/uv/UvDependency.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/uv/UvDependency.cs
@@ -1,13 +1,12 @@
 namespace Microsoft.ComponentDetection.Detectors.Uv;
 
-using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 
-[DataContract]
 internal class UvDependency
 {
-    [DataMember(Name = "name")]
+    [JsonPropertyName("name")]
     public string Name { get; set; } = string.Empty;
 
-    [DataMember(Name = "specifier")]
+    [JsonPropertyName("specifier")]
     public string? Specifier { get; set; }
 }

--- a/src/Microsoft.ComponentDetection.Detectors/uv/UvDependency.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/uv/UvDependency.cs
@@ -1,8 +1,13 @@
 namespace Microsoft.ComponentDetection.Detectors.Uv;
 
+using System.Runtime.Serialization;
+
+[DataContract]
 internal class UvDependency
 {
-    public required string Name { get; init; }
+    [DataMember(Name = "name")]
+    public string Name { get; set; } = string.Empty;
 
+    [DataMember(Name = "specifier")]
     public string? Specifier { get; set; }
 }

--- a/src/Microsoft.ComponentDetection.Detectors/uv/UvLock.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/uv/UvLock.cs
@@ -1,146 +1,41 @@
 namespace Microsoft.ComponentDetection.Detectors.Uv;
 
-using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Runtime.Serialization;
 using Tomlyn;
-using Tomlyn.Model;
 
+[DataContract]
 internal class UvLock
 {
-    // a list of packages with their dependencies
+    // A list of packages with their dependencies.
+    [DataMember(Name = "package")]
     public List<UvPackage> Packages { get; set; } = [];
 
-    // static method to parse the TOML stream into a UvLock model
     public static UvLock Parse(Stream tomlStream)
     {
         using var reader = new StreamReader(tomlStream);
         var tomlContent = reader.ReadToEnd();
-        var model = Toml.ToModel(tomlContent);
-        return new UvLock
+        var options = new TomlModelOptions
         {
-            Packages = ParsePackagesFromModel(model),
+            IgnoreMissingProperties = true,
         };
+
+        var parsed = Toml.ToModel<UvLock>(tomlContent, options: options);
+        parsed.Normalize();
+        return parsed;
     }
 
-    internal static List<UvPackage> ParsePackagesFromModel(object? model)
+    private void Normalize()
     {
-        if (model is not TomlTable table)
+        this.Packages = this.Packages
+            .Where(p => !string.IsNullOrWhiteSpace(p.Name) && !string.IsNullOrWhiteSpace(p.Version))
+            .ToList();
+
+        foreach (var package in this.Packages)
         {
-            throw new InvalidOperationException("TOML root is not a table");
-        }
-
-        if (!table.TryGetValue("package", out var packagesObj) || packagesObj is not TomlTableArray packages)
-        {
-            return [];
-        }
-
-        var result = new List<UvPackage>();
-        foreach (var pkg in packages)
-        {
-            var parsed = ParsePackage(pkg);
-            if (parsed is not null)
-            {
-                result.Add(parsed);
-            }
-        }
-
-        return result;
-    }
-
-    internal static UvPackage? ParsePackage(object? pkg)
-    {
-        if (pkg is not TomlTable pkgTable)
-        {
-            return null;
-        }
-
-        if (pkgTable.TryGetValue("name", out var nameObj) && nameObj is string name &&
-            pkgTable.TryGetValue("version", out var versionObj) && versionObj is string version)
-        {
-            var uvPackage = new UvPackage
-            {
-                Name = name,
-                Version = version,
-                Dependencies = [],
-                MetadataRequiresDist = [],
-                MetadataRequiresDev = [],
-            };
-
-            if (pkgTable.TryGetValue("dependencies", out var depsObj) && depsObj is TomlArray depsArray)
-            {
-                uvPackage.Dependencies = ParseDependenciesArray(depsArray);
-            }
-
-            if (pkgTable.TryGetValue("metadata", out var metadataObj) && metadataObj is TomlTable metadataTable)
-            {
-                ParseMetadata(metadataTable, uvPackage);
-            }
-
-            // Parse source
-            if (pkgTable.TryGetValue("source", out var sourceObj) && sourceObj is TomlTable sourceTable)
-            {
-                var source = new UvSource
-                {
-                    Registry = sourceTable.TryGetValue("registry", out var regObj) && regObj is string reg ? reg : null,
-                    Virtual = sourceTable.TryGetValue("virtual", out var virtObj) && virtObj is string virt ? virt : null,
-                    Git = sourceTable.TryGetValue("git", out var gitObj) && gitObj is string git ? git : null,
-                };
-                uvPackage.Source = source;
-            }
-
-            return uvPackage;
-        }
-
-        return null;
-    }
-
-    internal static List<UvDependency> ParseDependenciesArray(TomlArray? depsArray)
-    {
-        var deps = new List<UvDependency>();
-        if (depsArray is null)
-        {
-            return deps;
-        }
-
-        foreach (var dep in depsArray)
-        {
-            if (dep is TomlTable depTable &&
-                depTable.TryGetValue("name", out var depNameObj) && depNameObj is string depName)
-            {
-                var depSpec = depTable.TryGetValue("specifier", out var specObj) && specObj is string s ? s : null;
-                deps.Add(new UvDependency
-                {
-                    Name = depName,
-                    Specifier = depSpec,
-                });
-            }
-        }
-
-        return deps;
-    }
-
-    internal static void ParseMetadata(TomlTable? metadataTable, UvPackage uvPackage)
-    {
-        if (metadataTable is null)
-        {
-            return;
-        }
-
-        if (metadataTable.TryGetValue("requires-dist", out var requiresDistObj) && requiresDistObj is TomlArray requiresDistArr)
-        {
-            uvPackage.MetadataRequiresDist = ParseDependenciesArray(requiresDistArr);
-        }
-
-        if (metadataTable.TryGetValue("requires-dev", out var requiresDevObj) && requiresDevObj is TomlTable requiresDevTable)
-        {
-            foreach (var kvp in requiresDevTable)
-            {
-                if (kvp.Value is TomlArray groupArr)
-                {
-                    uvPackage.MetadataRequiresDev.AddRange(ParseDependenciesArray(groupArr));
-                }
-            }
+            package.Normalize();
         }
     }
 }

--- a/src/Microsoft.ComponentDetection.Detectors/uv/UvLock.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/uv/UvLock.cs
@@ -3,14 +3,13 @@ namespace Microsoft.ComponentDetection.Detectors.Uv;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 using Tomlyn;
 
-[DataContract]
 internal class UvLock
 {
     // A list of packages with their dependencies.
-    [DataMember(Name = "package")]
+    [JsonPropertyName("package")]
     public List<UvPackage> Packages { get; set; } = [];
 
     public static UvLock Parse(Stream tomlStream)

--- a/src/Microsoft.ComponentDetection.Detectors/uv/UvMetadata.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/uv/UvMetadata.cs
@@ -2,15 +2,14 @@ namespace Microsoft.ComponentDetection.Detectors.Uv;
 
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 
-[DataContract]
 internal class UvMetadata
 {
-    [DataMember(Name = "requires-dist")]
+    [JsonPropertyName("requires-dist")]
     public List<UvDependency> RequiresDist { get; set; } = [];
 
-    [DataMember(Name = "requires-dev")]
+    [JsonPropertyName("requires-dev")]
     public Dictionary<string, List<UvDependency>> RequiresDev { get; set; } = [];
 
     public void Normalize()

--- a/src/Microsoft.ComponentDetection.Detectors/uv/UvMetadata.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/uv/UvMetadata.cs
@@ -1,0 +1,32 @@
+namespace Microsoft.ComponentDetection.Detectors.Uv;
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+
+[DataContract]
+internal class UvMetadata
+{
+    [DataMember(Name = "requires-dist")]
+    public List<UvDependency> RequiresDist { get; set; } = [];
+
+    [DataMember(Name = "requires-dev")]
+    public Dictionary<string, List<UvDependency>> RequiresDev { get; set; } = [];
+
+    public void Normalize()
+    {
+        this.RequiresDist = this.RequiresDist
+            .Where(d => !string.IsNullOrWhiteSpace(d.Name))
+            .ToList();
+
+        var normalizedDev = new Dictionary<string, List<UvDependency>>(this.RequiresDev.Count, this.RequiresDev.Comparer);
+        foreach (var (group, dependencies) in this.RequiresDev)
+        {
+            normalizedDev[group] = dependencies
+                .Where(d => !string.IsNullOrWhiteSpace(d.Name))
+                .ToList();
+        }
+
+        this.RequiresDev = normalizedDev;
+    }
+}

--- a/src/Microsoft.ComponentDetection.Detectors/uv/UvPackage.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/uv/UvPackage.cs
@@ -3,31 +3,30 @@ namespace Microsoft.ComponentDetection.Detectors.Uv;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 
-[DataContract]
 internal class UvPackage
 {
-    [DataMember(Name = "name")]
+    [JsonPropertyName("name")]
     public string Name { get; set; } = string.Empty;
 
-    [DataMember(Name = "version")]
+    [JsonPropertyName("version")]
     public string Version { get; set; } = string.Empty;
 
-    [DataMember(Name = "dependencies")]
+    [JsonPropertyName("dependencies")]
     public List<UvDependency> Dependencies { get; set; } = [];
 
-    [DataMember(Name = "metadata")]
+    [JsonPropertyName("metadata")]
     public UvMetadata? Metadata { get; set; }
 
-    [DataMember(Name = "source")]
+    [JsonPropertyName("source")]
     public UvSource? Source { get; set; }
 
-    [IgnoreDataMember]
+    [JsonIgnore]
     public List<UvDependency> MetadataRequiresDist => this.Metadata?.RequiresDist ?? [];
 
-    [IgnoreDataMember]
+    [JsonIgnore]
     public List<UvDependency> MetadataRequiresDev => this.Metadata?.RequiresDev?.Values
         .Where(group => group != null)
         .SelectMany(group => group!)

--- a/src/Microsoft.ComponentDetection.Detectors/uv/UvPackage.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/uv/UvPackage.cs
@@ -2,24 +2,36 @@ namespace Microsoft.ComponentDetection.Detectors.Uv;
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 
+[DataContract]
 internal class UvPackage
 {
-    public required string Name { get; init; }
+    [DataMember(Name = "name")]
+    public string Name { get; set; } = string.Empty;
 
-    public required string Version { get; init; }
+    [DataMember(Name = "version")]
+    public string Version { get; set; } = string.Empty;
 
+    [DataMember(Name = "dependencies")]
     public List<UvDependency> Dependencies { get; set; } = [];
 
-    // Metadata dependencies (requires-dist)
-    public List<UvDependency> MetadataRequiresDist { get; set; } = [];
+    [DataMember(Name = "metadata")]
+    public UvMetadata? Metadata { get; set; }
 
-    // Metadata dev dependencies (requires-dev)
-    public List<UvDependency> MetadataRequiresDev { get; set; } = [];
-
-    // Source property for uv.lock
+    [DataMember(Name = "source")]
     public UvSource? Source { get; set; }
+
+    [IgnoreDataMember]
+    public List<UvDependency> MetadataRequiresDist => this.Metadata?.RequiresDist ?? [];
+
+    [IgnoreDataMember]
+    public List<UvDependency> MetadataRequiresDev => this.Metadata?.RequiresDev?.Values
+        .Where(group => group != null)
+        .SelectMany(group => group!)
+        .ToList() ?? [];
 
     public TypedComponent ToTypedComponent()
     {
@@ -30,6 +42,15 @@ internal class UvPackage
         }
 
         return new PipComponent(this.Name, this.Version);
+    }
+
+    public void Normalize()
+    {
+        this.Dependencies = this.Dependencies
+            .Where(d => !string.IsNullOrWhiteSpace(d.Name))
+            .ToList();
+
+        this.Metadata?.Normalize();
     }
 
     private static (Uri RepositoryUrl, string CommitHash) ParseGitUrl(string gitUrl)

--- a/src/Microsoft.ComponentDetection.Detectors/uv/UvSource.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/uv/UvSource.cs
@@ -1,16 +1,15 @@
 namespace Microsoft.ComponentDetection.Detectors.Uv;
 
-using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 
-[DataContract]
 internal class UvSource
 {
-    [DataMember(Name = "registry")]
+    [JsonPropertyName("registry")]
     public string? Registry { get; set; }
 
-    [DataMember(Name = "virtual")]
+    [JsonPropertyName("virtual")]
     public string? Virtual { get; set; }
 
-    [DataMember(Name = "git")]
+    [JsonPropertyName("git")]
     public string? Git { get; set; }
 }

--- a/src/Microsoft.ComponentDetection.Detectors/uv/UvSource.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/uv/UvSource.cs
@@ -1,10 +1,16 @@
 namespace Microsoft.ComponentDetection.Detectors.Uv;
 
+using System.Runtime.Serialization;
+
+[DataContract]
 internal class UvSource
 {
+    [DataMember(Name = "registry")]
     public string? Registry { get; set; }
 
+    [DataMember(Name = "virtual")]
     public string? Virtual { get; set; }
 
+    [DataMember(Name = "git")]
     public string? Git { get; set; }
 }

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/UvLockTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/UvLockTests.cs
@@ -8,7 +8,6 @@ using System.Text;
 using AwesomeAssertions;
 using Microsoft.ComponentDetection.Detectors.Uv;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Tomlyn.Model;
 
 [TestClass]
 public class UvLockTests
@@ -108,12 +107,12 @@ version = '2.0.0'
     }
 
     [TestMethod]
-    public void Parse_PackageKeyNotArray_ReturnsNoPackages()
+    public void Parse_PackageKeyNotArray_Throws()
     {
         var toml = "package = 42";
         using var ms = new MemoryStream(Encoding.UTF8.GetBytes(toml));
-        var uvLock = UvLock.Parse(ms);
-        uvLock.Packages.Should().BeEmpty();
+        var act = () => UvLock.Parse(ms);
+        act.Should().Throw<Tomlyn.TomlException>();
     }
 
     [TestMethod]
@@ -131,200 +130,6 @@ name = 'foo'
     }
 
     [TestMethod]
-    public void Parse_PackageWithMalformedDependencies_IgnoresMalformed()
-    {
-        var toml = @"
-[[package]]
-name = 'foo'
-version = '1.2.3'
-dependencies = [42, { name = 'bar' }]
-";
-        using var ms = new MemoryStream(Encoding.UTF8.GetBytes(toml));
-        var uvLock = UvLock.Parse(ms);
-        uvLock.Packages.Should().ContainSingle();
-        var pkg = uvLock.Packages.First();
-        pkg.Dependencies.Should().ContainSingle(d => d.Name == "bar");
-    }
-
-    [TestMethod]
-    public void Parse_PackageWithMalformedMetadata_IgnoresMalformed()
-    {
-        var toml = @"
-[[package]]
-name = 'foo'
-version = '1.2.3'
-[package.metadata]
-requires-dist = [42, { name = 'bar' }]
-[package.metadata.requires-dev]
-dev = [42, { name = 'baz' }]
-";
-        using var ms = new MemoryStream(Encoding.UTF8.GetBytes(toml));
-        var uvLock = UvLock.Parse(ms);
-        uvLock.Packages.Should().ContainSingle();
-        var pkg = uvLock.Packages.First();
-        pkg.MetadataRequiresDist.Should().ContainSingle(d => d.Name == "bar");
-        pkg.MetadataRequiresDev.Should().ContainSingle(d => d.Name == "baz");
-    }
-
-    [TestMethod]
-    public void ParsePackagesFromModel_InvalidRoot_Throws()
-    {
-        Action act = () => UvLock.ParsePackagesFromModel(42);
-        act.Should().Throw<InvalidOperationException>();
-    }
-
-    [TestMethod]
-    public void ParsePackagesFromModel_NoPackages_ReturnsEmpty()
-    {
-        var table = new TomlTable();
-        var result = UvLock.ParsePackagesFromModel(table);
-        result.Should().BeEmpty();
-    }
-
-    [TestMethod]
-    public void ParsePackage_ValidPackage_ParsesCorrectly()
-    {
-        var pkg = new TomlTable
-        {
-            ["name"] = "foo",
-            ["version"] = "1.0.0",
-            ["dependencies"] = new TomlArray { new TomlTable { ["name"] = "bar", ["specifier"] = ">=2.0.0" } },
-        };
-        var result = UvLock.ParsePackage(pkg);
-        result.Should().NotBeNull();
-        result.Name.Should().Be("foo");
-        result.Version.Should().Be("1.0.0");
-        result.Dependencies.Should().ContainSingle(d => d.Name == "bar" && d.Specifier == ">=2.0.0");
-    }
-
-    [TestMethod]
-    public void ParsePackage_MissingNameOrVersion_ReturnsNull()
-    {
-        var pkg1 = new TomlTable { ["version"] = "1.0.0" };
-        var pkg2 = new TomlTable { ["name"] = "foo" };
-        UvLock.ParsePackage(pkg1).Should().BeNull();
-        UvLock.ParsePackage(pkg2).Should().BeNull();
-    }
-
-    [TestMethod]
-    public void ParsePackage_NullOrNonTable_ReturnsNull()
-    {
-        UvLock.ParsePackage(null).Should().BeNull();
-        UvLock.ParsePackage(42).Should().BeNull();
-    }
-
-    [TestMethod]
-    public void ParsePackage_BranchCoverage_AllPaths()
-    {
-        // Path: pkg is TomlTable, but missing name
-        var pkgMissingName = new TomlTable { ["version"] = "1.0.0" };
-        UvLock.ParsePackage(pkgMissingName).Should().BeNull();
-
-        // Path: pkg is TomlTable, but missing version
-        var pkgMissingVersion = new TomlTable { ["name"] = "foo" };
-        UvLock.ParsePackage(pkgMissingVersion).Should().BeNull();
-    }
-
-    [TestMethod]
-    public void ParseDependenciesArray_ParsesValidDepsAndSkipsMalformed()
-    {
-        var arr = new TomlArray { 42, new TomlTable { ["name"] = "bar", ["specifier"] = "==1.2.3" }, new TomlTable { ["name"] = "baz" } };
-        var result = UvLock.ParseDependenciesArray(arr);
-        result.Should().Contain(d => d.Name == "bar" && d.Specifier == "==1.2.3");
-        result.Should().Contain(d => d.Name == "baz" && d.Specifier == null);
-        result.Should().HaveCount(2);
-    }
-
-    [TestMethod]
-    public void ParseDependenciesArray_NullOrNoValidDeps_ReturnsEmpty()
-    {
-        UvLock.ParseDependenciesArray(null).Should().BeEmpty();
-        var arr = new TomlArray { 42, "foo", 3.14 };
-        UvLock.ParseDependenciesArray(arr).Should().BeEmpty();
-    }
-
-    [TestMethod]
-    public void ParseDependenciesArray_BranchCoverage_AllPaths()
-    {
-        // Path: dep is TomlTable but missing name
-        var arr = new TomlArray { new TomlTable { ["specifier"] = "==1.2.3" } };
-        UvLock.ParseDependenciesArray(arr).Should().BeEmpty();
-    }
-
-    [TestMethod]
-    public void ParseMetadata_ParsesRequiresDistAndDev()
-    {
-        var pkg = new UvPackage { Name = "foo", Version = "1.0.0" };
-        var metadata = new TomlTable
-        {
-            ["requires-dist"] = new TomlArray { new TomlTable { ["name"] = "bar", ["specifier"] = ">=2.0.0" } },
-            ["requires-dev"] = new TomlTable { ["dev"] = new TomlArray { new TomlTable { ["name"] = "baz" } } },
-        };
-        UvLock.ParseMetadata(metadata, pkg);
-        pkg.MetadataRequiresDist.Should().ContainSingle(d => d.Name == "bar" && d.Specifier == ">=2.0.0");
-        pkg.MetadataRequiresDev.Should().ContainSingle(d => d.Name == "baz" && d.Specifier == null);
-    }
-
-    [TestMethod]
-    public void ParseMetadata_NullOrNoRelevantKeys_DoesNothing()
-    {
-        var pkg = new UvPackage { Name = "foo", Version = "1.0.0" };
-        UvLock.ParseMetadata(null, pkg); // Should not throw
-        var emptyTable = new TomlTable();
-        UvLock.ParseMetadata(emptyTable, pkg); // Should not throw or set anything
-        pkg.MetadataRequiresDist.Should().BeEmpty();
-        pkg.MetadataRequiresDev.Should().BeEmpty();
-    }
-
-    [TestMethod]
-    public void ParseMetadata_BranchCoverage_RequiresDistOnly()
-    {
-        var pkg = new UvPackage { Name = "foo", Version = "1.0.0" };
-        var metadata = new TomlTable
-        {
-            ["requires-dist"] = new TomlArray { new TomlTable { ["name"] = "bar" } },
-        };
-        UvLock.ParseMetadata(metadata, pkg);
-        pkg.MetadataRequiresDist.Should().ContainSingle(d => d.Name == "bar");
-        pkg.MetadataRequiresDev.Should().BeEmpty();
-    }
-
-    [TestMethod]
-    public void ParseMetadata_BranchCoverage_RequiresDevOnly()
-    {
-        var pkg = new UvPackage { Name = "foo", Version = "1.0.0" };
-        var metadata = new TomlTable
-        {
-            ["requires-dev"] = new TomlTable { ["dev"] = new TomlArray { new TomlTable { ["name"] = "baz" } } },
-        };
-        UvLock.ParseMetadata(metadata, pkg);
-        pkg.MetadataRequiresDist.Should().BeEmpty();
-        pkg.MetadataRequiresDev.Should().ContainSingle(d => d.Name == "baz");
-    }
-
-    [TestMethod]
-    public void ParseMetadata_RequiresDevTableWithoutDevArray_DoesNotThrowOrSet()
-    {
-        var pkg = new UvPackage { Name = "foo", Version = "1.0.0" };
-
-        // requires-dev exists but no "dev" key
-        var metadata = new TomlTable
-        {
-            ["requires-dev"] = new TomlTable { ["notdev"] = 42 },
-        };
-        UvLock.ParseMetadata(metadata, pkg);
-        pkg.MetadataRequiresDev.Should().BeEmpty();
-
-        // requires-dev exists, "dev" is not a TomlArray
-        metadata = new TomlTable
-        {
-            ["requires-dev"] = new TomlTable { ["dev"] = 42 },
-        };
-        UvLock.ParseMetadata(metadata, pkg);
-        pkg.MetadataRequiresDev.Should().BeEmpty();
-    }
-
-    [TestMethod]
     public void ParsePackage_ParsesSourceRegistryAndVirtual()
     {
         var toml = """
@@ -338,7 +143,7 @@ source = { registry = 'https://example.com/', virtual = '.' }
         uvLock.Packages.Should().ContainSingle();
         var pkg = uvLock.Packages.First();
         pkg.Source.Should().NotBeNull();
-        pkg.Source!.Registry.Should().Be("https://example.com/");
+        pkg.Source.Registry.Should().Be("https://example.com/");
         pkg.Source.Virtual.Should().Be(".");
     }
 
@@ -356,7 +161,7 @@ source = { registry = 'https://example.com/' }
         uvLock.Packages.Should().ContainSingle();
         var pkg = uvLock.Packages.First();
         pkg.Source.Should().NotBeNull();
-        pkg.Source!.Registry.Should().Be("https://example.com/");
+        pkg.Source.Registry.Should().Be("https://example.com/");
         pkg.Source.Virtual.Should().BeNull();
     }
 
@@ -374,7 +179,7 @@ source = { virtual = '.' }
         uvLock.Packages.Should().ContainSingle();
         var pkg = uvLock.Packages.First();
         pkg.Source.Should().NotBeNull();
-        pkg.Source!.Registry.Should().BeNull();
+        pkg.Source.Registry.Should().BeNull();
         pkg.Source.Virtual.Should().Be(".");
     }
 

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/UvLockTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/UvLockTests.cs
@@ -78,6 +78,8 @@ version = '2.0.0'
         uvLock.Packages.Should().HaveCount(2);
         uvLock.Packages.First().Name.Should().Be("foo");
         uvLock.Packages.First().Dependencies.Should().ContainSingle(d => d.Name == "bar" && d.Specifier == ">=2.0.0");
+        uvLock.Packages.Last().Name.Should().Be("bar");
+        uvLock.Packages.Last().Dependencies.Should().BeEmpty();
     }
 
     [TestMethod]


### PR DESCRIPTION
This simplifies the parsing of uv.lock files by just using the built-in model parser. It comes at the expense of some resiliency to malformed files, but given that these are generated files and the reliability of data from a manually edited file is questionable that seems either preferable or like an acceptable tradeoff to me.