### PR TITLE
Use SHA-256 for SPDX document fingerprints

### DIFF
--- a/docs/detectors/spdx.md
+++ b/docs/detectors/spdx.md
@@ -13,7 +13,7 @@ The SPDX detector (`Spdx22ComponentDetector`) discovers SPDX SBOM (Software Bill
 The detector:
 - Searches for files matching the pattern `*.spdx.json`
 - Validates that the SPDX version is `SPDX-2.2` (currently the only supported version)
-- Computes a SHA-1 hash of the SPDX file for identification
+- Computes a SHA-256 hash of the SPDX file for identification
 - Extracts metadata including:
   - Document namespace
   - Document name

--- a/src/Microsoft.ComponentDetection.Detectors/spdx/Spdx22ComponentDetector.cs
+++ b/src/Microsoft.ComponentDetection.Detectors/spdx/Spdx22ComponentDetector.cs
@@ -39,7 +39,7 @@ public class Spdx22ComponentDetector : FileComponentDetector, IDefaultOffCompone
 
     public override IEnumerable<ComponentType> SupportedComponentTypes { get; } = [ComponentType.Spdx];
 
-    public override int Version => 1;
+    public override int Version => 2;
 
     public override IList<string> SearchPatterns => ["*.spdx.json"];
 
@@ -50,7 +50,7 @@ public class Spdx22ComponentDetector : FileComponentDetector, IDefaultOffCompone
 
         try
         {
-            var hash = this.GetSHA1HashFromStream(file.Stream);
+            var hash = this.GetSHA256HashFromStream(file.Stream);
 
             // Reset buffer to starting position after hash generation.
             file.Stream.Seek(0, SeekOrigin.Begin);
@@ -160,10 +160,10 @@ public class Spdx22ComponentDetector : FileComponentDetector, IDefaultOffCompone
         return component;
     }
 
-    private string GetSHA1HashFromStream(Stream stream)
+    private string GetSHA256HashFromStream(Stream stream)
     {
-#pragma warning disable CA5350 // Suppress Do Not Use Weak Cryptographic Algorithms because we use SHA1 intentionally in SPDX format
-        return BitConverter.ToString(SHA1.Create().ComputeHash(stream)).Replace("-", string.Empty).ToLower(); // CodeQL [SM02196] Sha1 is used in SPDX 2.2 format this file is parsing (https://spdx.github.io/spdx-spec/v2.2.2/file-information/).
-#pragma warning restore CA5350
+#pragma warning disable CA1308 // Component checksums are serialized as lowercase hexadecimal.
+        return Convert.ToHexString(SHA256.HashData(stream)).ToLowerInvariant();
+#pragma warning restore CA1308
     }
 }

--- a/test/Microsoft.ComponentDetection.Detectors.Tests/SPDX22ComponentDetectorTests.cs
+++ b/test/Microsoft.ComponentDetection.Detectors.Tests/SPDX22ComponentDetectorTests.cs
@@ -116,9 +116,9 @@ public class Spdx22ComponentDetectorTests
 
         sbomComponent.Should().NotBeNull();
 
-#pragma warning disable CA5350 // Suppress Do Not Use Weak Cryptographic Algorithms because we use SHA1 intentionally in SPDX format
-        var checksum = BitConverter.ToString(SHA1.HashData(Encoding.UTF8.GetBytes(spdxFile))).Replace("-", string.Empty).ToLower();
-#pragma warning restore CA5350
+#pragma warning disable CA1308 // Component checksums are serialized as lowercase hexadecimal.
+        var checksum = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(spdxFile))).ToLowerInvariant();
+#pragma warning restore CA1308
 
         components.Should().ContainSingle();
         sbomComponent.Name.Should().Be("Test 1.0.0");
@@ -126,6 +126,7 @@ public class Spdx22ComponentDetectorTests
         sbomComponent.DocumentNamespace.Should().Be(new Uri("https://sbom.microsoft/Test/1.0.0/61de1a5-57cc-4732-9af5-edb321b4a7ee"));
         sbomComponent.SpdxVersion.Should().Be("SPDX-2.2");
         sbomComponent.Checksum.Should().Be(checksum);
+        sbomComponent.Id.Should().Be($"Test 1.0.0-SPDX-2.2-{checksum}");
         sbomComponent.Path.Should().Be(Path.Combine(Path.GetTempPath(), spdxFileName));
 
         sbomComponent.CreatorTool.Should().Be("Microsoft.SBOMTool-1.0.0");


### PR DESCRIPTION
## Summary

- replace the SPDX detector's SHA-1 whole-document fingerprint with SHA-256
- bump the SPDX detector version from 1 to 2 because the checksum contributes to component identity
- update the detector test and documentation for the new 64-character lowercase checksum

This changes only the detector-generated fingerprint of the complete SPDX manifest. It does not modify or validate checksums embedded in SPDX file entries.

## Testing

- `Microsoft.ComponentDetection.Detectors.Tests`: 960 passed
- verified generated SPDX checksums match SHA-256 of the source manifests
- verified component IDs are constructed from the SHA-256 checksums

## Snapshot verification

The snapshot verification workflow is expected to report the three existing SPDX components as removed and re-added because their IDs intentionally change from SHA-1-based to SHA-256-based values. A local release-versus-current comparison confirmed:

- 1,111 total components in both outputs
- exactly 3 removed and 3 added IDs, all from `SPDX22SBOM`
- the same 3 manifest paths and identical non-identity component metadata
- identical dependency graphs after translating each old SPDX ID to its corresponding new ID

After this merges, the snapshot published from `main` will use the SHA-256 identities, so subsequent comparisons will use the new baseline.