### PR TITLE
Fix directory enumeration hang

### DIFF
--- a/src/Microsoft.ComponentDetection.Common/FastDirectoryWalkerFactory.cs
+++ b/src/Microsoft.ComponentDetection.Common/FastDirectoryWalkerFactory.cs
@@ -142,19 +142,26 @@ internal class FastDirectoryWalkerFactory : IObservableDirectoryWalkerFactory
                     var scan = new ActionBlock<DirectoryInfo>(
                         di =>
                         {
-                            var enumerator = new FileSystemEnumerable<FileSystemInfo>(di.FullName, this.Transform, new EnumerationOptions()
+                            try
                             {
-                                RecurseSubdirectories = true,
-                                IgnoreInaccessible = true,
-                                ReturnSpecialDirectories = false,
-                            })
-                            {
-                                ShouldRecursePredicate = shouldRecurse,
-                            };
+                                var enumerator = new FileSystemEnumerable<FileSystemInfo>(di.FullName, this.Transform, new EnumerationOptions()
+                                {
+                                    RecurseSubdirectories = true,
+                                    IgnoreInaccessible = true,
+                                    ReturnSpecialDirectories = false,
+                                })
+                                {
+                                    ShouldRecursePredicate = shouldRecurse,
+                                };
 
-                            foreach (var fileSystemInfo in enumerator)
+                                foreach (var fileSystemInfo in enumerator)
+                                {
+                                    observer.OnNext(fileSystemInfo);
+                                }
+                            }
+                            catch (DirectoryNotFoundException)
                             {
-                                observer.OnNext(fileSystemInfo);
+                                this.logger.LogDebug("Directory disappeared during enumeration: {DirectoryFullName}", di.FullName);
                             }
                         },
                         new ExecutionDataflowBlockOptions() { MaxDegreeOfParallelism = Environment.ProcessorCount });
@@ -183,6 +190,12 @@ internal class FastDirectoryWalkerFactory : IObservableDirectoryWalkerFactory
                     }
 
                     s.OnNext(info);
+                },
+                error =>
+                {
+                    sw.Stop();
+                    this.logger.LogError(error, "Directory enumeration failed for {RootFullName}", root.FullName);
+                    s.OnError(error);
                 },
                 () =>
                 {

--- a/test/Microsoft.ComponentDetection.Common.Tests/FastDirectoryWalkerFactoryTests.cs
+++ b/test/Microsoft.ComponentDetection.Common.Tests/FastDirectoryWalkerFactoryTests.cs
@@ -1,0 +1,123 @@
+#nullable disable
+namespace Microsoft.ComponentDetection.Common.Tests;
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using AwesomeAssertions;
+using Microsoft.ComponentDetection.Contracts;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+[TestClass]
+[TestCategory("Governance/All")]
+[TestCategory("Governance/ComponentDetection")]
+public class FastDirectoryWalkerFactoryTests
+{
+    private string temporaryDirectory;
+
+    [TestInitialize]
+    public void TestInitialize()
+    {
+        this.temporaryDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(this.temporaryDirectory);
+    }
+
+    [TestCleanup]
+    public void TestCleanup()
+    {
+        if (Directory.Exists(this.temporaryDirectory))
+        {
+            Directory.Delete(this.temporaryDirectory, true);
+        }
+    }
+
+    [TestMethod]
+    public async Task GetDirectoryScanner_CompletesWhenDiscoveredDirectoryDisappears()
+    {
+        var disappearingDirectory = Directory.CreateDirectory(Path.Combine(this.temporaryDirectory, "disappearing"));
+        await File.WriteAllTextAsync(Path.Combine(disappearingDirectory.FullName, "component.txt"), "content");
+
+        var directoryWasDeleted = false;
+        bool DeleteDiscoveredDirectory(ReadOnlySpan<char> directoryName, ReadOnlySpan<char> parentPath)
+        {
+            _ = directoryName;
+            _ = parentPath;
+            Directory.Delete(disappearingDirectory.FullName, true);
+            directoryWasDeleted = true;
+            return false;
+        }
+
+        var walker = new FastDirectoryWalkerFactory(
+            Mock.Of<IPathUtilityService>(),
+            Mock.Of<ILogger<FastDirectoryWalkerFactory>>());
+
+        var completion = new TaskCompletionSource<IReadOnlyList<FileSystemInfo>>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var subscription = walker.GetDirectoryScanner(
+            new DirectoryInfo(this.temporaryDirectory),
+            new ConcurrentDictionary<string, bool>(),
+            DeleteDiscoveredDirectory).Subscribe(new RecordingObserver(completion));
+
+        var results = await completion.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        directoryWasDeleted.Should().BeTrue();
+        results.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task GetDirectoryScanner_PropagatesUnexpectedEnumerationError()
+    {
+        var parentDirectory = Directory.CreateDirectory(Path.Combine(this.temporaryDirectory, "parent"));
+        Directory.CreateDirectory(Path.Combine(parentDirectory.FullName, "nested"));
+        var expectedException = new InvalidOperationException("Unexpected enumeration error");
+
+        bool ThrowForNestedDirectory(ReadOnlySpan<char> directoryName, ReadOnlySpan<char> parentPath)
+        {
+            _ = parentPath;
+
+            if (directoryName.SequenceEqual("nested"))
+            {
+                throw expectedException;
+            }
+
+            return false;
+        }
+
+        var logger = new Mock<ILogger<FastDirectoryWalkerFactory>>();
+        var walker = new FastDirectoryWalkerFactory(
+            Mock.Of<IPathUtilityService>(),
+            logger.Object);
+
+        var completion = new TaskCompletionSource<IReadOnlyList<FileSystemInfo>>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var subscription = walker.GetDirectoryScanner(
+            new DirectoryInfo(this.temporaryDirectory),
+            new ConcurrentDictionary<string, bool>(),
+            ThrowForNestedDirectory).Subscribe(new RecordingObserver(completion));
+
+        Func<Task> waitForCompletion = async () => await completion.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var assertion = await waitForCompletion.Should().ThrowAsync<InvalidOperationException>();
+        assertion.Which.Should().BeSameAs(expectedException);
+        logger.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((value, _) => value.ToString().Contains("Directory enumeration failed")),
+                expectedException,
+                It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+            Times.Once);
+    }
+
+    private sealed class RecordingObserver(TaskCompletionSource<IReadOnlyList<FileSystemInfo>> completion) : IObserver<FileSystemInfo>
+    {
+        private readonly List<FileSystemInfo> results = [];
+
+        public void OnCompleted() => completion.SetResult(this.results);
+
+        public void OnError(Exception error) => completion.SetException(error);
+
+        public void OnNext(FileSystemInfo value) => this.results.Add(value);
+    }
+}


### PR DESCRIPTION
## Summary

Fix a directory enumeration failure that can leave Component Detection waiting indefinitely when the source tree changes during a scan.

## Problem

Component Detection first discovers directories and then enumerates them concurrently. In a mutable build tree, a discovered directory can be deleted before recursive enumeration begins. The resulting `DirectoryNotFoundException` faults the directory enumeration `ActionBlock`.

Errors from the concatenated enumeration observables were also not forwarded to the outer observer. As a result, an unexpected enumeration failure could leave the shared replay observable without a terminal notification. Detectors waiting for enumeration to complete would then remain blocked indefinitely.

This behavior was observed in a process dump where:

- A previously discovered directory no longer existed.
- Recursive directory enumeration had faulted with `DirectoryNotFoundException`.
- The replay observable had neither completed nor failed.
- Detector tasks remained incomplete while worker threads were idle.

## Solution

- Treat `DirectoryNotFoundException` during recursive enumeration as a recoverable race and continue scanning the remaining directories.
- Log unexpected enumeration failures and propagate them through `OnError` so the scan fails instead of hanging.

Other I/O and enumeration exceptions are not suppressed.

## Tests

Added regression coverage that verifies:

- Enumeration completes when a directory is deleted after discovery but before recursive enumeration.
- Unexpected recursive enumeration failures are logged and propagated to subscribers rather than timing out.
