### PR TITLE
Capture additional data from conda-lock files

### DIFF
--- a/src/Microsoft.ComponentDetection.Contracts/TypedComponent/CondaComponent.cs
+++ b/src/Microsoft.ComponentDetection.Contracts/TypedComponent/CondaComponent.cs
@@ -1,11 +1,13 @@
 #nullable disable
 namespace Microsoft.ComponentDetection.Contracts.TypedComponent;
 
+using System;
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 public class CondaComponent : TypedComponent
 {
-    public CondaComponent(string name, string version, string build, string channel, string subdir, string @namespace, string url, string md5)
+    public CondaComponent(string name, string version, string build, string channel, string subdir, string @namespace, string url, string md5, string sha256 = null)
     {
         this.Name = this.ValidateRequiredInput(name, nameof(this.Name), nameof(ComponentType.Conda));
         this.Version = this.ValidateRequiredInput(version, nameof(this.Version), nameof(ComponentType.Conda));
@@ -15,6 +17,12 @@ public class CondaComponent : TypedComponent
         this.Namespace = @namespace;
         this.Url = url;
         this.MD5 = md5;
+        this.SHA256 = sha256;
+
+        if (Uri.TryCreate(url, UriKind.Absolute, out var downloadUrl))
+        {
+            this.DownloadUrl = downloadUrl;
+        }
     }
 
     public CondaComponent()
@@ -46,8 +54,34 @@ public class CondaComponent : TypedComponent
     [JsonPropertyName("mD5")]
     public string MD5 { get; set; }
 
+    [JsonPropertyName("sha256")]
+    public string SHA256 { get; set; }
+
     [JsonIgnore]
     public override ComponentType Type => ComponentType.Conda;
 
-    protected override string ComputeBaseId() => $"{this.Name} {this.Version} {this.Build} {this.Channel} {this.Subdir} {this.Namespace} {this.Url} {this.MD5} - {this.Type}";
+    protected override string ComputeBaseId() => $"{this.Name} {this.Version} - {this.Type}";
+
+    /// <summary>
+    /// Uses native Conda coordinates to distinguish artifacts while excluding mirror URLs and
+    /// integrity hashes from component identity.
+    /// </summary>
+    /// <returns>The Conda coordinates included in the extended component identity.</returns>
+    protected override IEnumerable<KeyValuePair<string, string>> GetExtendedIdProperties()
+    {
+        if (!string.IsNullOrWhiteSpace(this.Build))
+        {
+            yield return new KeyValuePair<string, string>(nameof(this.Build), this.Build);
+        }
+
+        if (!string.IsNullOrWhiteSpace(this.Channel))
+        {
+            yield return new KeyValuePair<string, string>(nameof(this.Channel), this.Channel);
+        }
+
+        if (!string.IsNullOrWhiteSpace(this.Subdir))
+        {
+            yield return new KeyValuePair<string, string>(nameof(this.Subdir), this.Subdir);
+        }
+    }
 }

--- a/src/Microsoft.ComponentDetection.Detectors/conda/CondaDependencyResolver.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/conda/CondaDependencyResolver.cs
@@ -119,22 +119,89 @@ public static class CondaDependencyResolver
     /// If the condapackage is a python package it will be converted to a
     /// PipComponent. Otherwise it will be converted to a CondaComponent.
     ///
-    /// For the conda component, only the most necessary information that are
-    /// required for component governance are passed. This way duplicates
-    /// will be avoided. For example the URL of the package is platform-specific.
-    /// That is, the same package with the same version will exist multiple
-    /// times in the conda-lock files with different urls. If we were to add
-    /// the url, we would register these duplicates. As the information is
-    /// anyway not required for compoment governance, we don't pass it and
-    /// this way avoid duplicates.
-    ///
+    /// Conda package metadata is populated from the lock entry and, for older
+    /// lock files, from the package URL.
     /// </summary>
     /// <param name="package">The CondaPackage to convert.</param>
     /// <returns>The TypedComponent.</returns>
     private static TypedComponent CreateComponent(CondaPackage package)
-        => IsPythonPackage(package)
-                ? new PipComponent(package.Name, package.Version)
-                : new CondaComponent(package.Name, package.Version, null, package.Category, null, null, null, null);
+    {
+        if (IsPythonPackage(package))
+        {
+            var pipComponent = new PipComponent(package.Name, package.Version);
+            if (Uri.TryCreate(package.Url, UriKind.Absolute, out var downloadUrl))
+            {
+                pipComponent.DownloadUrl = downloadUrl;
+            }
+
+            return pipComponent;
+        }
+
+        var (channel, subdir, fileName) = GetPackageUrlMetadata(package.Url);
+        var md5 = package.Hash != null && package.Hash.TryGetValue("md5", out var hash)
+            ? hash
+            : null;
+
+        var sha256 = package.Hash != null && package.Hash.TryGetValue("sha256", out var sha256Hash)
+            ? sha256Hash
+            : null;
+
+        return new CondaComponent(
+            name: package.Name,
+            version: package.Version,
+            build: package.Build ?? GetBuildFromFileName(package, fileName),
+            channel: channel,
+            subdir: subdir ?? package.Platform,
+            @namespace: null,
+            url: package.Url,
+            md5: md5,
+            sha256: sha256);
+    }
+
+    private static string GetBuildFromFileName(CondaPackage package, string fileName)
+    {
+        if (string.IsNullOrWhiteSpace(fileName))
+        {
+            return null;
+        }
+
+        var packageFileName = fileName.EndsWith(".tar.bz2", StringComparison.OrdinalIgnoreCase)
+            ? fileName[..^8]
+            : fileName.EndsWith(".conda", StringComparison.OrdinalIgnoreCase)
+                ? fileName[..^6]
+                : fileName;
+        var buildPrefix = $"{package.Name}-{package.Version}-";
+
+        return packageFileName.StartsWith(buildPrefix, StringComparison.Ordinal)
+            ? packageFileName[buildPrefix.Length..]
+            : null;
+    }
+
+    private static (string Channel, string Subdir, string FileName) GetPackageUrlMetadata(string packageUrl)
+    {
+        if (!Uri.TryCreate(packageUrl, UriKind.Absolute, out var uri))
+        {
+            return (null, null, null);
+        }
+
+        var segments = uri.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length < 2)
+        {
+            return (null, null, null);
+        }
+
+        var channelUri = new UriBuilder(uri)
+        {
+            Path = segments.Length == 2 ? "/" : $"/{string.Join("/", segments[..^2])}",
+            Query = string.Empty,
+            Fragment = string.Empty,
+        }.Uri.GetLeftPart(UriPartial.Path).TrimEnd('/');
+
+        return (
+            channelUri,
+            Uri.UnescapeDataString(segments[^2]),
+            Uri.UnescapeDataString(segments[^1]));
+    }
 
     /// <summary>
     /// Checks if a package is a python package.
@@ -146,5 +213,5 @@ public static class CondaDependencyResolver
     /// <returns>True if the package is a python package.</returns>
     private static bool IsPythonPackage(CondaPackage package)
         => package.Manager.Equals("pip", StringComparison.OrdinalIgnoreCase) ||
-           package.Dependencies.Keys.Any(dependency => dependency.Equals("python", StringComparison.OrdinalIgnoreCase));
+           package.Dependencies?.Keys.Any(dependency => dependency.Equals("python", StringComparison.OrdinalIgnoreCase)) == true;
 }

--- a/src/Microsoft.ComponentDetection.Detectors/conda/CondaDependencyResolver.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/conda/CondaDependencyResolver.cs
@@ -212,6 +212,6 @@ public static class CondaDependencyResolver
     /// <param name="package">The CondaPackage.</param>
     /// <returns>True if the package is a python package.</returns>
     private static bool IsPythonPackage(CondaPackage package)
-        => package.Manager.Equals("pip", StringComparison.OrdinalIgnoreCase) ||
+        => package.Manager?.Equals("pip", StringComparison.OrdinalIgnoreCase) == true ||
            package.Dependencies?.Keys.Any(dependency => dependency.Equals("python", StringComparison.OrdinalIgnoreCase)) == true;
 }

--- a/src/Microsoft.ComponentDetection.Detectors/conda/CondaLockComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/conda/CondaLockComponentDetector.cs
@@ -30,7 +30,7 @@ public class CondaLockComponentDetector : FileComponentDetector, IExperimentalDe
 
     public override IEnumerable<ComponentType> SupportedComponentTypes => [ComponentType.Conda, ComponentType.Pip];
 
-    public override int Version { get; } = 2;
+    public override int Version { get; } = 3;
 
     public override IEnumerable<string> Categories => ["Python"];
 

--- a/src/Microsoft.ComponentDetection.Detectors/conda/Contracts/CondaPackage.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/conda/Contracts/CondaPackage.cs
@@ -14,6 +14,9 @@ public class CondaPackage
     [YamlMember(Alias = "category")]
     public string Category { get; set; }
 
+    [YamlMember(Alias = "build")]
+    public string Build { get; set; }
+
     [YamlMember(Alias = "dependencies")]
     public Dictionary<string, string> Dependencies { get; set; }
 

--- a/src/Microsoft.ComponentDetection.Detectors/linux/Factories/CondaComponentFactory.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/linux/Factories/CondaComponentFactory.cs
@@ -28,7 +28,7 @@ internal class CondaComponentFactory : ArtifactComponentFactoryBase
             return null;
         }
 
-        // Syft provides conda metadata including build, channel, subdir, url, and md5
+        // Syft provides conda metadata including build, channel, subdir, URL, and hashes.
         var metadata = artifact.Metadata;
 
         return new CondaComponent(
@@ -39,7 +39,8 @@ internal class CondaComponentFactory : ArtifactComponentFactoryBase
             subdir: metadata?.Subdir,
             @namespace: null, // Syft doesn't provide namespace
             url: metadata?.Url?.String,
-            md5: metadata?.Md5
+            md5: metadata?.Md5,
+            sha256: metadata?.Sha256
         );
     }
 }

--- a/test/Microsoft.ComponentDetection.Contracts.Tests/TypedComponentSerializationTests.cs
+++ b/test/Microsoft.ComponentDetection.Contracts.Tests/TypedComponentSerializationTests.cs
@@ -81,6 +81,73 @@ public class TypedComponentSerializationTests
     }
 
     [TestMethod]
+    public void TypedComponent_Serialization_Conda_WithHashes()
+    {
+        TypedComponent tc = new CondaComponent(
+            "sample",
+            "1.2.3",
+            "build_0",
+            "https://conda.example/channel",
+            "linux-64",
+            null,
+            "https://conda.example/channel/linux-64/sample-1.2.3-build_0.conda",
+            "md5-placeholder",
+            "sha256-placeholder");
+
+        var result = JsonSerializer.Serialize(tc);
+        var condaComponent = JsonSerializer.Deserialize<TypedComponent>(result)
+            .Should().BeOfType<CondaComponent>().Subject;
+
+        condaComponent.MD5.Should().Be("md5-placeholder");
+        condaComponent.SHA256.Should().Be("sha256-placeholder");
+        condaComponent.DownloadUrl.Should().Be(
+            new Uri("https://conda.example/channel/linux-64/sample-1.2.3-build_0.conda"));
+        condaComponent.BaseId.Should().Be("sample 1.2.3 - Conda");
+        condaComponent.Id.Should().Be(
+            "sample 1.2.3 - Conda [Build:build_0 Channel:https://conda.example/channel Subdir:linux-64]");
+        condaComponent.Id.Should().NotContainAny("md5-placeholder", "sha256-placeholder", condaComponent.Url);
+    }
+
+    [TestMethod]
+    public void CondaComponent_Identity_ExcludesArtifactProvenance()
+    {
+        var componentA = new CondaComponent(
+            "sample",
+            "1.2.3",
+            "build_0",
+            "https://conda.example/channel",
+            "linux-64",
+            null,
+            "https://mirror-a.example/sample-1.2.3-build_0.conda",
+            "md5-a",
+            "sha256-a");
+        var componentB = new CondaComponent(
+            "sample",
+            "1.2.3",
+            "build_0",
+            "https://conda.example/channel",
+            "linux-64",
+            null,
+            "https://mirror-b.example/sample-1.2.3-build_0.conda",
+            "md5-b",
+            "sha256-b");
+
+        componentA.Id.Should().Be(componentB.Id);
+    }
+
+    [TestMethod]
+    public void CondaComponent_Identity_DistinguishesPlatformArtifacts()
+    {
+        var linuxComponent = new CondaComponent(
+            "sample", "1.2.3", "linux_build", "conda-forge", "linux-64", null, null, null);
+        var windowsComponent = new CondaComponent(
+            "sample", "1.2.3", "windows_build", "conda-forge", "win-64", null, null, null);
+
+        linuxComponent.BaseId.Should().Be(windowsComponent.BaseId);
+        linuxComponent.Id.Should().NotBe(windowsComponent.Id);
+    }
+
+    [TestMethod]
     public void TypedComponent_Serialization_Maven()
     {
         TypedComponent tc = new MavenComponent("SomeGroupId", "SomeArtifactId", "1.2.3");

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/ArtifactComponentFactoryTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/ArtifactComponentFactoryTests.cs
@@ -265,6 +265,7 @@ public class ArtifactComponentFactoryTests
                 Channel = "https://conda.anaconda.org/conda-forge",
                 Subdir = "linux-64",
                 Md5 = "abc123def456",
+                Sha256 = "def456abc123",
             },
         };
 
@@ -277,6 +278,7 @@ public class ArtifactComponentFactoryTests
         result.Channel.Should().Be("https://conda.anaconda.org/conda-forge");
         result.Subdir.Should().Be("linux-64");
         result.MD5.Should().Be("abc123def456");
+        result.SHA256.Should().Be("def456abc123");
     }
 
     [TestMethod]

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/CondaLockComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/CondaLockComponentDetectorTests.cs
@@ -1,6 +1,7 @@
 #nullable disable
 namespace Microsoft.ComponentDetection.Detectors.Tests;
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -64,6 +65,7 @@ package:
   version: 2.1.0
   manager: conda
   platform: linux-64
+  build: pyhd8ed1ab_0
   dependencies:
     urllib3: '>=1.26.5,<2.0'
   url: https://conda.anaconda.org/conda-forge/noarch/conda-lock-2.1.0-pyhd8ed1ab_0.conda
@@ -94,14 +96,211 @@ package:
         scanResult.ResultCode.Should().Be(ProcessingResultCode.Success);
 
         // packages from the conda section
-        this.AssertCondaLockComponentNameAndVersion(detectedComponents, "conda-lock", "2.1.0");
-        this.AssertCondaLockComponentNameAndVersion(detectedComponents, "urllib3", "1.26.16");
+        var condaLockComponent = detectedComponents
+            .Select(component => component.Component)
+            .OfType<CondaComponent>()
+            .Single(component => component.Name == "conda-lock");
+        condaLockComponent.Version.Should().Be("2.1.0");
+        condaLockComponent.Build.Should().Be("pyhd8ed1ab_0");
+        condaLockComponent.Channel.Should().Be("https://conda.anaconda.org/conda-forge");
+        condaLockComponent.Subdir.Should().Be("noarch");
+        condaLockComponent.Url.Should().Be("https://conda.anaconda.org/conda-forge/noarch/conda-lock-2.1.0-pyhd8ed1ab_0.conda");
+        condaLockComponent.DownloadUrl.Should().Be(
+            new Uri("https://conda.anaconda.org/conda-forge/noarch/conda-lock-2.1.0-pyhd8ed1ab_0.conda"));
+        condaLockComponent.MD5.Should().Be("1e07afcf3d3e371fc3a3681fe9b78e90");
+        condaLockComponent.SHA256.Should().Be("05319e84cbd36f6a05563954d2dbff041de6ece406a59650784918026080c98c");
+
+        var urllibComponent = detectedComponents
+            .Select(component => component.Component)
+            .OfType<CondaComponent>()
+            .Single(component => component.Name == "urllib3");
+        urllibComponent.Version.Should().Be("1.26.16");
+        urllibComponent.Build.Should().Be("py311h06a4308_0");
+        urllibComponent.Channel.Should().Be("https://repo.anaconda.com/pkgs/main");
+        urllibComponent.Subdir.Should().Be("linux-64");
+        urllibComponent.Url.Should().Be("https://repo.anaconda.com/pkgs/main/linux-64/urllib3-1.26.16-py311h06a4308_0.conda");
+        urllibComponent.MD5.Should().Be("4b62a74f7e797800039971833968e23f");
+        urllibComponent.SHA256.Should().Be("b9e919a9bcb4cb291fe60952895bf0c3ce9dbcbeaa3d5706131f862756fabc40");
 
         // packages from the pip section
         this.AssertPipComponentNameAndVersion(detectedComponents, "certifi", "2023.5.7");
         this.AssertPipComponentNameAndVersion(detectedComponents, "requests", "2.31.0");
+        var requestsComponent = detectedComponents
+            .Select(component => component.Component)
+            .OfType<PipComponent>()
+            .Single(component => component.Name == "requests");
+        requestsComponent.DownloadUrl.Should().Be(
+            new Uri("https://files.pythonhosted.org/packages/70/8e/0e2d847013cb52cd35b38c009bb167a1a26b2ce6cd6965bf26b47bc0bf44/requests-2.31.0-py3-none-any.whl"));
 
         detectedComponents.Should().HaveCount(4);
+    }
+
+    [TestMethod]
+    public async Task CondaComponentDetector_NoarchPackagesAreDeduplicatedAcrossPlatformsAsync()
+    {
+        var condaLockContent =
+@"version: 1
+metadata:
+  platforms:
+  - linux-64
+  - win-64
+package:
+- name: colorama
+  version: 0.4.6
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+  hash:
+    md5: 7c68c537b61ad0c41aa7f1c2a8a6bd6f
+    sha256: 45a2c7b5c2146b9f8e3a879284cf1c7c40264b4e3fd40fdbdbcf34a10f522f4d
+  category: main
+  optional: false
+- name: colorama
+  version: 0.4.6
+  manager: conda
+  platform: win-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+  hash:
+    md5: 7c68c537b61ad0c41aa7f1c2a8a6bd6f
+    sha256: 45a2c7b5c2146b9f8e3a879284cf1c7c40264b4e3fd40fdbdbcf34a10f522f4d
+  category: main
+  optional: false
+";
+
+        var (scanResult, componentRecorder) = await this.detectorTestUtility
+            .WithFile("conda-lock.yml", condaLockContent)
+            .ExecuteDetectorAsync();
+
+        scanResult.ResultCode.Should().Be(ProcessingResultCode.Success);
+        var component = componentRecorder.GetDetectedComponents().Single().Component.Should().BeOfType<CondaComponent>().Subject;
+        component.Build.Should().Be("pyhd8ed1ab_1");
+        component.Subdir.Should().Be("noarch");
+        component.SHA256.Should().Be("45a2c7b5c2146b9f8e3a879284cf1c7c40264b4e3fd40fdbdbcf34a10f522f4d");
+    }
+
+    [TestMethod]
+    public async Task CondaComponentDetector_PlatformPackagesUseSeparateGraphNodesAsync()
+    {
+        var condaLockContent =
+@"version: 1
+metadata:
+  platforms:
+  - linux-64
+  - osx-64
+  - win-64
+package:
+- name: sample
+  version: 1.0.0
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.example/channel/linux-64/sample-1.0.0-linux_0.conda
+  hash:
+    md5: linux
+- name: sample
+  version: 1.0.0
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.example/channel/osx-64/sample-1.0.0-osx_0.conda
+  hash:
+    md5: osx
+- name: sample
+  version: 1.0.0
+  manager: conda
+  platform: win-64
+  dependencies: {}
+  url: https://conda.example/channel/win-64/sample-1.0.0-win_0.conda
+  hash:
+    md5: windows
+";
+
+        var (scanResult, componentRecorder) = await this.detectorTestUtility
+            .WithFile("conda-lock.yml", condaLockContent)
+            .ExecuteDetectorAsync();
+
+        scanResult.ResultCode.Should().Be(ProcessingResultCode.Success);
+        var components = componentRecorder.GetDetectedComponents()
+            .Select(component => component.Component)
+            .OfType<CondaComponent>()
+            .ToList();
+        var graph = componentRecorder.GetDependencyGraphsByLocation().Values.Single();
+
+        components.Should().HaveCount(3);
+        components.Select(component => component.BaseId).Distinct().Should().ContainSingle()
+            .Which.Should().Be("sample 1.0.0 - Conda");
+        components.Select(component => component.Id).Should().OnlyHaveUniqueItems();
+        components.Should().OnlyContain(component => graph.Contains(component.Id));
+    }
+
+    [TestMethod]
+    public async Task CondaComponentDetector_CondaPackageWithoutMd5IsRecordedAsync()
+    {
+        var condaLockContent =
+@"version: 1
+metadata:
+  platforms:
+  - linux-64
+package:
+- name: sample
+  version: 1.0.0
+  build: custom_0
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://example.test/channel/linux-64/sample-1.0.0-different_1.conda
+  hash:
+    sha256: d2d2d2d2
+  category: main
+  optional: false
+";
+
+        var (scanResult, componentRecorder) = await this.detectorTestUtility
+            .WithFile("conda-lock.yml", condaLockContent)
+            .ExecuteDetectorAsync();
+
+        scanResult.ResultCode.Should().Be(ProcessingResultCode.Success);
+        var component = componentRecorder.GetDetectedComponents().Single().Component.Should().BeOfType<CondaComponent>().Subject;
+        component.Build.Should().Be("custom_0");
+        component.MD5.Should().BeNull();
+        component.SHA256.Should().Be("d2d2d2d2");
+    }
+
+    [TestMethod]
+    [DataRow(".conda")]
+    [DataRow(".tar.bz2")]
+    public async Task CondaComponentDetector_ExtractsBuildFromPackageFileNameAsync(string packageExtension)
+    {
+        var packageUrl = $"https://conda.example/channel/linux-64/sample-1.0.0-build_0{packageExtension}";
+        var condaLockContent =
+$@"version: 1
+metadata:
+  platforms:
+  - linux-64
+package:
+- name: sample
+  version: 1.0.0
+  manager: conda
+  platform: linux-64
+  dependencies: {{}}
+  url: {packageUrl}
+  hash:
+    md5: d2d2d2d2
+  category: main
+  optional: false
+";
+
+        var (scanResult, componentRecorder) = await this.detectorTestUtility
+            .WithFile("conda-lock.yml", condaLockContent)
+            .ExecuteDetectorAsync();
+
+        scanResult.ResultCode.Should().Be(ProcessingResultCode.Success);
+        var component = componentRecorder.GetDetectedComponents().Single().Component.Should().BeOfType<CondaComponent>().Subject;
+        component.Build.Should().Be("build_0");
+        component.DownloadUrl.Should().Be(new Uri(packageUrl));
+        component.Id.Should().Contain("Build:build_0");
     }
 
     [TestMethod]
@@ -144,15 +343,6 @@ package:
         detectedComponents.Should().HaveCount(2);
         dependencyGraph.GetDependenciesForComponent(pythonId).Should().Contain(pipId);
         dependencyGraph.GetDependenciesForComponent(pipId).Should().Contain(pythonId);
-    }
-
-    private void AssertCondaLockComponentNameAndVersion(IEnumerable<DetectedComponent> detectedComponents, string name, string version)
-    {
-        detectedComponents.SingleOrDefault(c =>
-                c.Component is CondaComponent component &&
-                component.Name.Equals(name) &&
-                component.Version.Equals(version)).Should().NotBeNull(
-            $"Component with name {name} and version {version} was not found");
     }
 
     private void AssertPipComponentNameAndVersion(IEnumerable<DetectedComponent> detectedComponents, string name, string version)


### PR DESCRIPTION
On reflection there was more data that we could have been consuming or inferring within the conda-lock files. Some of that data is needed to make a [conda-valid PURL](https://github.com/package-url/purl-spec/blob/main/types/conda-definition.json), so let's make sure it gets reported.