### PR TITLE
Handle circular dependencies

### DIFF
--- a/src/Microsoft.ComponentDetection.Detectors/conda/CondaDependencyResolver.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/conda/CondaDependencyResolver.cs
@@ -18,7 +18,10 @@ public static class CondaDependencyResolver
     /// <param name="condaLock">The full condaLock object.</param>
     /// <param name="singleFileComponentRecorder">The SingleFileComponentRecorder.</param>
     public static void RecordDependencyGraphFromFile(CondaLock condaLock, ISingleFileComponentRecorder singleFileComponentRecorder)
-        => GetPackages(condaLock).ForEach(package => RegisterPackageWithDependencies(package, null, condaLock, singleFileComponentRecorder));
+    {
+        HashSet<(string Name, string Version)> visitedPackages = [];
+        GetPackages(condaLock).ForEach(package => RegisterPackageWithDependencies(package, null, condaLock, singleFileComponentRecorder, visitedPackages));
+    }
 
     /// <summary>
     /// Updates all registered packages that don't have any ancestors.
@@ -60,7 +63,13 @@ public static class CondaDependencyResolver
     /// <param name="parentId">The id of the parent package.</param>
     /// <param name="condaLock">The full condaLock object.</param>
     /// <param name="singleFileComponentRecorder">The SingleFileComponentRecorder.</param>
-    private static void RegisterPackageWithDependencies(CondaPackage package, string parentId, CondaLock condaLock, ISingleFileComponentRecorder singleFileComponentRecorder)
+    /// <param name="visitedPackages">The packages whose dependencies have already been registered.</param>
+    private static void RegisterPackageWithDependencies(
+        CondaPackage package,
+        string parentId,
+        CondaLock condaLock,
+        ISingleFileComponentRecorder singleFileComponentRecorder,
+        ISet<(string Name, string Version)> visitedPackages)
     {
         if (package == null)
         {
@@ -72,13 +81,19 @@ public static class CondaDependencyResolver
         //// Register the package itself.
         RegisterPackage(component, parentId, false, singleFileComponentRecorder);
 
+        if (!visitedPackages.Add((package.Name, package.Version)))
+        {
+            return;
+        }
+
         //// Register all dependencies of the package.
         package.Dependencies.Keys.ToList().ForEach(dependency =>
             RegisterPackageWithDependencies(
                 condaLock?.Package.FirstOrDefault(condaPackage => condaPackage.Name == dependency && condaPackage.Platform == package.Platform),
                 component.Id,
                 condaLock,
-                singleFileComponentRecorder));
+                singleFileComponentRecorder,
+                visitedPackages));
     }
 
     /// <summary>

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/CondaLockComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/CondaLockComponentDetectorTests.cs
@@ -104,6 +104,46 @@ package:
         detectedComponents.Should().HaveCount(4);
     }
 
+    [TestMethod]
+    public async Task CondaComponentDetector_CircularDependenciesAsync()
+    {
+        var condaLockContent =
+@"version: 1
+package:
+- name: alpha
+  version: 1.0.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    beta: '>=1.0.0'
+  category: main
+  optional: false
+- name: beta
+  version: 1.0.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    alpha: '>=1.0.0'
+  category: main
+  optional: false
+";
+
+        var (scanResult, componentRecorder) = await this.detectorTestUtility
+            .WithFile("conda-lock.yml", condaLockContent)
+            .ExecuteDetectorAsync();
+
+        scanResult.ResultCode.Should().Be(ProcessingResultCode.Success);
+
+        var detectedComponents = componentRecorder.GetDetectedComponents();
+        var alpha = detectedComponents.Single(component => component.Component is CondaComponent condaComponent && condaComponent.Name == "alpha");
+        var beta = detectedComponents.Single(component => component.Component is CondaComponent condaComponent && condaComponent.Name == "beta");
+        var dependencyGraph = componentRecorder.GetDependencyGraphsByLocation().Values.Single();
+
+        detectedComponents.Should().HaveCount(2);
+        dependencyGraph.GetDependenciesForComponent(alpha.Component.Id).Should().ContainSingle(beta.Component.Id);
+        dependencyGraph.GetDependenciesForComponent(beta.Component.Id).Should().ContainSingle(alpha.Component.Id);
+    }
+
     private void AssertCondaLockComponentNameAndVersion(IEnumerable<DetectedComponent> detectedComponents, string name, string version)
     {
         detectedComponents.SingleOrDefault(c =>


### PR DESCRIPTION
As-is it's possible to get stuck in a look when A->B->A (Or A->B->C->A, etc) which eventually causes a stack-overflow. This PR adds a set to keep track of visited packages so we can be sure we never end up in a loop. Before the fix the unit test I added would crash the test-host. I also checked the fix against the real-world report which alerted me to this issue.